### PR TITLE
[ISSUE-41] Bugfix: Parsing `text/plain` and `text/html` attachments

### DIFF
--- a/letters_test.go
+++ b/letters_test.go
@@ -2177,6 +2177,40 @@ Pack my box with five dozen liquor jugs.`,
 				},
 				Data: []byte{123, 34, 102, 111, 111, 34, 58, 34, 98, 97, 114, 34, 125},
 			},
+			{
+				ContentType: ContentTypeHeader{
+					ContentType: "text/plain",
+					Params: map[string]string{
+						"name": "attached-text-plain-name.txt",
+					},
+				},
+				ContentDisposition: ContentDispositionHeader{
+					ContentDisposition: attachment,
+					Params: map[string]string{
+						"filename": "attached-text-plain-filename.txt",
+					},
+				},
+				Data: []byte{84, 101, 120, 116, 47, 112, 108, 97, 105, 110, 32, 99, 111, 110, 116, 101, 110, 116, 32,
+					97, 115, 32, 97, 110, 32, 97, 116, 116, 97, 99, 104, 101, 100, 32, 46, 116, 120, 116, 32, 102, 105,
+					108, 101, 46},
+			},
+			{
+				ContentType: ContentTypeHeader{
+					ContentType: "text/html",
+					Params: map[string]string{
+						"name": "attached-text-html-name.html",
+					},
+				},
+				ContentDisposition: ContentDispositionHeader{
+					ContentDisposition: attachment,
+					Params: map[string]string{
+						"filename": "attached-text-html-filename.html",
+					},
+				},
+				Data: []byte{84, 101, 120, 116, 47, 104, 116, 109, 108, 32, 99, 111, 110, 116, 101, 110, 116, 32, 97,
+					115, 32, 97, 110, 32, 97, 116, 116, 97, 99, 104, 101, 100, 32, 46, 104, 116, 109, 108, 32, 102,
+					105, 108, 101, 46},
+			},
 		},
 	}
 
@@ -2417,6 +2451,40 @@ Pack my box with five dozen liquor jugs.`,
 					},
 				},
 				Data: []byte{123, 34, 102, 111, 111, 34, 58, 34, 98, 97, 114, 34, 125},
+			},
+			{
+				ContentType: ContentTypeHeader{
+					ContentType: "text/plain",
+					Params: map[string]string{
+						"name": "attached-text-plain-name.txt",
+					},
+				},
+				ContentDisposition: ContentDispositionHeader{
+					ContentDisposition: attachment,
+					Params: map[string]string{
+						"filename": "attached-text-plain-filename.txt",
+					},
+				},
+				Data: []byte{84, 101, 120, 116, 47, 112, 108, 97, 105, 110, 32, 99, 111, 110, 116, 101, 110, 116, 32,
+					97, 115, 32, 97, 110, 32, 97, 116, 116, 97, 99, 104, 101, 100, 32, 46, 116, 120, 116, 32, 102, 105,
+					108, 101, 46},
+			},
+			{
+				ContentType: ContentTypeHeader{
+					ContentType: "text/html",
+					Params: map[string]string{
+						"name": "attached-text-html-name.html",
+					},
+				},
+				ContentDisposition: ContentDispositionHeader{
+					ContentDisposition: attachment,
+					Params: map[string]string{
+						"filename": "attached-text-html-filename.html",
+					},
+				},
+				Data: []byte{84, 101, 120, 116, 47, 104, 116, 109, 108, 32, 99, 111, 110, 116, 101, 110, 116, 32, 97,
+					115, 32, 97, 110, 32, 97, 116, 116, 97, 99, 104, 101, 100, 32, 46, 104, 116, 109, 108, 32, 102,
+					105, 108, 101, 46},
 			},
 		},
 	}
@@ -2659,6 +2727,40 @@ Pack my box with five dozen liquor jugs.`,
 				},
 				Data: []byte{123, 34, 102, 111, 111, 34, 58, 34, 98, 97, 114, 34, 125},
 			},
+			{
+				ContentType: ContentTypeHeader{
+					ContentType: "text/plain",
+					Params: map[string]string{
+						"name": "attached-text-plain-name.txt",
+					},
+				},
+				ContentDisposition: ContentDispositionHeader{
+					ContentDisposition: attachment,
+					Params: map[string]string{
+						"filename": "attached-text-plain-filename.txt",
+					},
+				},
+				Data: []byte{84, 101, 120, 116, 47, 112, 108, 97, 105, 110, 32, 99, 111, 110, 116, 101, 110, 116, 32,
+					97, 115, 32, 97, 110, 32, 97, 116, 116, 97, 99, 104, 101, 100, 32, 46, 116, 120, 116, 32, 102, 105,
+					108, 101, 46},
+			},
+			{
+				ContentType: ContentTypeHeader{
+					ContentType: "text/html",
+					Params: map[string]string{
+						"name": "attached-text-html-name.html",
+					},
+				},
+				ContentDisposition: ContentDispositionHeader{
+					ContentDisposition: attachment,
+					Params: map[string]string{
+						"filename": "attached-text-html-filename.html",
+					},
+				},
+				Data: []byte{84, 101, 120, 116, 47, 104, 116, 109, 108, 32, 99, 111, 110, 116, 101, 110, 116, 32, 97,
+					115, 32, 97, 110, 32, 97, 116, 116, 97, 99, 104, 101, 100, 32, 46, 104, 116, 109, 108, 32, 102,
+					105, 108, 101, 46},
+			},
 		},
 	}
 
@@ -2899,6 +3001,40 @@ Pack my box with five dozen liquor jugs.`,
 					},
 				},
 				Data: []byte{123, 34, 102, 111, 111, 34, 58, 34, 98, 97, 114, 34, 125},
+			},
+			{
+				ContentType: ContentTypeHeader{
+					ContentType: "text/plain",
+					Params: map[string]string{
+						"name": "attached-text-plain-name.txt",
+					},
+				},
+				ContentDisposition: ContentDispositionHeader{
+					ContentDisposition: attachment,
+					Params: map[string]string{
+						"filename": "attached-text-plain-filename.txt",
+					},
+				},
+				Data: []byte{84, 101, 120, 116, 47, 112, 108, 97, 105, 110, 32, 99, 111, 110, 116, 101, 110, 116, 32,
+					97, 115, 32, 97, 110, 32, 97, 116, 116, 97, 99, 104, 101, 100, 32, 46, 116, 120, 116, 32, 102, 105,
+					108, 101, 46},
+			},
+			{
+				ContentType: ContentTypeHeader{
+					ContentType: "text/html",
+					Params: map[string]string{
+						"name": "attached-text-html-name.html",
+					},
+				},
+				ContentDisposition: ContentDispositionHeader{
+					ContentDisposition: attachment,
+					Params: map[string]string{
+						"filename": "attached-text-html-filename.html",
+					},
+				},
+				Data: []byte{84, 101, 120, 116, 47, 104, 116, 109, 108, 32, 99, 111, 110, 116, 101, 110, 116, 32, 97,
+					115, 32, 97, 110, 32, 97, 116, 116, 97, 99, 104, 101, 100, 32, 46, 104, 116, 109, 108, 32, 102,
+					105, 108, 101, 46},
 			},
 		},
 	}
@@ -3141,6 +3277,40 @@ Pack my box with five dozen liquor jugs.`,
 				},
 				Data: []byte{123, 34, 102, 111, 111, 34, 58, 34, 98, 97, 114, 34, 125},
 			},
+			{
+				ContentType: ContentTypeHeader{
+					ContentType: "text/plain",
+					Params: map[string]string{
+						"name": "attached-text-plain-name.txt",
+					},
+				},
+				ContentDisposition: ContentDispositionHeader{
+					ContentDisposition: attachment,
+					Params: map[string]string{
+						"filename": "attached-text-plain-filename.txt",
+					},
+				},
+				Data: []byte{84, 101, 120, 116, 47, 112, 108, 97, 105, 110, 32, 99, 111, 110, 116, 101, 110, 116, 32,
+					97, 115, 32, 97, 110, 32, 97, 116, 116, 97, 99, 104, 101, 100, 32, 46, 116, 120, 116, 32, 102, 105,
+					108, 101, 46},
+			},
+			{
+				ContentType: ContentTypeHeader{
+					ContentType: "text/html",
+					Params: map[string]string{
+						"name": "attached-text-html-name.html",
+					},
+				},
+				ContentDisposition: ContentDispositionHeader{
+					ContentDisposition: attachment,
+					Params: map[string]string{
+						"filename": "attached-text-html-filename.html",
+					},
+				},
+				Data: []byte{84, 101, 120, 116, 47, 104, 116, 109, 108, 32, 99, 111, 110, 116, 101, 110, 116, 32, 97,
+					115, 32, 97, 110, 32, 97, 116, 116, 97, 99, 104, 101, 100, 32, 46, 104, 116, 109, 108, 32, 102,
+					105, 108, 101, 46},
+			},
 		},
 	}
 
@@ -3381,6 +3551,40 @@ Pack my box with five dozen liquor jugs.`,
 					},
 				},
 				Data: []byte{123, 34, 102, 111, 111, 34, 58, 34, 98, 97, 114, 34, 125},
+			},
+			{
+				ContentType: ContentTypeHeader{
+					ContentType: "text/plain",
+					Params: map[string]string{
+						"name": "attached-text-plain-name.txt",
+					},
+				},
+				ContentDisposition: ContentDispositionHeader{
+					ContentDisposition: attachment,
+					Params: map[string]string{
+						"filename": "attached-text-plain-filename.txt",
+					},
+				},
+				Data: []byte{84, 101, 120, 116, 47, 112, 108, 97, 105, 110, 32, 99, 111, 110, 116, 101, 110, 116, 32,
+					97, 115, 32, 97, 110, 32, 97, 116, 116, 97, 99, 104, 101, 100, 32, 46, 116, 120, 116, 32, 102, 105,
+					108, 101, 46},
+			},
+			{
+				ContentType: ContentTypeHeader{
+					ContentType: "text/html",
+					Params: map[string]string{
+						"name": "attached-text-html-name.html",
+					},
+				},
+				ContentDisposition: ContentDispositionHeader{
+					ContentDisposition: attachment,
+					Params: map[string]string{
+						"filename": "attached-text-html-filename.html",
+					},
+				},
+				Data: []byte{84, 101, 120, 116, 47, 104, 116, 109, 108, 32, 99, 111, 110, 116, 101, 110, 116, 32, 97,
+					115, 32, 97, 110, 32, 97, 116, 116, 97, 99, 104, 101, 100, 32, 46, 104, 116, 109, 108, 32, 102,
+					105, 108, 101, 46},
 			},
 		},
 	}
@@ -5822,6 +6026,40 @@ func TestParseEmailChineseMultipartMixedGb18030OverBase64(t *testing.T) {
 				},
 				Data: []byte{123, 34, 102, 111, 111, 34, 58, 34, 98, 97, 114, 34, 125},
 			},
+			{
+				ContentType: ContentTypeHeader{
+					ContentType: "text/plain",
+					Params: map[string]string{
+						"name": "attached-text-plain-name.txt",
+					},
+				},
+				ContentDisposition: ContentDispositionHeader{
+					ContentDisposition: attachment,
+					Params: map[string]string{
+						"filename": "attached-text-plain-filename.txt",
+					},
+				},
+				Data: []byte{84, 101, 120, 116, 47, 112, 108, 97, 105, 110, 32, 99, 111, 110, 116, 101, 110, 116, 32,
+					97, 115, 32, 97, 110, 32, 97, 116, 116, 97, 99, 104, 101, 100, 32, 46, 116, 120, 116, 32, 102, 105,
+					108, 101, 46},
+			},
+			{
+				ContentType: ContentTypeHeader{
+					ContentType: "text/html",
+					Params: map[string]string{
+						"name": "attached-text-html-name.html",
+					},
+				},
+				ContentDisposition: ContentDispositionHeader{
+					ContentDisposition: attachment,
+					Params: map[string]string{
+						"filename": "attached-text-html-filename.html",
+					},
+				},
+				Data: []byte{84, 101, 120, 116, 47, 104, 116, 109, 108, 32, 99, 111, 110, 116, 101, 110, 116, 32, 97,
+					115, 32, 97, 110, 32, 97, 116, 116, 97, 99, 104, 101, 100, 32, 46, 104, 116, 109, 108, 32, 102,
+					105, 108, 101, 46},
+			},
 		},
 	}
 
@@ -6071,6 +6309,40 @@ func TestParseEmailChineseMultipartMixedGb18030OverQuotedprintable(t *testing.T)
 					},
 				},
 				Data: []byte{123, 34, 102, 111, 111, 34, 58, 34, 98, 97, 114, 34, 125},
+			},
+			{
+				ContentType: ContentTypeHeader{
+					ContentType: "text/plain",
+					Params: map[string]string{
+						"name": "attached-text-plain-name.txt",
+					},
+				},
+				ContentDisposition: ContentDispositionHeader{
+					ContentDisposition: attachment,
+					Params: map[string]string{
+						"filename": "attached-text-plain-filename.txt",
+					},
+				},
+				Data: []byte{84, 101, 120, 116, 47, 112, 108, 97, 105, 110, 32, 99, 111, 110, 116, 101, 110, 116, 32,
+					97, 115, 32, 97, 110, 32, 97, 116, 116, 97, 99, 104, 101, 100, 32, 46, 116, 120, 116, 32, 102, 105,
+					108, 101, 46},
+			},
+			{
+				ContentType: ContentTypeHeader{
+					ContentType: "text/html",
+					Params: map[string]string{
+						"name": "attached-text-html-name.html",
+					},
+				},
+				ContentDisposition: ContentDispositionHeader{
+					ContentDisposition: attachment,
+					Params: map[string]string{
+						"filename": "attached-text-html-filename.html",
+					},
+				},
+				Data: []byte{84, 101, 120, 116, 47, 104, 116, 109, 108, 32, 99, 111, 110, 116, 101, 110, 116, 32, 97,
+					115, 32, 97, 110, 32, 97, 116, 116, 97, 99, 104, 101, 100, 32, 46, 104, 116, 109, 108, 32, 102,
+					105, 108, 101, 46},
 			},
 		},
 	}
@@ -6322,6 +6594,40 @@ func TestParseEmailChineseMultipartMixedGbkOverBase64(t *testing.T) {
 				},
 				Data: []byte{123, 34, 102, 111, 111, 34, 58, 34, 98, 97, 114, 34, 125},
 			},
+			{
+				ContentType: ContentTypeHeader{
+					ContentType: "text/plain",
+					Params: map[string]string{
+						"name": "attached-text-plain-name.txt",
+					},
+				},
+				ContentDisposition: ContentDispositionHeader{
+					ContentDisposition: attachment,
+					Params: map[string]string{
+						"filename": "attached-text-plain-filename.txt",
+					},
+				},
+				Data: []byte{84, 101, 120, 116, 47, 112, 108, 97, 105, 110, 32, 99, 111, 110, 116, 101, 110, 116, 32,
+					97, 115, 32, 97, 110, 32, 97, 116, 116, 97, 99, 104, 101, 100, 32, 46, 116, 120, 116, 32, 102, 105,
+					108, 101, 46},
+			},
+			{
+				ContentType: ContentTypeHeader{
+					ContentType: "text/html",
+					Params: map[string]string{
+						"name": "attached-text-html-name.html",
+					},
+				},
+				ContentDisposition: ContentDispositionHeader{
+					ContentDisposition: attachment,
+					Params: map[string]string{
+						"filename": "attached-text-html-filename.html",
+					},
+				},
+				Data: []byte{84, 101, 120, 116, 47, 104, 116, 109, 108, 32, 99, 111, 110, 116, 101, 110, 116, 32, 97,
+					115, 32, 97, 110, 32, 97, 116, 116, 97, 99, 104, 101, 100, 32, 46, 104, 116, 109, 108, 32, 102,
+					105, 108, 101, 46},
+			},
 		},
 	}
 
@@ -6571,6 +6877,40 @@ func TestParseEmailChineseMultipartMixedGbkOverQuotedprintable(t *testing.T) {
 					},
 				},
 				Data: []byte{123, 34, 102, 111, 111, 34, 58, 34, 98, 97, 114, 34, 125},
+			},
+			{
+				ContentType: ContentTypeHeader{
+					ContentType: "text/plain",
+					Params: map[string]string{
+						"name": "attached-text-plain-name.txt",
+					},
+				},
+				ContentDisposition: ContentDispositionHeader{
+					ContentDisposition: attachment,
+					Params: map[string]string{
+						"filename": "attached-text-plain-filename.txt",
+					},
+				},
+				Data: []byte{84, 101, 120, 116, 47, 112, 108, 97, 105, 110, 32, 99, 111, 110, 116, 101, 110, 116, 32,
+					97, 115, 32, 97, 110, 32, 97, 116, 116, 97, 99, 104, 101, 100, 32, 46, 116, 120, 116, 32, 102, 105,
+					108, 101, 46},
+			},
+			{
+				ContentType: ContentTypeHeader{
+					ContentType: "text/html",
+					Params: map[string]string{
+						"name": "attached-text-html-name.html",
+					},
+				},
+				ContentDisposition: ContentDispositionHeader{
+					ContentDisposition: attachment,
+					Params: map[string]string{
+						"filename": "attached-text-html-filename.html",
+					},
+				},
+				Data: []byte{84, 101, 120, 116, 47, 104, 116, 109, 108, 32, 99, 111, 110, 116, 101, 110, 116, 32, 97,
+					115, 32, 97, 110, 32, 97, 116, 116, 97, 99, 104, 101, 100, 32, 46, 104, 116, 109, 108, 32, 102,
+					105, 108, 101, 46},
 			},
 		},
 	}
@@ -8642,6 +8982,40 @@ Wieniläinen sioux:ta puhuva ökyzombie diggaa Åsan roquefort-tacoja.`,
 				},
 				Data: []byte{123, 34, 102, 111, 111, 34, 58, 34, 98, 97, 114, 34, 125},
 			},
+			{
+				ContentType: ContentTypeHeader{
+					ContentType: "text/plain",
+					Params: map[string]string{
+						"name": "attached-text-plain-name.txt",
+					},
+				},
+				ContentDisposition: ContentDispositionHeader{
+					ContentDisposition: attachment,
+					Params: map[string]string{
+						"filename": "attached-text-plain-filename.txt",
+					},
+				},
+				Data: []byte{84, 101, 120, 116, 47, 112, 108, 97, 105, 110, 32, 99, 111, 110, 116, 101, 110, 116, 32,
+					97, 115, 32, 97, 110, 32, 97, 116, 116, 97, 99, 104, 101, 100, 32, 46, 116, 120, 116, 32, 102, 105,
+					108, 101, 46},
+			},
+			{
+				ContentType: ContentTypeHeader{
+					ContentType: "text/html",
+					Params: map[string]string{
+						"name": "attached-text-html-name.html",
+					},
+				},
+				ContentDisposition: ContentDispositionHeader{
+					ContentDisposition: attachment,
+					Params: map[string]string{
+						"filename": "attached-text-html-filename.html",
+					},
+				},
+				Data: []byte{84, 101, 120, 116, 47, 104, 116, 109, 108, 32, 99, 111, 110, 116, 101, 110, 116, 32, 97,
+					115, 32, 97, 110, 32, 97, 116, 116, 97, 99, 104, 101, 100, 32, 46, 104, 116, 109, 108, 32, 102,
+					105, 108, 101, 46},
+			},
 		},
 	}
 
@@ -8879,6 +9253,40 @@ Wieniläinen sioux:ta puhuva ökyzombie diggaa Åsan roquefort-tacoja.`,
 					},
 				},
 				Data: []byte{123, 34, 102, 111, 111, 34, 58, 34, 98, 97, 114, 34, 125},
+			},
+			{
+				ContentType: ContentTypeHeader{
+					ContentType: "text/plain",
+					Params: map[string]string{
+						"name": "attached-text-plain-name.txt",
+					},
+				},
+				ContentDisposition: ContentDispositionHeader{
+					ContentDisposition: attachment,
+					Params: map[string]string{
+						"filename": "attached-text-plain-filename.txt",
+					},
+				},
+				Data: []byte{84, 101, 120, 116, 47, 112, 108, 97, 105, 110, 32, 99, 111, 110, 116, 101, 110, 116, 32,
+					97, 115, 32, 97, 110, 32, 97, 116, 116, 97, 99, 104, 101, 100, 32, 46, 116, 120, 116, 32, 102, 105,
+					108, 101, 46},
+			},
+			{
+				ContentType: ContentTypeHeader{
+					ContentType: "text/html",
+					Params: map[string]string{
+						"name": "attached-text-html-name.html",
+					},
+				},
+				ContentDisposition: ContentDispositionHeader{
+					ContentDisposition: attachment,
+					Params: map[string]string{
+						"filename": "attached-text-html-filename.html",
+					},
+				},
+				Data: []byte{84, 101, 120, 116, 47, 104, 116, 109, 108, 32, 99, 111, 110, 116, 101, 110, 116, 32, 97,
+					115, 32, 97, 110, 32, 97, 116, 116, 97, 99, 104, 101, 100, 32, 46, 104, 116, 109, 108, 32, 102,
+					105, 108, 101, 46},
 			},
 		},
 	}
@@ -9118,6 +9526,40 @@ Wieniläinen sioux:ta puhuva ökyzombie diggaa Åsan roquefort-tacoja.`,
 				},
 				Data: []byte{123, 34, 102, 111, 111, 34, 58, 34, 98, 97, 114, 34, 125},
 			},
+			{
+				ContentType: ContentTypeHeader{
+					ContentType: "text/plain",
+					Params: map[string]string{
+						"name": "attached-text-plain-name.txt",
+					},
+				},
+				ContentDisposition: ContentDispositionHeader{
+					ContentDisposition: attachment,
+					Params: map[string]string{
+						"filename": "attached-text-plain-filename.txt",
+					},
+				},
+				Data: []byte{84, 101, 120, 116, 47, 112, 108, 97, 105, 110, 32, 99, 111, 110, 116, 101, 110, 116, 32,
+					97, 115, 32, 97, 110, 32, 97, 116, 116, 97, 99, 104, 101, 100, 32, 46, 116, 120, 116, 32, 102, 105,
+					108, 101, 46},
+			},
+			{
+				ContentType: ContentTypeHeader{
+					ContentType: "text/html",
+					Params: map[string]string{
+						"name": "attached-text-html-name.html",
+					},
+				},
+				ContentDisposition: ContentDispositionHeader{
+					ContentDisposition: attachment,
+					Params: map[string]string{
+						"filename": "attached-text-html-filename.html",
+					},
+				},
+				Data: []byte{84, 101, 120, 116, 47, 104, 116, 109, 108, 32, 99, 111, 110, 116, 101, 110, 116, 32, 97,
+					115, 32, 97, 110, 32, 97, 116, 116, 97, 99, 104, 101, 100, 32, 46, 104, 116, 109, 108, 32, 102,
+					105, 108, 101, 46},
+			},
 		},
 	}
 
@@ -9355,6 +9797,40 @@ Wieniläinen sioux:ta puhuva ökyzombie diggaa Åsan roquefort-tacoja.`,
 					},
 				},
 				Data: []byte{123, 34, 102, 111, 111, 34, 58, 34, 98, 97, 114, 34, 125},
+			},
+			{
+				ContentType: ContentTypeHeader{
+					ContentType: "text/plain",
+					Params: map[string]string{
+						"name": "attached-text-plain-name.txt",
+					},
+				},
+				ContentDisposition: ContentDispositionHeader{
+					ContentDisposition: attachment,
+					Params: map[string]string{
+						"filename": "attached-text-plain-filename.txt",
+					},
+				},
+				Data: []byte{84, 101, 120, 116, 47, 112, 108, 97, 105, 110, 32, 99, 111, 110, 116, 101, 110, 116, 32,
+					97, 115, 32, 97, 110, 32, 97, 116, 116, 97, 99, 104, 101, 100, 32, 46, 116, 120, 116, 32, 102, 105,
+					108, 101, 46},
+			},
+			{
+				ContentType: ContentTypeHeader{
+					ContentType: "text/html",
+					Params: map[string]string{
+						"name": "attached-text-html-name.html",
+					},
+				},
+				ContentDisposition: ContentDispositionHeader{
+					ContentDisposition: attachment,
+					Params: map[string]string{
+						"filename": "attached-text-html-filename.html",
+					},
+				},
+				Data: []byte{84, 101, 120, 116, 47, 104, 116, 109, 108, 32, 99, 111, 110, 116, 101, 110, 116, 32, 97,
+					115, 32, 97, 110, 32, 97, 116, 116, 97, 99, 104, 101, 100, 32, 46, 104, 116, 109, 108, 32, 102,
+					105, 108, 101, 46},
 			},
 		},
 	}
@@ -11353,6 +11829,40 @@ Svo hölt, yxna kýr þegði jú um dóp í fé á bæ.
 				},
 				Data: []byte{123, 34, 102, 111, 111, 34, 58, 34, 98, 97, 114, 34, 125},
 			},
+			{
+				ContentType: ContentTypeHeader{
+					ContentType: "text/plain",
+					Params: map[string]string{
+						"name": "attached-text-plain-name.txt",
+					},
+				},
+				ContentDisposition: ContentDispositionHeader{
+					ContentDisposition: attachment,
+					Params: map[string]string{
+						"filename": "attached-text-plain-filename.txt",
+					},
+				},
+				Data: []byte{84, 101, 120, 116, 47, 112, 108, 97, 105, 110, 32, 99, 111, 110, 116, 101, 110, 116, 32,
+					97, 115, 32, 97, 110, 32, 97, 116, 116, 97, 99, 104, 101, 100, 32, 46, 116, 120, 116, 32, 102, 105,
+					108, 101, 46},
+			},
+			{
+				ContentType: ContentTypeHeader{
+					ContentType: "text/html",
+					Params: map[string]string{
+						"name": "attached-text-html-name.html",
+					},
+				},
+				ContentDisposition: ContentDispositionHeader{
+					ContentDisposition: attachment,
+					Params: map[string]string{
+						"filename": "attached-text-html-filename.html",
+					},
+				},
+				Data: []byte{84, 101, 120, 116, 47, 104, 116, 109, 108, 32, 99, 111, 110, 116, 101, 110, 116, 32, 97,
+					115, 32, 97, 110, 32, 97, 116, 116, 97, 99, 104, 101, 100, 32, 46, 104, 116, 109, 108, 32, 102,
+					105, 108, 101, 46},
+			},
 		},
 	}
 
@@ -11581,6 +12091,40 @@ Svo hölt, yxna kýr þegði jú um dóp í fé á bæ.
 					},
 				},
 				Data: []byte{123, 34, 102, 111, 111, 34, 58, 34, 98, 97, 114, 34, 125},
+			},
+			{
+				ContentType: ContentTypeHeader{
+					ContentType: "text/plain",
+					Params: map[string]string{
+						"name": "attached-text-plain-name.txt",
+					},
+				},
+				ContentDisposition: ContentDispositionHeader{
+					ContentDisposition: attachment,
+					Params: map[string]string{
+						"filename": "attached-text-plain-filename.txt",
+					},
+				},
+				Data: []byte{84, 101, 120, 116, 47, 112, 108, 97, 105, 110, 32, 99, 111, 110, 116, 101, 110, 116, 32,
+					97, 115, 32, 97, 110, 32, 97, 116, 116, 97, 99, 104, 101, 100, 32, 46, 116, 120, 116, 32, 102, 105,
+					108, 101, 46},
+			},
+			{
+				ContentType: ContentTypeHeader{
+					ContentType: "text/html",
+					Params: map[string]string{
+						"name": "attached-text-html-name.html",
+					},
+				},
+				ContentDisposition: ContentDispositionHeader{
+					ContentDisposition: attachment,
+					Params: map[string]string{
+						"filename": "attached-text-html-filename.html",
+					},
+				},
+				Data: []byte{84, 101, 120, 116, 47, 104, 116, 109, 108, 32, 99, 111, 110, 116, 101, 110, 116, 32, 97,
+					115, 32, 97, 110, 32, 97, 116, 116, 97, 99, 104, 101, 100, 32, 46, 104, 116, 109, 108, 32, 102,
+					105, 108, 101, 46},
 			},
 		},
 	}
@@ -11811,6 +12355,40 @@ Svo hölt, yxna kýr þegði jú um dóp í fé á bæ.
 				},
 				Data: []byte{123, 34, 102, 111, 111, 34, 58, 34, 98, 97, 114, 34, 125},
 			},
+			{
+				ContentType: ContentTypeHeader{
+					ContentType: "text/plain",
+					Params: map[string]string{
+						"name": "attached-text-plain-name.txt",
+					},
+				},
+				ContentDisposition: ContentDispositionHeader{
+					ContentDisposition: attachment,
+					Params: map[string]string{
+						"filename": "attached-text-plain-filename.txt",
+					},
+				},
+				Data: []byte{84, 101, 120, 116, 47, 112, 108, 97, 105, 110, 32, 99, 111, 110, 116, 101, 110, 116, 32,
+					97, 115, 32, 97, 110, 32, 97, 116, 116, 97, 99, 104, 101, 100, 32, 46, 116, 120, 116, 32, 102, 105,
+					108, 101, 46},
+			},
+			{
+				ContentType: ContentTypeHeader{
+					ContentType: "text/html",
+					Params: map[string]string{
+						"name": "attached-text-html-name.html",
+					},
+				},
+				ContentDisposition: ContentDispositionHeader{
+					ContentDisposition: attachment,
+					Params: map[string]string{
+						"filename": "attached-text-html-filename.html",
+					},
+				},
+				Data: []byte{84, 101, 120, 116, 47, 104, 116, 109, 108, 32, 99, 111, 110, 116, 101, 110, 116, 32, 97,
+					115, 32, 97, 110, 32, 97, 116, 116, 97, 99, 104, 101, 100, 32, 46, 104, 116, 109, 108, 32, 102,
+					105, 108, 101, 46},
+			},
 		},
 	}
 
@@ -12039,6 +12617,40 @@ Svo hölt, yxna kýr þegði jú um dóp í fé á bæ.
 					},
 				},
 				Data: []byte{123, 34, 102, 111, 111, 34, 58, 34, 98, 97, 114, 34, 125},
+			},
+			{
+				ContentType: ContentTypeHeader{
+					ContentType: "text/plain",
+					Params: map[string]string{
+						"name": "attached-text-plain-name.txt",
+					},
+				},
+				ContentDisposition: ContentDispositionHeader{
+					ContentDisposition: attachment,
+					Params: map[string]string{
+						"filename": "attached-text-plain-filename.txt",
+					},
+				},
+				Data: []byte{84, 101, 120, 116, 47, 112, 108, 97, 105, 110, 32, 99, 111, 110, 116, 101, 110, 116, 32,
+					97, 115, 32, 97, 110, 32, 97, 116, 116, 97, 99, 104, 101, 100, 32, 46, 116, 120, 116, 32, 102, 105,
+					108, 101, 46},
+			},
+			{
+				ContentType: ContentTypeHeader{
+					ContentType: "text/html",
+					Params: map[string]string{
+						"name": "attached-text-html-name.html",
+					},
+				},
+				ContentDisposition: ContentDispositionHeader{
+					ContentDisposition: attachment,
+					Params: map[string]string{
+						"filename": "attached-text-html-filename.html",
+					},
+				},
+				Data: []byte{84, 101, 120, 116, 47, 104, 116, 109, 108, 32, 99, 111, 110, 116, 101, 110, 116, 32, 97,
+					115, 32, 97, 110, 32, 97, 116, 116, 97, 99, 104, 101, 100, 32, 46, 104, 116, 109, 108, 32, 102,
+					105, 108, 101, 46},
 			},
 		},
 	}
@@ -15815,6 +16427,40 @@ Iro wa nioedo / Chirinuru o / Wa ga yo tare zo / Tsune naran / Ui no okuyama / K
 				},
 				Data: []byte{123, 34, 102, 111, 111, 34, 58, 34, 98, 97, 114, 34, 125},
 			},
+			{
+				ContentType: ContentTypeHeader{
+					ContentType: "text/plain",
+					Params: map[string]string{
+						"name": "attached-text-plain-name.txt",
+					},
+				},
+				ContentDisposition: ContentDispositionHeader{
+					ContentDisposition: attachment,
+					Params: map[string]string{
+						"filename": "attached-text-plain-filename.txt",
+					},
+				},
+				Data: []byte{84, 101, 120, 116, 47, 112, 108, 97, 105, 110, 32, 99, 111, 110, 116, 101, 110, 116, 32,
+					97, 115, 32, 97, 110, 32, 97, 116, 116, 97, 99, 104, 101, 100, 32, 46, 116, 120, 116, 32, 102, 105,
+					108, 101, 46},
+			},
+			{
+				ContentType: ContentTypeHeader{
+					ContentType: "text/html",
+					Params: map[string]string{
+						"name": "attached-text-html-name.html",
+					},
+				},
+				ContentDisposition: ContentDispositionHeader{
+					ContentDisposition: attachment,
+					Params: map[string]string{
+						"filename": "attached-text-html-filename.html",
+					},
+				},
+				Data: []byte{84, 101, 120, 116, 47, 104, 116, 109, 108, 32, 99, 111, 110, 116, 101, 110, 116, 32, 97,
+					115, 32, 97, 110, 32, 97, 116, 116, 97, 99, 104, 101, 100, 32, 46, 104, 116, 109, 108, 32, 102,
+					105, 108, 101, 46},
+			},
 		},
 	}
 
@@ -16097,6 +16743,40 @@ Iro wa nioedo / Chirinuru o / Wa ga yo tare zo / Tsune naran / Ui no okuyama / K
 					},
 				},
 				Data: []byte{123, 34, 102, 111, 111, 34, 58, 34, 98, 97, 114, 34, 125},
+			},
+			{
+				ContentType: ContentTypeHeader{
+					ContentType: "text/plain",
+					Params: map[string]string{
+						"name": "attached-text-plain-name.txt",
+					},
+				},
+				ContentDisposition: ContentDispositionHeader{
+					ContentDisposition: attachment,
+					Params: map[string]string{
+						"filename": "attached-text-plain-filename.txt",
+					},
+				},
+				Data: []byte{84, 101, 120, 116, 47, 112, 108, 97, 105, 110, 32, 99, 111, 110, 116, 101, 110, 116, 32,
+					97, 115, 32, 97, 110, 32, 97, 116, 116, 97, 99, 104, 101, 100, 32, 46, 116, 120, 116, 32, 102, 105,
+					108, 101, 46},
+			},
+			{
+				ContentType: ContentTypeHeader{
+					ContentType: "text/html",
+					Params: map[string]string{
+						"name": "attached-text-html-name.html",
+					},
+				},
+				ContentDisposition: ContentDispositionHeader{
+					ContentDisposition: attachment,
+					Params: map[string]string{
+						"filename": "attached-text-html-filename.html",
+					},
+				},
+				Data: []byte{84, 101, 120, 116, 47, 104, 116, 109, 108, 32, 99, 111, 110, 116, 101, 110, 116, 32, 97,
+					115, 32, 97, 110, 32, 97, 116, 116, 97, 99, 104, 101, 100, 32, 46, 104, 116, 109, 108, 32, 102,
+					105, 108, 101, 46},
 			},
 		},
 	}
@@ -16381,6 +17061,40 @@ Iro wa nioedo / Chirinuru o / Wa ga yo tare zo / Tsune naran / Ui no okuyama / K
 				},
 				Data: []byte{123, 34, 102, 111, 111, 34, 58, 34, 98, 97, 114, 34, 125},
 			},
+			{
+				ContentType: ContentTypeHeader{
+					ContentType: "text/plain",
+					Params: map[string]string{
+						"name": "attached-text-plain-name.txt",
+					},
+				},
+				ContentDisposition: ContentDispositionHeader{
+					ContentDisposition: attachment,
+					Params: map[string]string{
+						"filename": "attached-text-plain-filename.txt",
+					},
+				},
+				Data: []byte{84, 101, 120, 116, 47, 112, 108, 97, 105, 110, 32, 99, 111, 110, 116, 101, 110, 116, 32,
+					97, 115, 32, 97, 110, 32, 97, 116, 116, 97, 99, 104, 101, 100, 32, 46, 116, 120, 116, 32, 102, 105,
+					108, 101, 46},
+			},
+			{
+				ContentType: ContentTypeHeader{
+					ContentType: "text/html",
+					Params: map[string]string{
+						"name": "attached-text-html-name.html",
+					},
+				},
+				ContentDisposition: ContentDispositionHeader{
+					ContentDisposition: attachment,
+					Params: map[string]string{
+						"filename": "attached-text-html-filename.html",
+					},
+				},
+				Data: []byte{84, 101, 120, 116, 47, 104, 116, 109, 108, 32, 99, 111, 110, 116, 101, 110, 116, 32, 97,
+					115, 32, 97, 110, 32, 97, 116, 116, 97, 99, 104, 101, 100, 32, 46, 104, 116, 109, 108, 32, 102,
+					105, 108, 101, 46},
+			},
 		},
 	}
 
@@ -16663,6 +17377,40 @@ Iro wa nioedo / Chirinuru o / Wa ga yo tare zo / Tsune naran / Ui no okuyama / K
 					},
 				},
 				Data: []byte{123, 34, 102, 111, 111, 34, 58, 34, 98, 97, 114, 34, 125},
+			},
+			{
+				ContentType: ContentTypeHeader{
+					ContentType: "text/plain",
+					Params: map[string]string{
+						"name": "attached-text-plain-name.txt",
+					},
+				},
+				ContentDisposition: ContentDispositionHeader{
+					ContentDisposition: attachment,
+					Params: map[string]string{
+						"filename": "attached-text-plain-filename.txt",
+					},
+				},
+				Data: []byte{84, 101, 120, 116, 47, 112, 108, 97, 105, 110, 32, 99, 111, 110, 116, 101, 110, 116, 32,
+					97, 115, 32, 97, 110, 32, 97, 116, 116, 97, 99, 104, 101, 100, 32, 46, 116, 120, 116, 32, 102, 105,
+					108, 101, 46},
+			},
+			{
+				ContentType: ContentTypeHeader{
+					ContentType: "text/html",
+					Params: map[string]string{
+						"name": "attached-text-html-name.html",
+					},
+				},
+				ContentDisposition: ContentDispositionHeader{
+					ContentDisposition: attachment,
+					Params: map[string]string{
+						"filename": "attached-text-html-filename.html",
+					},
+				},
+				Data: []byte{84, 101, 120, 116, 47, 104, 116, 109, 108, 32, 99, 111, 110, 116, 101, 110, 116, 32, 97,
+					115, 32, 97, 110, 32, 97, 116, 116, 97, 99, 104, 101, 100, 32, 46, 104, 116, 109, 108, 32, 102,
+					105, 108, 101, 46},
 			},
 		},
 	}
@@ -16947,6 +17695,40 @@ Iro wa nioedo / Chirinuru o / Wa ga yo tare zo / Tsune naran / Ui no okuyama / K
 				},
 				Data: []byte{123, 34, 102, 111, 111, 34, 58, 34, 98, 97, 114, 34, 125},
 			},
+			{
+				ContentType: ContentTypeHeader{
+					ContentType: "text/plain",
+					Params: map[string]string{
+						"name": "attached-text-plain-name.txt",
+					},
+				},
+				ContentDisposition: ContentDispositionHeader{
+					ContentDisposition: attachment,
+					Params: map[string]string{
+						"filename": "attached-text-plain-filename.txt",
+					},
+				},
+				Data: []byte{84, 101, 120, 116, 47, 112, 108, 97, 105, 110, 32, 99, 111, 110, 116, 101, 110, 116, 32,
+					97, 115, 32, 97, 110, 32, 97, 116, 116, 97, 99, 104, 101, 100, 32, 46, 116, 120, 116, 32, 102, 105,
+					108, 101, 46},
+			},
+			{
+				ContentType: ContentTypeHeader{
+					ContentType: "text/html",
+					Params: map[string]string{
+						"name": "attached-text-html-name.html",
+					},
+				},
+				ContentDisposition: ContentDispositionHeader{
+					ContentDisposition: attachment,
+					Params: map[string]string{
+						"filename": "attached-text-html-filename.html",
+					},
+				},
+				Data: []byte{84, 101, 120, 116, 47, 104, 116, 109, 108, 32, 99, 111, 110, 116, 101, 110, 116, 32, 97,
+					115, 32, 97, 110, 32, 97, 116, 116, 97, 99, 104, 101, 100, 32, 46, 104, 116, 109, 108, 32, 102,
+					105, 108, 101, 46},
+			},
 		},
 	}
 
@@ -17229,6 +18011,40 @@ Iro wa nioedo / Chirinuru o / Wa ga yo tare zo / Tsune naran / Ui no okuyama / K
 					},
 				},
 				Data: []byte{123, 34, 102, 111, 111, 34, 58, 34, 98, 97, 114, 34, 125},
+			},
+			{
+				ContentType: ContentTypeHeader{
+					ContentType: "text/plain",
+					Params: map[string]string{
+						"name": "attached-text-plain-name.txt",
+					},
+				},
+				ContentDisposition: ContentDispositionHeader{
+					ContentDisposition: attachment,
+					Params: map[string]string{
+						"filename": "attached-text-plain-filename.txt",
+					},
+				},
+				Data: []byte{84, 101, 120, 116, 47, 112, 108, 97, 105, 110, 32, 99, 111, 110, 116, 101, 110, 116, 32,
+					97, 115, 32, 97, 110, 32, 97, 116, 116, 97, 99, 104, 101, 100, 32, 46, 116, 120, 116, 32, 102, 105,
+					108, 101, 46},
+			},
+			{
+				ContentType: ContentTypeHeader{
+					ContentType: "text/html",
+					Params: map[string]string{
+						"name": "attached-text-html-name.html",
+					},
+				},
+				ContentDisposition: ContentDispositionHeader{
+					ContentDisposition: attachment,
+					Params: map[string]string{
+						"filename": "attached-text-html-filename.html",
+					},
+				},
+				Data: []byte{84, 101, 120, 116, 47, 104, 116, 109, 108, 32, 99, 111, 110, 116, 101, 110, 116, 32, 97,
+					115, 32, 97, 110, 32, 97, 116, 116, 97, 99, 104, 101, 100, 32, 46, 104, 116, 109, 108, 32, 102,
+					105, 108, 101, 46},
 			},
 		},
 	}
@@ -17513,6 +18329,40 @@ Iro wa nioedo / Chirinuru o / Wa ga yo tare zo / Tsune naran / Ui no okuyama / K
 				},
 				Data: []byte{123, 34, 102, 111, 111, 34, 58, 34, 98, 97, 114, 34, 125},
 			},
+			{
+				ContentType: ContentTypeHeader{
+					ContentType: "text/plain",
+					Params: map[string]string{
+						"name": "attached-text-plain-name.txt",
+					},
+				},
+				ContentDisposition: ContentDispositionHeader{
+					ContentDisposition: attachment,
+					Params: map[string]string{
+						"filename": "attached-text-plain-filename.txt",
+					},
+				},
+				Data: []byte{84, 101, 120, 116, 47, 112, 108, 97, 105, 110, 32, 99, 111, 110, 116, 101, 110, 116, 32,
+					97, 115, 32, 97, 110, 32, 97, 116, 116, 97, 99, 104, 101, 100, 32, 46, 116, 120, 116, 32, 102, 105,
+					108, 101, 46},
+			},
+			{
+				ContentType: ContentTypeHeader{
+					ContentType: "text/html",
+					Params: map[string]string{
+						"name": "attached-text-html-name.html",
+					},
+				},
+				ContentDisposition: ContentDispositionHeader{
+					ContentDisposition: attachment,
+					Params: map[string]string{
+						"filename": "attached-text-html-filename.html",
+					},
+				},
+				Data: []byte{84, 101, 120, 116, 47, 104, 116, 109, 108, 32, 99, 111, 110, 116, 101, 110, 116, 32, 97,
+					115, 32, 97, 110, 32, 97, 116, 116, 97, 99, 104, 101, 100, 32, 46, 104, 116, 109, 108, 32, 102,
+					105, 108, 101, 46},
+			},
 		},
 	}
 
@@ -17795,6 +18645,40 @@ Iro wa nioedo / Chirinuru o / Wa ga yo tare zo / Tsune naran / Ui no okuyama / K
 					},
 				},
 				Data: []byte{123, 34, 102, 111, 111, 34, 58, 34, 98, 97, 114, 34, 125},
+			},
+			{
+				ContentType: ContentTypeHeader{
+					ContentType: "text/plain",
+					Params: map[string]string{
+						"name": "attached-text-plain-name.txt",
+					},
+				},
+				ContentDisposition: ContentDispositionHeader{
+					ContentDisposition: attachment,
+					Params: map[string]string{
+						"filename": "attached-text-plain-filename.txt",
+					},
+				},
+				Data: []byte{84, 101, 120, 116, 47, 112, 108, 97, 105, 110, 32, 99, 111, 110, 116, 101, 110, 116, 32,
+					97, 115, 32, 97, 110, 32, 97, 116, 116, 97, 99, 104, 101, 100, 32, 46, 116, 120, 116, 32, 102, 105,
+					108, 101, 46},
+			},
+			{
+				ContentType: ContentTypeHeader{
+					ContentType: "text/html",
+					Params: map[string]string{
+						"name": "attached-text-html-name.html",
+					},
+				},
+				ContentDisposition: ContentDispositionHeader{
+					ContentDisposition: attachment,
+					Params: map[string]string{
+						"filename": "attached-text-html-filename.html",
+					},
+				},
+				Data: []byte{84, 101, 120, 116, 47, 104, 116, 109, 108, 32, 99, 111, 110, 116, 101, 110, 116, 32, 97,
+					115, 32, 97, 110, 32, 97, 116, 116, 97, 99, 104, 101, 100, 32, 46, 104, 116, 109, 108, 32, 102,
+					105, 108, 101, 46},
 			},
 		},
 	}
@@ -20483,6 +21367,40 @@ func TestParseEmailKoreanMultipartMixedUtf8OverBase64(t *testing.T) {
 				},
 				Data: []byte{123, 34, 102, 111, 111, 34, 58, 34, 98, 97, 114, 34, 125},
 			},
+			{
+				ContentType: ContentTypeHeader{
+					ContentType: "text/plain",
+					Params: map[string]string{
+						"name": "attached-text-plain-name.txt",
+					},
+				},
+				ContentDisposition: ContentDispositionHeader{
+					ContentDisposition: attachment,
+					Params: map[string]string{
+						"filename": "attached-text-plain-filename.txt",
+					},
+				},
+				Data: []byte{84, 101, 120, 116, 47, 112, 108, 97, 105, 110, 32, 99, 111, 110, 116, 101, 110, 116, 32,
+					97, 115, 32, 97, 110, 32, 97, 116, 116, 97, 99, 104, 101, 100, 32, 46, 116, 120, 116, 32, 102, 105,
+					108, 101, 46},
+			},
+			{
+				ContentType: ContentTypeHeader{
+					ContentType: "text/html",
+					Params: map[string]string{
+						"name": "attached-text-html-name.html",
+					},
+				},
+				ContentDisposition: ContentDispositionHeader{
+					ContentDisposition: attachment,
+					Params: map[string]string{
+						"filename": "attached-text-html-filename.html",
+					},
+				},
+				Data: []byte{84, 101, 120, 116, 47, 104, 116, 109, 108, 32, 99, 111, 110, 116, 101, 110, 116, 32, 97,
+					115, 32, 97, 110, 32, 97, 116, 116, 97, 99, 104, 101, 100, 32, 46, 104, 116, 109, 108, 32, 102,
+					105, 108, 101, 46},
+			},
 		},
 	}
 
@@ -20705,6 +21623,40 @@ func TestParseEmailKoreanMultipartMixedUtf8OverQuotedprintable(t *testing.T) {
 					},
 				},
 				Data: []byte{123, 34, 102, 111, 111, 34, 58, 34, 98, 97, 114, 34, 125},
+			},
+			{
+				ContentType: ContentTypeHeader{
+					ContentType: "text/plain",
+					Params: map[string]string{
+						"name": "attached-text-plain-name.txt",
+					},
+				},
+				ContentDisposition: ContentDispositionHeader{
+					ContentDisposition: attachment,
+					Params: map[string]string{
+						"filename": "attached-text-plain-filename.txt",
+					},
+				},
+				Data: []byte{84, 101, 120, 116, 47, 112, 108, 97, 105, 110, 32, 99, 111, 110, 116, 101, 110, 116, 32,
+					97, 115, 32, 97, 110, 32, 97, 116, 116, 97, 99, 104, 101, 100, 32, 46, 116, 120, 116, 32, 102, 105,
+					108, 101, 46},
+			},
+			{
+				ContentType: ContentTypeHeader{
+					ContentType: "text/html",
+					Params: map[string]string{
+						"name": "attached-text-html-name.html",
+					},
+				},
+				ContentDisposition: ContentDispositionHeader{
+					ContentDisposition: attachment,
+					Params: map[string]string{
+						"filename": "attached-text-html-filename.html",
+					},
+				},
+				Data: []byte{84, 101, 120, 116, 47, 104, 116, 109, 108, 32, 99, 111, 110, 116, 101, 110, 116, 32, 97,
+					115, 32, 97, 110, 32, 97, 116, 116, 97, 99, 104, 101, 100, 32, 46, 104, 116, 109, 108, 32, 102,
+					105, 108, 101, 46},
 			},
 		},
 	}
@@ -20929,6 +21881,40 @@ func TestParseEmailKoreanMultipartMixedEuckrOverBase64(t *testing.T) {
 				},
 				Data: []byte{123, 34, 102, 111, 111, 34, 58, 34, 98, 97, 114, 34, 125},
 			},
+			{
+				ContentType: ContentTypeHeader{
+					ContentType: "text/plain",
+					Params: map[string]string{
+						"name": "attached-text-plain-name.txt",
+					},
+				},
+				ContentDisposition: ContentDispositionHeader{
+					ContentDisposition: attachment,
+					Params: map[string]string{
+						"filename": "attached-text-plain-filename.txt",
+					},
+				},
+				Data: []byte{84, 101, 120, 116, 47, 112, 108, 97, 105, 110, 32, 99, 111, 110, 116, 101, 110, 116, 32,
+					97, 115, 32, 97, 110, 32, 97, 116, 116, 97, 99, 104, 101, 100, 32, 46, 116, 120, 116, 32, 102, 105,
+					108, 101, 46},
+			},
+			{
+				ContentType: ContentTypeHeader{
+					ContentType: "text/html",
+					Params: map[string]string{
+						"name": "attached-text-html-name.html",
+					},
+				},
+				ContentDisposition: ContentDispositionHeader{
+					ContentDisposition: attachment,
+					Params: map[string]string{
+						"filename": "attached-text-html-filename.html",
+					},
+				},
+				Data: []byte{84, 101, 120, 116, 47, 104, 116, 109, 108, 32, 99, 111, 110, 116, 101, 110, 116, 32, 97,
+					115, 32, 97, 110, 32, 97, 116, 116, 97, 99, 104, 101, 100, 32, 46, 104, 116, 109, 108, 32, 102,
+					105, 108, 101, 46},
+			},
 		},
 	}
 
@@ -21151,6 +22137,40 @@ func TestParseEmailKoreanMultipartMixedEuckrOverQuotedprintable(t *testing.T) {
 					},
 				},
 				Data: []byte{123, 34, 102, 111, 111, 34, 58, 34, 98, 97, 114, 34, 125},
+			},
+			{
+				ContentType: ContentTypeHeader{
+					ContentType: "text/plain",
+					Params: map[string]string{
+						"name": "attached-text-plain-name.txt",
+					},
+				},
+				ContentDisposition: ContentDispositionHeader{
+					ContentDisposition: attachment,
+					Params: map[string]string{
+						"filename": "attached-text-plain-filename.txt",
+					},
+				},
+				Data: []byte{84, 101, 120, 116, 47, 112, 108, 97, 105, 110, 32, 99, 111, 110, 116, 101, 110, 116, 32,
+					97, 115, 32, 97, 110, 32, 97, 116, 116, 97, 99, 104, 101, 100, 32, 46, 116, 120, 116, 32, 102, 105,
+					108, 101, 46},
+			},
+			{
+				ContentType: ContentTypeHeader{
+					ContentType: "text/html",
+					Params: map[string]string{
+						"name": "attached-text-html-name.html",
+					},
+				},
+				ContentDisposition: ContentDispositionHeader{
+					ContentDisposition: attachment,
+					Params: map[string]string{
+						"filename": "attached-text-html-filename.html",
+					},
+				},
+				Data: []byte{84, 101, 120, 116, 47, 104, 116, 109, 108, 32, 99, 111, 110, 116, 101, 110, 116, 32, 97,
+					115, 32, 97, 110, 32, 97, 116, 116, 97, 99, 104, 101, 100, 32, 46, 104, 116, 109, 108, 32, 102,
+					105, 108, 101, 46},
 			},
 		},
 	}
@@ -23224,6 +24244,40 @@ Chwyć małżonkę, strój bądź pleśń z fugi.`,
 				},
 				Data: []byte{123, 34, 102, 111, 111, 34, 58, 34, 98, 97, 114, 34, 125},
 			},
+			{
+				ContentType: ContentTypeHeader{
+					ContentType: "text/plain",
+					Params: map[string]string{
+						"name": "attached-text-plain-name.txt",
+					},
+				},
+				ContentDisposition: ContentDispositionHeader{
+					ContentDisposition: attachment,
+					Params: map[string]string{
+						"filename": "attached-text-plain-filename.txt",
+					},
+				},
+				Data: []byte{84, 101, 120, 116, 47, 112, 108, 97, 105, 110, 32, 99, 111, 110, 116, 101, 110, 116, 32,
+					97, 115, 32, 97, 110, 32, 97, 116, 116, 97, 99, 104, 101, 100, 32, 46, 116, 120, 116, 32, 102, 105,
+					108, 101, 46},
+			},
+			{
+				ContentType: ContentTypeHeader{
+					ContentType: "text/html",
+					Params: map[string]string{
+						"name": "attached-text-html-name.html",
+					},
+				},
+				ContentDisposition: ContentDispositionHeader{
+					ContentDisposition: attachment,
+					Params: map[string]string{
+						"filename": "attached-text-html-filename.html",
+					},
+				},
+				Data: []byte{84, 101, 120, 116, 47, 104, 116, 109, 108, 32, 99, 111, 110, 116, 101, 110, 116, 32, 97,
+					115, 32, 97, 110, 32, 97, 116, 116, 97, 99, 104, 101, 100, 32, 46, 104, 116, 109, 108, 32, 102,
+					105, 108, 101, 46},
+			},
 		},
 	}
 
@@ -23467,6 +24521,40 @@ Chwyć małżonkę, strój bądź pleśń z fugi.`,
 					},
 				},
 				Data: []byte{123, 34, 102, 111, 111, 34, 58, 34, 98, 97, 114, 34, 125},
+			},
+			{
+				ContentType: ContentTypeHeader{
+					ContentType: "text/plain",
+					Params: map[string]string{
+						"name": "attached-text-plain-name.txt",
+					},
+				},
+				ContentDisposition: ContentDispositionHeader{
+					ContentDisposition: attachment,
+					Params: map[string]string{
+						"filename": "attached-text-plain-filename.txt",
+					},
+				},
+				Data: []byte{84, 101, 120, 116, 47, 112, 108, 97, 105, 110, 32, 99, 111, 110, 116, 101, 110, 116, 32,
+					97, 115, 32, 97, 110, 32, 97, 116, 116, 97, 99, 104, 101, 100, 32, 46, 116, 120, 116, 32, 102, 105,
+					108, 101, 46},
+			},
+			{
+				ContentType: ContentTypeHeader{
+					ContentType: "text/html",
+					Params: map[string]string{
+						"name": "attached-text-html-name.html",
+					},
+				},
+				ContentDisposition: ContentDispositionHeader{
+					ContentDisposition: attachment,
+					Params: map[string]string{
+						"filename": "attached-text-html-filename.html",
+					},
+				},
+				Data: []byte{84, 101, 120, 116, 47, 104, 116, 109, 108, 32, 99, 111, 110, 116, 101, 110, 116, 32, 97,
+					115, 32, 97, 110, 32, 97, 116, 116, 97, 99, 104, 101, 100, 32, 46, 104, 116, 109, 108, 32, 102,
+					105, 108, 101, 46},
 			},
 		},
 	}
@@ -23712,6 +24800,40 @@ Chwyć małżonkę, strój bądź pleśń z fugi.`,
 				},
 				Data: []byte{123, 34, 102, 111, 111, 34, 58, 34, 98, 97, 114, 34, 125},
 			},
+			{
+				ContentType: ContentTypeHeader{
+					ContentType: "text/plain",
+					Params: map[string]string{
+						"name": "attached-text-plain-name.txt",
+					},
+				},
+				ContentDisposition: ContentDispositionHeader{
+					ContentDisposition: attachment,
+					Params: map[string]string{
+						"filename": "attached-text-plain-filename.txt",
+					},
+				},
+				Data: []byte{84, 101, 120, 116, 47, 112, 108, 97, 105, 110, 32, 99, 111, 110, 116, 101, 110, 116, 32,
+					97, 115, 32, 97, 110, 32, 97, 116, 116, 97, 99, 104, 101, 100, 32, 46, 116, 120, 116, 32, 102, 105,
+					108, 101, 46},
+			},
+			{
+				ContentType: ContentTypeHeader{
+					ContentType: "text/html",
+					Params: map[string]string{
+						"name": "attached-text-html-name.html",
+					},
+				},
+				ContentDisposition: ContentDispositionHeader{
+					ContentDisposition: attachment,
+					Params: map[string]string{
+						"filename": "attached-text-html-filename.html",
+					},
+				},
+				Data: []byte{84, 101, 120, 116, 47, 104, 116, 109, 108, 32, 99, 111, 110, 116, 101, 110, 116, 32, 97,
+					115, 32, 97, 110, 32, 97, 116, 116, 97, 99, 104, 101, 100, 32, 46, 104, 116, 109, 108, 32, 102,
+					105, 108, 101, 46},
+			},
 		},
 	}
 
@@ -23955,6 +25077,40 @@ Chwyć małżonkę, strój bądź pleśń z fugi.`,
 					},
 				},
 				Data: []byte{123, 34, 102, 111, 111, 34, 58, 34, 98, 97, 114, 34, 125},
+			},
+			{
+				ContentType: ContentTypeHeader{
+					ContentType: "text/plain",
+					Params: map[string]string{
+						"name": "attached-text-plain-name.txt",
+					},
+				},
+				ContentDisposition: ContentDispositionHeader{
+					ContentDisposition: attachment,
+					Params: map[string]string{
+						"filename": "attached-text-plain-filename.txt",
+					},
+				},
+				Data: []byte{84, 101, 120, 116, 47, 112, 108, 97, 105, 110, 32, 99, 111, 110, 116, 101, 110, 116, 32,
+					97, 115, 32, 97, 110, 32, 97, 116, 116, 97, 99, 104, 101, 100, 32, 46, 116, 120, 116, 32, 102, 105,
+					108, 101, 46},
+			},
+			{
+				ContentType: ContentTypeHeader{
+					ContentType: "text/html",
+					Params: map[string]string{
+						"name": "attached-text-html-name.html",
+					},
+				},
+				ContentDisposition: ContentDispositionHeader{
+					ContentDisposition: attachment,
+					Params: map[string]string{
+						"filename": "attached-text-html-filename.html",
+					},
+				},
+				Data: []byte{84, 101, 120, 116, 47, 104, 116, 109, 108, 32, 99, 111, 110, 116, 101, 110, 116, 32, 97,
+					115, 32, 97, 110, 32, 97, 116, 116, 97, 99, 104, 101, 100, 32, 46, 104, 116, 109, 108, 32, 102,
+					105, 108, 101, 46},
 			},
 		},
 	}

--- a/tests/test_chinese_multipart_mixed_gb18030_over_base64.txt
+++ b/tests/test_chinese_multipart_mixed_gb18030_over_base64.txt
@@ -110,4 +110,17 @@ Content-Type: appliCATION/jsON; NAME="attached-json-name.json"
 Content-Disposition: ATTACHMENT; FILenaME="attached-json-filename.json"
 
 {"foo":"bar"}
+--MixedBoundaryString
+Content-Type: TexT/PlAIn; nAmE="attached-text-plain-name.txt"
+Content-Disposition: ATTAchMENt; fiLeNaME="attached-text-plain-filename.txt"
+Content-Transfer-Encoding: base64
+
+VGV4dC9wbGFpbiBjb250ZW50IGFzIGFuIGF0dGFjaGVkIC50eHQgZmlsZS4=
+
+--MixedBoundaryString
+Content-Type: teXt/hTml; nAme="attached-text-html-name.html"
+Content-Disposition: aTtAChMent; FILeNAME="attached-text-html-filename.html"
+Content-Transfer-Encoding: BAsE64
+
+VGV4dC9odG1sIGNvbnRlbnQgYXMgYW4gYXR0YWNoZWQgLmh0bWwgZmlsZS4=
 --MixedBoundaryString--

--- a/tests/test_chinese_multipart_mixed_gb18030_over_quoted-printable.txt
+++ b/tests/test_chinese_multipart_mixed_gb18030_over_quoted-printable.txt
@@ -138,4 +138,17 @@ Content-Type: aPplICatiOn/json; name="attached-json-name.json"
 Content-Disposition: attaChmENT; FiLENAMe="attached-json-filename.json"
 
 {"foo":"bar"}
+--MixedBoundaryString
+Content-Type: text/plaiN; NAme="attached-text-plain-name.txt"
+Content-Disposition: ATTacHmEnT; filENaMe="attached-text-plain-filename.txt"
+Content-Transfer-Encoding: BASe64
+
+VGV4dC9wbGFpbiBjb250ZW50IGFzIGFuIGF0dGFjaGVkIC50eHQgZmlsZS4=
+
+--MixedBoundaryString
+Content-Type: TEXT/HtmL; nAmE="attached-text-html-name.html"
+Content-Disposition: atTACHmEnT; FIlENAME="attached-text-html-filename.html"
+Content-Transfer-Encoding: basE64
+
+VGV4dC9odG1sIGNvbnRlbnQgYXMgYW4gYXR0YWNoZWQgLmh0bWwgZmlsZS4=
 --MixedBoundaryString--

--- a/tests/test_chinese_multipart_mixed_gbk_over_base64.txt
+++ b/tests/test_chinese_multipart_mixed_gbk_over_base64.txt
@@ -110,4 +110,17 @@ Content-Type: APPLICatIon/json; naMe="attached-json-name.json"
 Content-Disposition: atTaCHMEnT; filenaME="attached-json-filename.json"
 
 {"foo":"bar"}
+--MixedBoundaryString
+Content-Type: tExT/PLAin; namE="attached-text-plain-name.txt"
+Content-Disposition: AttAcHMEnt; FiLENAME="attached-text-plain-filename.txt"
+Content-Transfer-Encoding: BASe64
+
+VGV4dC9wbGFpbiBjb250ZW50IGFzIGFuIGF0dGFjaGVkIC50eHQgZmlsZS4=
+
+--MixedBoundaryString
+Content-Type: TexT/HTml; Name="attached-text-html-name.html"
+Content-Disposition: ATTachMenT; fILENAme="attached-text-html-filename.html"
+Content-Transfer-Encoding: bASe64
+
+VGV4dC9odG1sIGNvbnRlbnQgYXMgYW4gYXR0YWNoZWQgLmh0bWwgZmlsZS4=
 --MixedBoundaryString--

--- a/tests/test_chinese_multipart_mixed_gbk_over_quoted-printable.txt
+++ b/tests/test_chinese_multipart_mixed_gbk_over_quoted-printable.txt
@@ -138,4 +138,17 @@ Content-Type: ApPLICATION/JSon; NamE="attached-json-name.json"
 Content-Disposition: aTTACHMENT; FILename="attached-json-filename.json"
 
 {"foo":"bar"}
+--MixedBoundaryString
+Content-Type: text/PlAiN; NAme="attached-text-plain-name.txt"
+Content-Disposition: ATTaChMeNt; FIlename="attached-text-plain-filename.txt"
+Content-Transfer-Encoding: bASe64
+
+VGV4dC9wbGFpbiBjb250ZW50IGFzIGFuIGF0dGFjaGVkIC50eHQgZmlsZS4=
+
+--MixedBoundaryString
+Content-Type: tEXT/hTML; name="attached-text-html-name.html"
+Content-Disposition: atTaCHmEnT; FIleNamE="attached-text-html-filename.html"
+Content-Transfer-Encoding: BAse64
+
+VGV4dC9odG1sIGNvbnRlbnQgYXMgYW4gYXR0YWNoZWQgLmh0bWwgZmlsZS4=
 --MixedBoundaryString--

--- a/tests/test_english_multipart_mixed_ascii_over_7bit.txt
+++ b/tests/test_english_multipart_mixed_ascii_over_7bit.txt
@@ -118,4 +118,17 @@ Content-Type: appliCAtION/JSON; NAME="attached-json-name.json"
 Content-Disposition: AtTacHMENT; FILENAME="attached-json-filename.json"
 
 {"foo":"bar"}
+--MixedBoundaryString
+Content-Type: TEXT/PLain; NAme="attached-text-plain-name.txt"
+Content-Disposition: ATTAChmeNt; filENAME="attached-text-plain-filename.txt"
+Content-Transfer-Encoding: BaSE64
+
+VGV4dC9wbGFpbiBjb250ZW50IGFzIGFuIGF0dGFjaGVkIC50eHQgZmlsZS4=
+
+--MixedBoundaryString
+Content-Type: TEXT/HtmL; NamE="attached-text-html-name.html"
+Content-Disposition: ATTAcHMEnt; FilENamE="attached-text-html-filename.html"
+Content-Transfer-Encoding: Base64
+
+VGV4dC9odG1sIGNvbnRlbnQgYXMgYW4gYXR0YWNoZWQgLmh0bWwgZmlsZS4=
 --MixedBoundaryString--

--- a/tests/test_english_multipart_mixed_ascii_over_base64.txt
+++ b/tests/test_english_multipart_mixed_ascii_over_base64.txt
@@ -111,4 +111,17 @@ Content-Type: APPLicatIoN/JSON; NAME="attached-json-name.json"
 Content-Disposition: ATTachment; filenAMe="attached-json-filename.json"
 
 {"foo":"bar"}
+--MixedBoundaryString
+Content-Type: texT/plAIn; naME="attached-text-plain-name.txt"
+Content-Disposition: AtTachmeNT; fILEnaMe="attached-text-plain-filename.txt"
+Content-Transfer-Encoding: Base64
+
+VGV4dC9wbGFpbiBjb250ZW50IGFzIGFuIGF0dGFjaGVkIC50eHQgZmlsZS4=
+
+--MixedBoundaryString
+Content-Type: TExt/hTMl; nAME="attached-text-html-name.html"
+Content-Disposition: aTTACHmEnT; fiLENAme="attached-text-html-filename.html"
+Content-Transfer-Encoding: bASE64
+
+VGV4dC9odG1sIGNvbnRlbnQgYXMgYW4gYXR0YWNoZWQgLmh0bWwgZmlsZS4=
 --MixedBoundaryString--

--- a/tests/test_english_multipart_mixed_ascii_over_quoted-printable.txt
+++ b/tests/test_english_multipart_mixed_ascii_over_quoted-printable.txt
@@ -118,4 +118,17 @@ Content-Type: aPPLIcAtIon/jsoN; NAME="attached-json-name.json"
 Content-Disposition: ATTACHmeNt; fILENAME="attached-json-filename.json"
 
 {"foo":"bar"}
+--MixedBoundaryString
+Content-Type: Text/pLAin; NAME="attached-text-plain-name.txt"
+Content-Disposition: attaChmEnt; FIleName="attached-text-plain-filename.txt"
+Content-Transfer-Encoding: baSe64
+
+VGV4dC9wbGFpbiBjb250ZW50IGFzIGFuIGF0dGFjaGVkIC50eHQgZmlsZS4=
+
+--MixedBoundaryString
+Content-Type: TEXT/htMl; nAmE="attached-text-html-name.html"
+Content-Disposition: AttacHmeNt; FilENAME="attached-text-html-filename.html"
+Content-Transfer-Encoding: basE64
+
+VGV4dC9odG1sIGNvbnRlbnQgYXMgYW4gYXR0YWNoZWQgLmh0bWwgZmlsZS4=
 --MixedBoundaryString--

--- a/tests/test_english_multipart_mixed_utf-8_over_7bit.txt
+++ b/tests/test_english_multipart_mixed_utf-8_over_7bit.txt
@@ -118,4 +118,17 @@ Content-Type: ApplICatioN/json; name="attached-json-name.json"
 Content-Disposition: ATtacHMENT; fIleNaME="attached-json-filename.json"
 
 {"foo":"bar"}
+--MixedBoundaryString
+Content-Type: text/pLaIn; NAME="attached-text-plain-name.txt"
+Content-Disposition: atTAChment; fILenAMe="attached-text-plain-filename.txt"
+Content-Transfer-Encoding: BaSe64
+
+VGV4dC9wbGFpbiBjb250ZW50IGFzIGFuIGF0dGFjaGVkIC50eHQgZmlsZS4=
+
+--MixedBoundaryString
+Content-Type: TExT/HtmL; naMe="attached-text-html-name.html"
+Content-Disposition: ATtachMEnT; FIlenaMe="attached-text-html-filename.html"
+Content-Transfer-Encoding: BASE64
+
+VGV4dC9odG1sIGNvbnRlbnQgYXMgYW4gYXR0YWNoZWQgLmh0bWwgZmlsZS4=
 --MixedBoundaryString--

--- a/tests/test_english_multipart_mixed_utf-8_over_base64.txt
+++ b/tests/test_english_multipart_mixed_utf-8_over_base64.txt
@@ -111,4 +111,17 @@ Content-Type: apPlicATIon/jSon; name="attached-json-name.json"
 Content-Disposition: attachmEnT; FIlename="attached-json-filename.json"
 
 {"foo":"bar"}
+--MixedBoundaryString
+Content-Type: tEXT/PlAIN; name="attached-text-plain-name.txt"
+Content-Disposition: aTTAchment; FiLEnAme="attached-text-plain-filename.txt"
+Content-Transfer-Encoding: baSe64
+
+VGV4dC9wbGFpbiBjb250ZW50IGFzIGFuIGF0dGFjaGVkIC50eHQgZmlsZS4=
+
+--MixedBoundaryString
+Content-Type: tExt/hTMl; nAME="attached-text-html-name.html"
+Content-Disposition: AtTacHmeNt; FILeNaMe="attached-text-html-filename.html"
+Content-Transfer-Encoding: bAsE64
+
+VGV4dC9odG1sIGNvbnRlbnQgYXMgYW4gYXR0YWNoZWQgLmh0bWwgZmlsZS4=
 --MixedBoundaryString--

--- a/tests/test_english_multipart_mixed_utf-8_over_quoted-printable.txt
+++ b/tests/test_english_multipart_mixed_utf-8_over_quoted-printable.txt
@@ -118,4 +118,17 @@ Content-Type: APPLICATION/JSon; NaMe="attached-json-name.json"
 Content-Disposition: ATTACHMENt; fiLename="attached-json-filename.json"
 
 {"foo":"bar"}
+--MixedBoundaryString
+Content-Type: TEXT/PLAIN; name="attached-text-plain-name.txt"
+Content-Disposition: ATTACHMEnt; FILEnAme="attached-text-plain-filename.txt"
+Content-Transfer-Encoding: bASE64
+
+VGV4dC9wbGFpbiBjb250ZW50IGFzIGFuIGF0dGFjaGVkIC50eHQgZmlsZS4=
+
+--MixedBoundaryString
+Content-Type: TexT/HTml; naME="attached-text-html-name.html"
+Content-Disposition: attacHMENt; FIlEnAmE="attached-text-html-filename.html"
+Content-Transfer-Encoding: bAsE64
+
+VGV4dC9odG1sIGNvbnRlbnQgYXMgYW4gYXR0YWNoZWQgLmh0bWwgZmlsZS4=
 --MixedBoundaryString--

--- a/tests/test_finnish_multipart_mixed_iso-8859-15_over_base64.txt
+++ b/tests/test_finnish_multipart_mixed_iso-8859-15_over_base64.txt
@@ -119,4 +119,17 @@ Content-Type: applicATIOn/jSoN; name="attached-json-name.json"
 Content-Disposition: atTaCHMENT; FILENAme="attached-json-filename.json"
 
 {"foo":"bar"}
+--MixedBoundaryString
+Content-Type: TexT/PlAin; NamE="attached-text-plain-name.txt"
+Content-Disposition: ATTAcHmeNT; FilENAmE="attached-text-plain-filename.txt"
+Content-Transfer-Encoding: BASE64
+
+VGV4dC9wbGFpbiBjb250ZW50IGFzIGFuIGF0dGFjaGVkIC50eHQgZmlsZS4=
+
+--MixedBoundaryString
+Content-Type: Text/hTML; naME="attached-text-html-name.html"
+Content-Disposition: AtTAChment; fiLEnaMe="attached-text-html-filename.html"
+Content-Transfer-Encoding: bAse64
+
+VGV4dC9odG1sIGNvbnRlbnQgYXMgYW4gYXR0YWNoZWQgLmh0bWwgZmlsZS4=
 --MixedBoundaryString--

--- a/tests/test_finnish_multipart_mixed_iso-8859-15_over_quoted-printable.txt
+++ b/tests/test_finnish_multipart_mixed_iso-8859-15_over_quoted-printable.txt
@@ -122,4 +122,17 @@ Content-Type: applicAtION/JSON; NAme="attached-json-name.json"
 Content-Disposition: ATTACHMent; fiLENAMe="attached-json-filename.json"
 
 {"foo":"bar"}
+--MixedBoundaryString
+Content-Type: TeXt/PLaIn; nAme="attached-text-plain-name.txt"
+Content-Disposition: atTAcHment; filEnAME="attached-text-plain-filename.txt"
+Content-Transfer-Encoding: bAsE64
+
+VGV4dC9wbGFpbiBjb250ZW50IGFzIGFuIGF0dGFjaGVkIC50eHQgZmlsZS4=
+
+--MixedBoundaryString
+Content-Type: teXt/HtMl; name="attached-text-html-name.html"
+Content-Disposition: aTtachMent; fILenAMe="attached-text-html-filename.html"
+Content-Transfer-Encoding: BASE64
+
+VGV4dC9odG1sIGNvbnRlbnQgYXMgYW4gYXR0YWNoZWQgLmh0bWwgZmlsZS4=
 --MixedBoundaryString--

--- a/tests/test_finnish_multipart_mixed_utf-8_over_base64.txt
+++ b/tests/test_finnish_multipart_mixed_utf-8_over_base64.txt
@@ -120,4 +120,17 @@ Content-Type: APPLIcation/json; nAmE="attached-json-name.json"
 Content-Disposition: AtTachment; fiLenAME="attached-json-filename.json"
 
 {"foo":"bar"}
+--MixedBoundaryString
+Content-Type: teXt/plAin; NAMe="attached-text-plain-name.txt"
+Content-Disposition: aTTAchmEnT; FiLEnAme="attached-text-plain-filename.txt"
+Content-Transfer-Encoding: baSe64
+
+VGV4dC9wbGFpbiBjb250ZW50IGFzIGFuIGF0dGFjaGVkIC50eHQgZmlsZS4=
+
+--MixedBoundaryString
+Content-Type: teXT/htMl; NaMe="attached-text-html-name.html"
+Content-Disposition: AtTaCHmeNT; fILename="attached-text-html-filename.html"
+Content-Transfer-Encoding: basE64
+
+VGV4dC9odG1sIGNvbnRlbnQgYXMgYW4gYXR0YWNoZWQgLmh0bWwgZmlsZS4=
 --MixedBoundaryString--

--- a/tests/test_finnish_multipart_mixed_utf-8_over_quoted-printable.txt
+++ b/tests/test_finnish_multipart_mixed_utf-8_over_quoted-printable.txt
@@ -128,4 +128,17 @@ Content-Type: ApPlicaTION/JSON; NAMe="attached-json-name.json"
 Content-Disposition: ATtacHmenT; FIlENAMe="attached-json-filename.json"
 
 {"foo":"bar"}
+--MixedBoundaryString
+Content-Type: tExT/plAin; NAME="attached-text-plain-name.txt"
+Content-Disposition: aTtachmENt; fILEnamE="attached-text-plain-filename.txt"
+Content-Transfer-Encoding: BASe64
+
+VGV4dC9wbGFpbiBjb250ZW50IGFzIGFuIGF0dGFjaGVkIC50eHQgZmlsZS4=
+
+--MixedBoundaryString
+Content-Type: TEXt/Html; NAME="attached-text-html-name.html"
+Content-Disposition: ATTachmEnt; FILENAme="attached-text-html-filename.html"
+Content-Transfer-Encoding: BaSe64
+
+VGV4dC9odG1sIGNvbnRlbnQgYXMgYW4gYXR0YWNoZWQgLmh0bWwgZmlsZS4=
 --MixedBoundaryString--

--- a/tests/test_icelandic_multipart_mixed_iso-8859-1_over_base64.txt
+++ b/tests/test_icelandic_multipart_mixed_iso-8859-1_over_base64.txt
@@ -104,4 +104,17 @@ Content-Type: ApPLICATION/JSon; Name="attached-json-name.json"
 Content-Disposition: AtTaCHMENT; FILename="attached-json-filename.json"
 
 {"foo":"bar"}
+--MixedBoundaryString
+Content-Type: TexT/plain; NamE="attached-text-plain-name.txt"
+Content-Disposition: aTTAchmENT; FILEName="attached-text-plain-filename.txt"
+Content-Transfer-Encoding: BasE64
+
+VGV4dC9wbGFpbiBjb250ZW50IGFzIGFuIGF0dGFjaGVkIC50eHQgZmlsZS4=
+
+--MixedBoundaryString
+Content-Type: tExt/html; NAme="attached-text-html-name.html"
+Content-Disposition: ATTAchmeNT; fileNamE="attached-text-html-filename.html"
+Content-Transfer-Encoding: basE64
+
+VGV4dC9odG1sIGNvbnRlbnQgYXMgYW4gYXR0YWNoZWQgLmh0bWwgZmlsZS4=
 --MixedBoundaryString--

--- a/tests/test_icelandic_multipart_mixed_iso-8859-1_over_quoted-printable.txt
+++ b/tests/test_icelandic_multipart_mixed_iso-8859-1_over_quoted-printable.txt
@@ -110,4 +110,17 @@ Content-Type: APPLICATion/json; name="attached-json-name.json"
 Content-Disposition: attaChMEnT; Filename="attached-json-filename.json"
 
 {"foo":"bar"}
+--MixedBoundaryString
+Content-Type: tExt/plaIN; NamE="attached-text-plain-name.txt"
+Content-Disposition: AttAChMeNt; FiLENAmE="attached-text-plain-filename.txt"
+Content-Transfer-Encoding: BASe64
+
+VGV4dC9wbGFpbiBjb250ZW50IGFzIGFuIGF0dGFjaGVkIC50eHQgZmlsZS4=
+
+--MixedBoundaryString
+Content-Type: Text/hTml; NAMe="attached-text-html-name.html"
+Content-Disposition: ATtACHMeNT; fiLeNaME="attached-text-html-filename.html"
+Content-Transfer-Encoding: basE64
+
+VGV4dC9odG1sIGNvbnRlbnQgYXMgYW4gYXR0YWNoZWQgLmh0bWwgZmlsZS4=
 --MixedBoundaryString--

--- a/tests/test_icelandic_multipart_mixed_utf-8_over_base64.txt
+++ b/tests/test_icelandic_multipart_mixed_utf-8_over_base64.txt
@@ -106,4 +106,17 @@ Content-Type: APPLIcAtion/json; name="attached-json-name.json"
 Content-Disposition: AtTAchMent; filename="attached-json-filename.json"
 
 {"foo":"bar"}
+--MixedBoundaryString
+Content-Type: texT/PlAin; namE="attached-text-plain-name.txt"
+Content-Disposition: attaChMEnt; fIlEnamE="attached-text-plain-filename.txt"
+Content-Transfer-Encoding: BASe64
+
+VGV4dC9wbGFpbiBjb250ZW50IGFzIGFuIGF0dGFjaGVkIC50eHQgZmlsZS4=
+
+--MixedBoundaryString
+Content-Type: tEXT/htmL; name="attached-text-html-name.html"
+Content-Disposition: attacHMeNT; FILenAME="attached-text-html-filename.html"
+Content-Transfer-Encoding: baSE64
+
+VGV4dC9odG1sIGNvbnRlbnQgYXMgYW4gYXR0YWNoZWQgLmh0bWwgZmlsZS4=
 --MixedBoundaryString--

--- a/tests/test_icelandic_multipart_mixed_utf-8_over_quoted-printable.txt
+++ b/tests/test_icelandic_multipart_mixed_utf-8_over_quoted-printable.txt
@@ -115,4 +115,17 @@ Content-Type: APPLICATion/json; name="attached-json-name.json"
 Content-Disposition: attAChMeNt; filename="attached-json-filename.json"
 
 {"foo":"bar"}
+--MixedBoundaryString
+Content-Type: tExt/PlAin; naME="attached-text-plain-name.txt"
+Content-Disposition: atTaCHmenT; FILEnaMe="attached-text-plain-filename.txt"
+Content-Transfer-Encoding: BaSE64
+
+VGV4dC9wbGFpbiBjb250ZW50IGFzIGFuIGF0dGFjaGVkIC50eHQgZmlsZS4=
+
+--MixedBoundaryString
+Content-Type: Text/htmL; Name="attached-text-html-name.html"
+Content-Disposition: AtTAcHMENt; FilEName="attached-text-html-filename.html"
+Content-Transfer-Encoding: BaSe64
+
+VGV4dC9odG1sIGNvbnRlbnQgYXMgYW4gYXR0YWNoZWQgLmh0bWwgZmlsZS4=
 --MixedBoundaryString--

--- a/tests/test_japanese_multipart_mixed_euc-jp_over_base64.txt
+++ b/tests/test_japanese_multipart_mixed_euc-jp_over_base64.txt
@@ -123,4 +123,17 @@ Content-Type: APPLICATIoN/json; name="attached-json-name.json"
 Content-Disposition: attaChMENT; FiLeName="attached-json-filename.json"
 
 {"foo":"bar"}
+--MixedBoundaryString
+Content-Type: TExt/PlAIn; naMe="attached-text-plain-name.txt"
+Content-Disposition: ATTacHMEnT; fiLENAme="attached-text-plain-filename.txt"
+Content-Transfer-Encoding: BASE64
+
+VGV4dC9wbGFpbiBjb250ZW50IGFzIGFuIGF0dGFjaGVkIC50eHQgZmlsZS4=
+
+--MixedBoundaryString
+Content-Type: teXT/HtMl; NAme="attached-text-html-name.html"
+Content-Disposition: ATtACHmeNT; FILenAmE="attached-text-html-filename.html"
+Content-Transfer-Encoding: BAse64
+
+VGV4dC9odG1sIGNvbnRlbnQgYXMgYW4gYXR0YWNoZWQgLmh0bWwgZmlsZS4=
 --MixedBoundaryString--

--- a/tests/test_japanese_multipart_mixed_euc-jp_over_quoted-printable.txt
+++ b/tests/test_japanese_multipart_mixed_euc-jp_over_quoted-printable.txt
@@ -182,4 +182,17 @@ Content-Type: apPlICATION/JSON; NaMe="attached-json-name.json"
 Content-Disposition: AtTaCHMENT; FILENAmE="attached-json-filename.json"
 
 {"foo":"bar"}
+--MixedBoundaryString
+Content-Type: text/PLAIN; naME="attached-text-plain-name.txt"
+Content-Disposition: aTtacHMENt; filEnAMe="attached-text-plain-filename.txt"
+Content-Transfer-Encoding: baSE64
+
+VGV4dC9wbGFpbiBjb250ZW50IGFzIGFuIGF0dGFjaGVkIC50eHQgZmlsZS4=
+
+--MixedBoundaryString
+Content-Type: TeXT/hTmL; Name="attached-text-html-name.html"
+Content-Disposition: ATTAchmeNT; filenAME="attached-text-html-filename.html"
+Content-Transfer-Encoding: BASe64
+
+VGV4dC9odG1sIGNvbnRlbnQgYXMgYW4gYXR0YWNoZWQgLmh0bWwgZmlsZS4=
 --MixedBoundaryString--

--- a/tests/test_japanese_multipart_mixed_iso-2022-jp_over_7bit.txt
+++ b/tests/test_japanese_multipart_mixed_iso-2022-jp_over_7bit.txt
@@ -160,4 +160,17 @@ Content-Type: APPLICATIoN/json; NaMe="attached-json-name.json"
 Content-Disposition: ATTACHMent; filename="attached-json-filename.json"
 
 {"foo":"bar"}
+--MixedBoundaryString
+Content-Type: text/PlAIN; NAMe="attached-text-plain-name.txt"
+Content-Disposition: attachMent; FIleNaMe="attached-text-plain-filename.txt"
+Content-Transfer-Encoding: Base64
+
+VGV4dC9wbGFpbiBjb250ZW50IGFzIGFuIGF0dGFjaGVkIC50eHQgZmlsZS4=
+
+--MixedBoundaryString
+Content-Type: text/htML; NAmE="attached-text-html-name.html"
+Content-Disposition: aTTachmEnt; fiLENAME="attached-text-html-filename.html"
+Content-Transfer-Encoding: bASe64
+
+VGV4dC9odG1sIGNvbnRlbnQgYXMgYW4gYXR0YWNoZWQgLmh0bWwgZmlsZS4=
 --MixedBoundaryString--

--- a/tests/test_japanese_multipart_mixed_iso-2022-jp_over_base64.txt
+++ b/tests/test_japanese_multipart_mixed_iso-2022-jp_over_base64.txt
@@ -128,4 +128,17 @@ Content-Type: APPLICAtION/JSON; NaME="attached-json-name.json"
 Content-Disposition: ATTaCHMent; Filename="attached-json-filename.json"
 
 {"foo":"bar"}
+--MixedBoundaryString
+Content-Type: TExT/PLAin; NamE="attached-text-plain-name.txt"
+Content-Disposition: ATTachMENT; FILENaME="attached-text-plain-filename.txt"
+Content-Transfer-Encoding: BAsE64
+
+VGV4dC9wbGFpbiBjb250ZW50IGFzIGFuIGF0dGFjaGVkIC50eHQgZmlsZS4=
+
+--MixedBoundaryString
+Content-Type: TexT/htmL; namE="attached-text-html-name.html"
+Content-Disposition: atTAcHment; fIlenamE="attached-text-html-filename.html"
+Content-Transfer-Encoding: bAse64
+
+VGV4dC9odG1sIGNvbnRlbnQgYXMgYW4gYXR0YWNoZWQgLmh0bWwgZmlsZS4=
 --MixedBoundaryString--

--- a/tests/test_japanese_multipart_mixed_iso-2022-jp_over_quoted-printable.txt
+++ b/tests/test_japanese_multipart_mixed_iso-2022-jp_over_quoted-printable.txt
@@ -169,4 +169,17 @@ Content-Type: aPPLICATIOn/Json; name="attached-json-name.json"
 Content-Disposition: attaCHMEnt; filename="attached-json-filename.json"
 
 {"foo":"bar"}
+--MixedBoundaryString
+Content-Type: TEXT/pLAIn; Name="attached-text-plain-name.txt"
+Content-Disposition: aTTaChmEnt; FILenAME="attached-text-plain-filename.txt"
+Content-Transfer-Encoding: bASE64
+
+VGV4dC9wbGFpbiBjb250ZW50IGFzIGFuIGF0dGFjaGVkIC50eHQgZmlsZS4=
+
+--MixedBoundaryString
+Content-Type: texT/htMl; nAme="attached-text-html-name.html"
+Content-Disposition: ATtaCHMEnt; FilENamE="attached-text-html-filename.html"
+Content-Transfer-Encoding: baSe64
+
+VGV4dC9odG1sIGNvbnRlbnQgYXMgYW4gYXR0YWNoZWQgLmh0bWwgZmlsZS4=
 --MixedBoundaryString--

--- a/tests/test_japanese_multipart_mixed_utf-8_over_7bit.txt
+++ b/tests/test_japanese_multipart_mixed_utf-8_over_7bit.txt
@@ -160,4 +160,17 @@ Content-Type: apPLICaTion/json; nAMe="attached-json-name.json"
 Content-Disposition: ATTACHMENT; FILeName="attached-json-filename.json"
 
 {"foo":"bar"}
+--MixedBoundaryString
+Content-Type: tEXT/PLaIn; NamE="attached-text-plain-name.txt"
+Content-Disposition: attAcHmENt; FilENamE="attached-text-plain-filename.txt"
+Content-Transfer-Encoding: BASE64
+
+VGV4dC9wbGFpbiBjb250ZW50IGFzIGFuIGF0dGFjaGVkIC50eHQgZmlsZS4=
+
+--MixedBoundaryString
+Content-Type: tEXT/Html; NAmE="attached-text-html-name.html"
+Content-Disposition: AttaChment; fILEnAme="attached-text-html-filename.html"
+Content-Transfer-Encoding: bAse64
+
+VGV4dC9odG1sIGNvbnRlbnQgYXMgYW4gYXR0YWNoZWQgLmh0bWwgZmlsZS4=
 --MixedBoundaryString--

--- a/tests/test_japanese_multipart_mixed_utf-8_over_base64.txt
+++ b/tests/test_japanese_multipart_mixed_utf-8_over_base64.txt
@@ -132,4 +132,17 @@ Content-Type: applicatiON/JSON; NAME="attached-json-name.json"
 Content-Disposition: ATTAChMent; FILENAME="attached-json-filename.json"
 
 {"foo":"bar"}
+--MixedBoundaryString
+Content-Type: Text/PLAiN; NamE="attached-text-plain-name.txt"
+Content-Disposition: attAcHMent; fIlenamE="attached-text-plain-filename.txt"
+Content-Transfer-Encoding: bAsE64
+
+VGV4dC9wbGFpbiBjb250ZW50IGFzIGFuIGF0dGFjaGVkIC50eHQgZmlsZS4=
+
+--MixedBoundaryString
+Content-Type: TeXt/HtML; NAME="attached-text-html-name.html"
+Content-Disposition: ATtACHMeNT; FILEnAmE="attached-text-html-filename.html"
+Content-Transfer-Encoding: bASe64
+
+VGV4dC9odG1sIGNvbnRlbnQgYXMgYW4gYXR0YWNoZWQgLmh0bWwgZmlsZS4=
 --MixedBoundaryString--

--- a/tests/test_japanese_multipart_mixed_utf-8_over_quoted-printable.txt
+++ b/tests/test_japanese_multipart_mixed_utf-8_over_quoted-printable.txt
@@ -196,4 +196,17 @@ Content-Type: appliCaTION/Json; namE="attached-json-name.json"
 Content-Disposition: AtTACHMENT; FILENaMe="attached-json-filename.json"
 
 {"foo":"bar"}
+--MixedBoundaryString
+Content-Type: TEXt/plAIn; NAME="attached-text-plain-name.txt"
+Content-Disposition: ATtachMENT; fiLEnaMe="attached-text-plain-filename.txt"
+Content-Transfer-Encoding: BaSE64
+
+VGV4dC9wbGFpbiBjb250ZW50IGFzIGFuIGF0dGFjaGVkIC50eHQgZmlsZS4=
+
+--MixedBoundaryString
+Content-Type: TeXT/HTMl; nAmE="attached-text-html-name.html"
+Content-Disposition: atTAChmenT; FILenaMe="attached-text-html-filename.html"
+Content-Transfer-Encoding: bAse64
+
+VGV4dC9odG1sIGNvbnRlbnQgYXMgYW4gYXR0YWNoZWQgLmh0bWwgZmlsZS4=
 --MixedBoundaryString--

--- a/tests/test_korean_multipart_mixed_euc-kr_over_base64.txt
+++ b/tests/test_korean_multipart_mixed_euc-kr_over_base64.txt
@@ -100,4 +100,17 @@ Content-Type: applicAtIOn/json; name="attached-json-name.json"
 Content-Disposition: attaCHMENT; FILENAME="attached-json-filename.json"
 
 {"foo":"bar"}
+--MixedBoundaryString
+Content-Type: teXt/plAiN; name="attached-text-plain-name.txt"
+Content-Disposition: ATtAChMeNt; FiLEnAME="attached-text-plain-filename.txt"
+Content-Transfer-Encoding: BASe64
+
+VGV4dC9wbGFpbiBjb250ZW50IGFzIGFuIGF0dGFjaGVkIC50eHQgZmlsZS4=
+
+--MixedBoundaryString
+Content-Type: Text/HTml; name="attached-text-html-name.html"
+Content-Disposition: ATTachMeNt; filEname="attached-text-html-filename.html"
+Content-Transfer-Encoding: bAsE64
+
+VGV4dC9odG1sIGNvbnRlbnQgYXMgYW4gYXR0YWNoZWQgLmh0bWwgZmlsZS4=
 --MixedBoundaryString--

--- a/tests/test_korean_multipart_mixed_euc-kr_over_quoted-printable.txt
+++ b/tests/test_korean_multipart_mixed_euc-kr_over_quoted-printable.txt
@@ -107,4 +107,17 @@ Content-Type: apPLICATION/JSoN; NaME="attached-json-name.json"
 Content-Disposition: aTTACHMENT; FILenAme="attached-json-filename.json"
 
 {"foo":"bar"}
+--MixedBoundaryString
+Content-Type: tEXt/PlAin; NAme="attached-text-plain-name.txt"
+Content-Disposition: AttacHMENt; FIlenamE="attached-text-plain-filename.txt"
+Content-Transfer-Encoding: BAse64
+
+VGV4dC9wbGFpbiBjb250ZW50IGFzIGFuIGF0dGFjaGVkIC50eHQgZmlsZS4=
+
+--MixedBoundaryString
+Content-Type: TeXt/htMl; name="attached-text-html-name.html"
+Content-Disposition: aTTaChment; FiLenAmE="attached-text-html-filename.html"
+Content-Transfer-Encoding: BAsE64
+
+VGV4dC9odG1sIGNvbnRlbnQgYXMgYW4gYXR0YWNoZWQgLmh0bWwgZmlsZS4=
 --MixedBoundaryString--

--- a/tests/test_korean_multipart_mixed_utf-8_over_base64.txt
+++ b/tests/test_korean_multipart_mixed_utf-8_over_base64.txt
@@ -101,4 +101,17 @@ Content-Type: APPLICATIoN/json; name="attached-json-name.json"
 Content-Disposition: attaChmENT; Filename="attached-json-filename.json"
 
 {"foo":"bar"}
+--MixedBoundaryString
+Content-Type: TexT/pLAIn; NAmE="attached-text-plain-name.txt"
+Content-Disposition: aTTaCHMENT; fileNamE="attached-text-plain-filename.txt"
+Content-Transfer-Encoding: BasE64
+
+VGV4dC9wbGFpbiBjb250ZW50IGFzIGFuIGF0dGFjaGVkIC50eHQgZmlsZS4=
+
+--MixedBoundaryString
+Content-Type: TexT/HtmL; NAME="attached-text-html-name.html"
+Content-Disposition: AtTACHmEnT; filENAmE="attached-text-html-filename.html"
+Content-Transfer-Encoding: BAse64
+
+VGV4dC9odG1sIGNvbnRlbnQgYXMgYW4gYXR0YWNoZWQgLmh0bWwgZmlsZS4=
 --MixedBoundaryString--

--- a/tests/test_korean_multipart_mixed_utf-8_over_quoted-printable.txt
+++ b/tests/test_korean_multipart_mixed_utf-8_over_quoted-printable.txt
@@ -110,4 +110,17 @@ Content-Type: APPLICATION/Json; Name="attached-json-name.json"
 Content-Disposition: attacHMENT; fileNAME="attached-json-filename.json"
 
 {"foo":"bar"}
+--MixedBoundaryString
+Content-Type: tExt/pLAiN; naMe="attached-text-plain-name.txt"
+Content-Disposition: atTAcHmeNt; FIleNAme="attached-text-plain-filename.txt"
+Content-Transfer-Encoding: BasE64
+
+VGV4dC9wbGFpbiBjb250ZW50IGFzIGFuIGF0dGFjaGVkIC50eHQgZmlsZS4=
+
+--MixedBoundaryString
+Content-Type: TexT/HtML; NamE="attached-text-html-name.html"
+Content-Disposition: AttAcHMeNt; FIlenaMe="attached-text-html-filename.html"
+Content-Transfer-Encoding: BAsE64
+
+VGV4dC9odG1sIGNvbnRlbnQgYXMgYW4gYXR0YWNoZWQgLmh0bWwgZmlsZS4=
 --MixedBoundaryString--

--- a/tests/test_polish_multipart_mixed_iso-8859-2_over_base64.txt
+++ b/tests/test_polish_multipart_mixed_iso-8859-2_over_base64.txt
@@ -114,4 +114,17 @@ Content-Type: aPPLICATION/json; name="attached-json-name.json"
 Content-Disposition: attachmENt; FIlEnAme="attached-json-filename.json"
 
 {"foo":"bar"}
+--MixedBoundaryString
+Content-Type: TEXt/pLAiN; NAmE="attached-text-plain-name.txt"
+Content-Disposition: attAcHMent; fILEnamE="attached-text-plain-filename.txt"
+Content-Transfer-Encoding: BAsE64
+
+VGV4dC9wbGFpbiBjb250ZW50IGFzIGFuIGF0dGFjaGVkIC50eHQgZmlsZS4=
+
+--MixedBoundaryString
+Content-Type: tExT/Html; NAme="attached-text-html-name.html"
+Content-Disposition: aTTaCHmenT; fiLenAmE="attached-text-html-filename.html"
+Content-Transfer-Encoding: BAse64
+
+VGV4dC9odG1sIGNvbnRlbnQgYXMgYW4gYXR0YWNoZWQgLmh0bWwgZmlsZS4=
 --MixedBoundaryString--

--- a/tests/test_polish_multipart_mixed_iso-8859-2_over_quoted-printable.txt
+++ b/tests/test_polish_multipart_mixed_iso-8859-2_over_quoted-printable.txt
@@ -122,4 +122,17 @@ Content-Type: APPlIcAtiOn/JSON; NAME="attached-json-name.json"
 Content-Disposition: ATTAcHment; filename="attached-json-filename.json"
 
 {"foo":"bar"}
+--MixedBoundaryString
+Content-Type: tEXT/PLaiN; name="attached-text-plain-name.txt"
+Content-Disposition: AtTAchMeNT; FILEname="attached-text-plain-filename.txt"
+Content-Transfer-Encoding: bASe64
+
+VGV4dC9wbGFpbiBjb250ZW50IGFzIGFuIGF0dGFjaGVkIC50eHQgZmlsZS4=
+
+--MixedBoundaryString
+Content-Type: TEXt/hTMl; nAMe="attached-text-html-name.html"
+Content-Disposition: ATTacHMeNt; FIlENAMe="attached-text-html-filename.html"
+Content-Transfer-Encoding: BAsE64
+
+VGV4dC9odG1sIGNvbnRlbnQgYXMgYW4gYXR0YWNoZWQgLmh0bWwgZmlsZS4=
 --MixedBoundaryString--

--- a/tests/test_polish_multipart_mixed_utf-8_over_base64.txt
+++ b/tests/test_polish_multipart_mixed_utf-8_over_base64.txt
@@ -119,4 +119,17 @@ Content-Type: Application/jsON; NAME="attached-json-name.json"
 Content-Disposition: ATTACHMENT; filenAme="attached-json-filename.json"
 
 {"foo":"bar"}
+--MixedBoundaryString
+Content-Type: TExT/pLAiN; name="attached-text-plain-name.txt"
+Content-Disposition: AtTachMENT; fIlEname="attached-text-plain-filename.txt"
+Content-Transfer-Encoding: BasE64
+
+VGV4dC9wbGFpbiBjb250ZW50IGFzIGFuIGF0dGFjaGVkIC50eHQgZmlsZS4=
+
+--MixedBoundaryString
+Content-Type: TExt/HtmL; name="attached-text-html-name.html"
+Content-Disposition: aTTachmENt; FIlEnamE="attached-text-html-filename.html"
+Content-Transfer-Encoding: bAsE64
+
+VGV4dC9odG1sIGNvbnRlbnQgYXMgYW4gYXR0YWNoZWQgLmh0bWwgZmlsZS4=
 --MixedBoundaryString--

--- a/tests/test_polish_multipart_mixed_utf-8_over_quoted-printable.txt
+++ b/tests/test_polish_multipart_mixed_utf-8_over_quoted-printable.txt
@@ -145,4 +145,17 @@ Content-Type: ApPlICaTion/json; name="attached-json-name.json"
 Content-Disposition: aTtACHMENT; FILEName="attached-json-filename.json"
 
 {"foo":"bar"}
+--MixedBoundaryString
+Content-Type: tEXt/pLAiN; Name="attached-text-plain-name.txt"
+Content-Disposition: attaChMEnt; FileNaME="attached-text-plain-filename.txt"
+Content-Transfer-Encoding: BASE64
+
+VGV4dC9wbGFpbiBjb250ZW50IGFzIGFuIGF0dGFjaGVkIC50eHQgZmlsZS4=
+
+--MixedBoundaryString
+Content-Type: TExT/HtML; name="attached-text-html-name.html"
+Content-Disposition: ATTachMENT; fILENAme="attached-text-html-filename.html"
+Content-Transfer-Encoding: BaSE64
+
+VGV4dC9odG1sIGNvbnRlbnQgYXMgYW4gYXR0YWNoZWQgLmh0bWwgZmlsZS4=
 --MixedBoundaryString--


### PR DESCRIPTION
# Rationale

As reported by @naidishuli in https://github.com/mnako/letters/issues/41, we have been parsing `text/plain` and `text/html` attachments incorrectly. Even when they are attached with the `Content-Disposition: attachment` header, we mistakenly treat them as text and HTML content, respectively.

This PR addresses and resolves this problem.

## Commits:

1. https://github.com/mnako/letters/commit/baed02e6e1f1861ff28c0884a9b76855f9415445: Add tests reproducing the reported issue. Tests should fail on this commit:
    * Modify multipart/mixed test files to include a `text/plain` and a `text/html` `content-disposition: attachment` files.
    * Modify `letters_test.go` to expect text/plain and text/html attachments to be correctly parsed.
2. https://github.com/mnako/letters/pull/44/commits/13b27919b050b337d9e53e53e1b507e82f068173: implement fix:
    * Modify parsers.go to parse Content Disposition header in `parsePart()` to correctly handle attachments of any content type.
    * Simplify `parsePart()` loop.
    * Simplify `isInlineFile()` and `isAttachedFile()` to not parse Content Disposition header multiple times.
