### PR TITLE
Add tests for all characters allowed in header field names and bodies

### DIFF
--- a/letters_test.go
+++ b/letters_test.go
@@ -121,6 +121,10 @@ func TestParseEmailEnglishNoTextContent(t *testing.T) {
 			},
 			ExtraHeaders: map[string][]string{
 				"X-Clacks-Overhead": {"GNU Terry Pratchett"},
+				"X-Script/function/\t !\"#$%&'()*+,-./;<=>?@[\\]^_`{|}~": {
+					"TEST VALUE 1\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+					"TEST VALUE 2\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+				},
 			},
 		},
 		Text:         "",
@@ -224,6 +228,10 @@ func TestParseEmailEnglishPlaintextAsciiOver7bit(t *testing.T) {
 			},
 			ExtraHeaders: map[string][]string{
 				"X-Clacks-Overhead": {"GNU Terry Pratchett"},
+				"X-Script/function/\t !\"#$%&'()*+,-./;<=>?@[\\]^_`{|}~": {
+					"TEST VALUE 1\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+					"TEST VALUE 2\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+				},
 			},
 		},
 		Text: `The quick brown fox jumps over a lazy dog.
@@ -357,6 +365,10 @@ func TestParseEmailEnglishPlaintextAsciiOverBase64(t *testing.T) {
 			},
 			ExtraHeaders: map[string][]string{
 				"X-Clacks-Overhead": {"GNU Terry Pratchett"},
+				"X-Script/function/\t !\"#$%&'()*+,-./;<=>?@[\\]^_`{|}~": {
+					"TEST VALUE 1\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+					"TEST VALUE 2\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+				},
 			},
 		},
 		Text: `The quick brown fox jumps over a lazy dog.
@@ -490,6 +502,10 @@ func TestParseEmailEnglishPlaintextAsciiOverQuotedprintable(t *testing.T) {
 			},
 			ExtraHeaders: map[string][]string{
 				"X-Clacks-Overhead": {"GNU Terry Pratchett"},
+				"X-Script/function/\t !\"#$%&'()*+,-./;<=>?@[\\]^_`{|}~": {
+					"TEST VALUE 1\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+					"TEST VALUE 2\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+				},
 			},
 		},
 		Text: `The quick brown fox jumps over a lazy dog.
@@ -623,6 +639,10 @@ func TestParseEmailEnglishPlaintextUtf8Over7bit(t *testing.T) {
 			},
 			ExtraHeaders: map[string][]string{
 				"X-Clacks-Overhead": {"GNU Terry Pratchett"},
+				"X-Script/function/\t !\"#$%&'()*+,-./;<=>?@[\\]^_`{|}~": {
+					"TEST VALUE 1\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+					"TEST VALUE 2\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+				},
 			},
 		},
 		Text: `The quick brown fox jumps over a lazy dog.
@@ -756,6 +776,10 @@ func TestParseEmailEnglishPlaintextUtf8OverBase64(t *testing.T) {
 			},
 			ExtraHeaders: map[string][]string{
 				"X-Clacks-Overhead": {"GNU Terry Pratchett"},
+				"X-Script/function/\t !\"#$%&'()*+,-./;<=>?@[\\]^_`{|}~": {
+					"TEST VALUE 1\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+					"TEST VALUE 2\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+				},
 			},
 		},
 		Text: `The quick brown fox jumps over a lazy dog.
@@ -889,6 +913,10 @@ func TestParseEmailEnglishPlaintextUtf8OverQuotedprintable(t *testing.T) {
 			},
 			ExtraHeaders: map[string][]string{
 				"X-Clacks-Overhead": {"GNU Terry Pratchett"},
+				"X-Script/function/\t !\"#$%&'()*+,-./;<=>?@[\\]^_`{|}~": {
+					"TEST VALUE 1\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+					"TEST VALUE 2\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+				},
 			},
 		},
 		Text: `The quick brown fox jumps over a lazy dog.
@@ -1023,6 +1051,10 @@ func TestParseEmailEnglishMultipartRelatedAsciiOver7bit(t *testing.T) {
 			},
 			ExtraHeaders: map[string][]string{
 				"X-Clacks-Overhead": {"GNU Terry Pratchett"},
+				"X-Script/function/\t !\"#$%&'()*+,-./;<=>?@[\\]^_`{|}~": {
+					"TEST VALUE 1\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+					"TEST VALUE 2\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+				},
 			},
 		},
 		Text: `The quick brown fox jumps over a lazy dog.
@@ -1196,6 +1228,10 @@ func TestParseEmailEnglishMultipartRelatedAsciiOverBase64(t *testing.T) {
 			},
 			ExtraHeaders: map[string][]string{
 				"X-Clacks-Overhead": {"GNU Terry Pratchett"},
+				"X-Script/function/\t !\"#$%&'()*+,-./;<=>?@[\\]^_`{|}~": {
+					"TEST VALUE 1\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+					"TEST VALUE 2\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+				},
 			},
 		},
 		Text: `The quick brown fox jumps over a lazy dog.
@@ -1369,6 +1405,10 @@ func TestParseEmailEnglishMultipartRelatedAsciiOverQuotedprintable(t *testing.T)
 			},
 			ExtraHeaders: map[string][]string{
 				"X-Clacks-Overhead": {"GNU Terry Pratchett"},
+				"X-Script/function/\t !\"#$%&'()*+,-./;<=>?@[\\]^_`{|}~": {
+					"TEST VALUE 1\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+					"TEST VALUE 2\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+				},
 			},
 		},
 		Text: `The quick brown fox jumps over a lazy dog.
@@ -1542,6 +1582,10 @@ func TestParseEmailEnglishMultipartRelatedUtf8Over7bit(t *testing.T) {
 			},
 			ExtraHeaders: map[string][]string{
 				"X-Clacks-Overhead": {"GNU Terry Pratchett"},
+				"X-Script/function/\t !\"#$%&'()*+,-./;<=>?@[\\]^_`{|}~": {
+					"TEST VALUE 1\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+					"TEST VALUE 2\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+				},
 			},
 		},
 		Text: `The quick brown fox jumps over a lazy dog.
@@ -1715,6 +1759,10 @@ func TestParseEmailEnglishMultipartRelatedUtf8OverBase64(t *testing.T) {
 			},
 			ExtraHeaders: map[string][]string{
 				"X-Clacks-Overhead": {"GNU Terry Pratchett"},
+				"X-Script/function/\t !\"#$%&'()*+,-./;<=>?@[\\]^_`{|}~": {
+					"TEST VALUE 1\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+					"TEST VALUE 2\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+				},
 			},
 		},
 		Text: `The quick brown fox jumps over a lazy dog.
@@ -1888,6 +1936,10 @@ func TestParseEmailEnglishMultipartRelatedUtf8OverQuotedprintable(t *testing.T) 
 			},
 			ExtraHeaders: map[string][]string{
 				"X-Clacks-Overhead": {"GNU Terry Pratchett"},
+				"X-Script/function/\t !\"#$%&'()*+,-./;<=>?@[\\]^_`{|}~": {
+					"TEST VALUE 1\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+					"TEST VALUE 2\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+				},
 			},
 		},
 		Text: `The quick brown fox jumps over a lazy dog.
@@ -2061,6 +2113,10 @@ func TestParseEmailEnglishMultipartMixedAsciiOver7bit(t *testing.T) {
 			},
 			ExtraHeaders: map[string][]string{
 				"X-Clacks-Overhead": {"GNU Terry Pratchett"},
+				"X-Script/function/\t !\"#$%&'()*+,-./;<=>?@[\\]^_`{|}~": {
+					"TEST VALUE 1\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+					"TEST VALUE 2\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+				},
 			},
 		},
 		Text: `The quick brown fox jumps over a lazy dog.
@@ -2336,6 +2392,10 @@ func TestParseEmailEnglishMultipartMixedAsciiOverBase64(t *testing.T) {
 			},
 			ExtraHeaders: map[string][]string{
 				"X-Clacks-Overhead": {"GNU Terry Pratchett"},
+				"X-Script/function/\t !\"#$%&'()*+,-./;<=>?@[\\]^_`{|}~": {
+					"TEST VALUE 1\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+					"TEST VALUE 2\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+				},
 			},
 		},
 		Text: `The quick brown fox jumps over a lazy dog.
@@ -2611,6 +2671,10 @@ func TestParseEmailEnglishMultipartMixedAsciiOverQuotedprintable(t *testing.T) {
 			},
 			ExtraHeaders: map[string][]string{
 				"X-Clacks-Overhead": {"GNU Terry Pratchett"},
+				"X-Script/function/\t !\"#$%&'()*+,-./;<=>?@[\\]^_`{|}~": {
+					"TEST VALUE 1\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+					"TEST VALUE 2\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+				},
 			},
 		},
 		Text: `The quick brown fox jumps over a lazy dog.
@@ -2886,6 +2950,10 @@ func TestParseEmailEnglishMultipartMixedUtf8Over7bit(t *testing.T) {
 			},
 			ExtraHeaders: map[string][]string{
 				"X-Clacks-Overhead": {"GNU Terry Pratchett"},
+				"X-Script/function/\t !\"#$%&'()*+,-./;<=>?@[\\]^_`{|}~": {
+					"TEST VALUE 1\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+					"TEST VALUE 2\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+				},
 			},
 		},
 		Text: `The quick brown fox jumps over a lazy dog.
@@ -3161,6 +3229,10 @@ func TestParseEmailEnglishMultipartMixedUtf8OverBase64(t *testing.T) {
 			},
 			ExtraHeaders: map[string][]string{
 				"X-Clacks-Overhead": {"GNU Terry Pratchett"},
+				"X-Script/function/\t !\"#$%&'()*+,-./;<=>?@[\\]^_`{|}~": {
+					"TEST VALUE 1\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+					"TEST VALUE 2\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+				},
 			},
 		},
 		Text: `The quick brown fox jumps over a lazy dog.
@@ -3436,6 +3508,10 @@ func TestParseEmailEnglishMultipartMixedUtf8OverQuotedprintable(t *testing.T) {
 			},
 			ExtraHeaders: map[string][]string{
 				"X-Clacks-Overhead": {"GNU Terry Pratchett"},
+				"X-Script/function/\t !\"#$%&'()*+,-./;<=>?@[\\]^_`{|}~": {
+					"TEST VALUE 1\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+					"TEST VALUE 2\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+				},
 			},
 		},
 		Text: `The quick brown fox jumps over a lazy dog.
@@ -3713,6 +3789,10 @@ func TestParseEmailEnglishMultipartSignedAsciiOver7bit(t *testing.T) {
 			},
 			ExtraHeaders: map[string][]string{
 				"X-Clacks-Overhead": {"GNU Terry Pratchett"},
+				"X-Script/function/\t !\"#$%&'()*+,-./;<=>?@[\\]^_`{|}~": {
+					"TEST VALUE 1\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+					"TEST VALUE 2\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+				},
 			},
 		},
 		Text: `The quick brown fox jumps over a lazy dog.
@@ -3866,6 +3946,10 @@ func TestParseEmailEnglishMultipartSignedAsciiOverBase64(t *testing.T) {
 			},
 			ExtraHeaders: map[string][]string{
 				"X-Clacks-Overhead": {"GNU Terry Pratchett"},
+				"X-Script/function/\t !\"#$%&'()*+,-./;<=>?@[\\]^_`{|}~": {
+					"TEST VALUE 1\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+					"TEST VALUE 2\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+				},
 			},
 		},
 		Text: `The quick brown fox jumps over a lazy dog.
@@ -4019,6 +4103,10 @@ func TestParseEmailEnglishMultipartSignedAsciiOverQuotedprintable(t *testing.T) 
 			},
 			ExtraHeaders: map[string][]string{
 				"X-Clacks-Overhead": {"GNU Terry Pratchett"},
+				"X-Script/function/\t !\"#$%&'()*+,-./;<=>?@[\\]^_`{|}~": {
+					"TEST VALUE 1\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+					"TEST VALUE 2\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+				},
 			},
 		},
 		Text: `The quick brown fox jumps over a lazy dog.
@@ -4172,6 +4260,10 @@ func TestParseEmailEnglishMultipartSignedUtf8Over7bit(t *testing.T) {
 			},
 			ExtraHeaders: map[string][]string{
 				"X-Clacks-Overhead": {"GNU Terry Pratchett"},
+				"X-Script/function/\t !\"#$%&'()*+,-./;<=>?@[\\]^_`{|}~": {
+					"TEST VALUE 1\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+					"TEST VALUE 2\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+				},
 			},
 		},
 		Text: `The quick brown fox jumps over a lazy dog.
@@ -4325,6 +4417,10 @@ func TestParseEmailEnglishMultipartSignedUtf8OverBase64(t *testing.T) {
 			},
 			ExtraHeaders: map[string][]string{
 				"X-Clacks-Overhead": {"GNU Terry Pratchett"},
+				"X-Script/function/\t !\"#$%&'()*+,-./;<=>?@[\\]^_`{|}~": {
+					"TEST VALUE 1\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+					"TEST VALUE 2\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+				},
 			},
 		},
 		Text: `The quick brown fox jumps over a lazy dog.
@@ -4478,6 +4574,10 @@ func TestParseEmailEnglishMultipartSignedUtf8OverQuotedprintable(t *testing.T) {
 			},
 			ExtraHeaders: map[string][]string{
 				"X-Clacks-Overhead": {"GNU Terry Pratchett"},
+				"X-Script/function/\t !\"#$%&'()*+,-./;<=>?@[\\]^_`{|}~": {
+					"TEST VALUE 1\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+					"TEST VALUE 2\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+				},
 			},
 		},
 		Text: `The quick brown fox jumps over a lazy dog.
@@ -4628,6 +4728,10 @@ func TestParseEmailChinesePlaintextGb18030OverBase64(t *testing.T) {
 			},
 			ExtraHeaders: map[string][]string{
 				"X-Clacks-Overhead": {"GNU Terry Pratchett"},
+				"X-Script/function/\t !\"#$%&'()*+,-./;<=>?@[\\]^_`{|}~": {
+					"TEST VALUE 1\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+					"TEST VALUE 2\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+				},
 			},
 		},
 		Text: `石室诗士施氏，嗜狮，誓食十狮。
@@ -4764,6 +4868,10 @@ func TestParseEmailChinesePlaintextGb18030OverQuotedprintable(t *testing.T) {
 			},
 			ExtraHeaders: map[string][]string{
 				"X-Clacks-Overhead": {"GNU Terry Pratchett"},
+				"X-Script/function/\t !\"#$%&'()*+,-./;<=>?@[\\]^_`{|}~": {
+					"TEST VALUE 1\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+					"TEST VALUE 2\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+				},
 			},
 		},
 		Text: `石室诗士施氏，嗜狮，誓食十狮。
@@ -4900,6 +5008,10 @@ func TestParseEmailChinesePlaintextGbkOverBase64(t *testing.T) {
 			},
 			ExtraHeaders: map[string][]string{
 				"X-Clacks-Overhead": {"GNU Terry Pratchett"},
+				"X-Script/function/\t !\"#$%&'()*+,-./;<=>?@[\\]^_`{|}~": {
+					"TEST VALUE 1\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+					"TEST VALUE 2\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+				},
 			},
 		},
 		Text: `石室诗士施氏，嗜狮，誓食十狮。
@@ -5036,6 +5148,10 @@ func TestParseEmailChinesePlaintextGbkOverQuotedprintable(t *testing.T) {
 			},
 			ExtraHeaders: map[string][]string{
 				"X-Clacks-Overhead": {"GNU Terry Pratchett"},
+				"X-Script/function/\t !\"#$%&'()*+,-./;<=>?@[\\]^_`{|}~": {
+					"TEST VALUE 1\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+					"TEST VALUE 2\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+				},
 			},
 		},
 		Text: `石室诗士施氏，嗜狮，誓食十狮。
@@ -5173,6 +5289,10 @@ func TestParseEmailChineseMultipartRelatedGb18030OverBase64(t *testing.T) {
 			},
 			ExtraHeaders: map[string][]string{
 				"X-Clacks-Overhead": {"GNU Terry Pratchett"},
+				"X-Script/function/\t !\"#$%&'()*+,-./;<=>?@[\\]^_`{|}~": {
+					"TEST VALUE 1\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+					"TEST VALUE 2\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+				},
 			},
 		},
 		Text: `石室诗士施氏，嗜狮，誓食十狮。
@@ -5355,6 +5475,10 @@ func TestParseEmailChineseMultipartRelatedGb18030OverQuotedprintable(t *testing.
 			},
 			ExtraHeaders: map[string][]string{
 				"X-Clacks-Overhead": {"GNU Terry Pratchett"},
+				"X-Script/function/\t !\"#$%&'()*+,-./;<=>?@[\\]^_`{|}~": {
+					"TEST VALUE 1\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+					"TEST VALUE 2\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+				},
 			},
 		},
 		Text: `石室诗士施氏，嗜狮，誓食十狮。
@@ -5537,6 +5661,10 @@ func TestParseEmailChineseMultipartRelatedGbkOverBase64(t *testing.T) {
 			},
 			ExtraHeaders: map[string][]string{
 				"X-Clacks-Overhead": {"GNU Terry Pratchett"},
+				"X-Script/function/\t !\"#$%&'()*+,-./;<=>?@[\\]^_`{|}~": {
+					"TEST VALUE 1\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+					"TEST VALUE 2\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+				},
 			},
 		},
 		Text: `石室诗士施氏，嗜狮，誓食十狮。
@@ -5719,6 +5847,10 @@ func TestParseEmailChineseMultipartRelatedGbkOverQuotedprintable(t *testing.T) {
 			},
 			ExtraHeaders: map[string][]string{
 				"X-Clacks-Overhead": {"GNU Terry Pratchett"},
+				"X-Script/function/\t !\"#$%&'()*+,-./;<=>?@[\\]^_`{|}~": {
+					"TEST VALUE 1\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+					"TEST VALUE 2\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+				},
 			},
 		},
 		Text: `石室诗士施氏，嗜狮，誓食十狮。
@@ -5901,6 +6033,10 @@ func TestParseEmailChineseMultipartMixedGb18030OverBase64(t *testing.T) {
 			},
 			ExtraHeaders: map[string][]string{
 				"X-Clacks-Overhead": {"GNU Terry Pratchett"},
+				"X-Script/function/\t !\"#$%&'()*+,-./;<=>?@[\\]^_`{|}~": {
+					"TEST VALUE 1\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+					"TEST VALUE 2\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+				},
 			},
 		},
 		Text: `石室诗士施氏，嗜狮，誓食十狮。
@@ -6185,6 +6321,10 @@ func TestParseEmailChineseMultipartMixedGb18030OverQuotedprintable(t *testing.T)
 			},
 			ExtraHeaders: map[string][]string{
 				"X-Clacks-Overhead": {"GNU Terry Pratchett"},
+				"X-Script/function/\t !\"#$%&'()*+,-./;<=>?@[\\]^_`{|}~": {
+					"TEST VALUE 1\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+					"TEST VALUE 2\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+				},
 			},
 		},
 		Text: `石室诗士施氏，嗜狮，誓食十狮。
@@ -6469,6 +6609,10 @@ func TestParseEmailChineseMultipartMixedGbkOverBase64(t *testing.T) {
 			},
 			ExtraHeaders: map[string][]string{
 				"X-Clacks-Overhead": {"GNU Terry Pratchett"},
+				"X-Script/function/\t !\"#$%&'()*+,-./;<=>?@[\\]^_`{|}~": {
+					"TEST VALUE 1\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+					"TEST VALUE 2\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+				},
 			},
 		},
 		Text: `石室诗士施氏，嗜狮，誓食十狮。
@@ -6753,6 +6897,10 @@ func TestParseEmailChineseMultipartMixedGbkOverQuotedprintable(t *testing.T) {
 			},
 			ExtraHeaders: map[string][]string{
 				"X-Clacks-Overhead": {"GNU Terry Pratchett"},
+				"X-Script/function/\t !\"#$%&'()*+,-./;<=>?@[\\]^_`{|}~": {
+					"TEST VALUE 1\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+					"TEST VALUE 2\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+				},
 			},
 		},
 		Text: `石室诗士施氏，嗜狮，誓食十狮。
@@ -7039,6 +7187,10 @@ func TestParseEmailChineseMultipartSignedGb18030OverBase64(t *testing.T) {
 			},
 			ExtraHeaders: map[string][]string{
 				"X-Clacks-Overhead": {"GNU Terry Pratchett"},
+				"X-Script/function/\t !\"#$%&'()*+,-./;<=>?@[\\]^_`{|}~": {
+					"TEST VALUE 1\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+					"TEST VALUE 2\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+				},
 			},
 		},
 		Text: `石室诗士施氏，嗜狮，誓食十狮。
@@ -7195,6 +7347,10 @@ func TestParseEmailChineseMultipartSignedGb18030OverQuotedprintable(t *testing.T
 			},
 			ExtraHeaders: map[string][]string{
 				"X-Clacks-Overhead": {"GNU Terry Pratchett"},
+				"X-Script/function/\t !\"#$%&'()*+,-./;<=>?@[\\]^_`{|}~": {
+					"TEST VALUE 1\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+					"TEST VALUE 2\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+				},
 			},
 		},
 		Text: `石室诗士施氏，嗜狮，誓食十狮。
@@ -7351,6 +7507,10 @@ func TestParseEmailChineseMultipartSignedGbkOverBase64(t *testing.T) {
 			},
 			ExtraHeaders: map[string][]string{
 				"X-Clacks-Overhead": {"GNU Terry Pratchett"},
+				"X-Script/function/\t !\"#$%&'()*+,-./;<=>?@[\\]^_`{|}~": {
+					"TEST VALUE 1\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+					"TEST VALUE 2\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+				},
 			},
 		},
 		Text: `石室诗士施氏，嗜狮，誓食十狮。
@@ -7507,6 +7667,10 @@ func TestParseEmailChineseMultipartSignedGbkOverQuotedprintable(t *testing.T) {
 			},
 			ExtraHeaders: map[string][]string{
 				"X-Clacks-Overhead": {"GNU Terry Pratchett"},
+				"X-Script/function/\t !\"#$%&'()*+,-./;<=>?@[\\]^_`{|}~": {
+					"TEST VALUE 1\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+					"TEST VALUE 2\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+				},
 			},
 		},
 		Text: `石室诗士施氏，嗜狮，誓食十狮。
@@ -7660,6 +7824,10 @@ func TestParseEmailFinnishPlaintextUtf8OverBase64(t *testing.T) {
 			},
 			ExtraHeaders: map[string][]string{
 				"X-Clacks-Overhead": {"GNU Terry Pratchett"},
+				"X-Script/function/\t !\"#$%&'()*+,-./;<=>?@[\\]^_`{|}~": {
+					"TEST VALUE 1\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+					"TEST VALUE 2\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+				},
 			},
 		},
 		Text: `Albert osti fagotin ja töräytti puhkuvan melodian.
@@ -7792,6 +7960,10 @@ func TestParseEmailFinnishPlaintextUtf8OverQuotedprintable(t *testing.T) {
 			},
 			ExtraHeaders: map[string][]string{
 				"X-Clacks-Overhead": {"GNU Terry Pratchett"},
+				"X-Script/function/\t !\"#$%&'()*+,-./;<=>?@[\\]^_`{|}~": {
+					"TEST VALUE 1\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+					"TEST VALUE 2\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+				},
 			},
 		},
 		Text: `Albert osti fagotin ja töräytti puhkuvan melodian.
@@ -7924,6 +8096,10 @@ func TestParseEmailFinnishPlaintextIso885915OverBase64(t *testing.T) {
 			},
 			ExtraHeaders: map[string][]string{
 				"X-Clacks-Overhead": {"GNU Terry Pratchett"},
+				"X-Script/function/\t !\"#$%&'()*+,-./;<=>?@[\\]^_`{|}~": {
+					"TEST VALUE 1\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+					"TEST VALUE 2\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+				},
 			},
 		},
 		Text: `Albert osti fagotin ja töräytti puhkuvan melodian.
@@ -8056,6 +8232,10 @@ func TestParseEmailFinnishPlaintextIso885915OverQuotedprintable(t *testing.T) {
 			},
 			ExtraHeaders: map[string][]string{
 				"X-Clacks-Overhead": {"GNU Terry Pratchett"},
+				"X-Script/function/\t !\"#$%&'()*+,-./;<=>?@[\\]^_`{|}~": {
+					"TEST VALUE 1\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+					"TEST VALUE 2\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+				},
 			},
 		},
 		Text: `Albert osti fagotin ja töräytti puhkuvan melodian.
@@ -8189,6 +8369,10 @@ func TestParseEmailFinnishMultipartRelatedUtf8OverBase64(t *testing.T) {
 			},
 			ExtraHeaders: map[string][]string{
 				"X-Clacks-Overhead": {"GNU Terry Pratchett"},
+				"X-Script/function/\t !\"#$%&'()*+,-./;<=>?@[\\]^_`{|}~": {
+					"TEST VALUE 1\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+					"TEST VALUE 2\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+				},
 			},
 		},
 		Text: `Albert osti fagotin ja töräytti puhkuvan melodian.
@@ -8359,6 +8543,10 @@ func TestParseEmailFinnishMultipartRelatedUtf8OverQuotedprintable(t *testing.T) 
 			},
 			ExtraHeaders: map[string][]string{
 				"X-Clacks-Overhead": {"GNU Terry Pratchett"},
+				"X-Script/function/\t !\"#$%&'()*+,-./;<=>?@[\\]^_`{|}~": {
+					"TEST VALUE 1\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+					"TEST VALUE 2\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+				},
 			},
 		},
 		Text: `Albert osti fagotin ja töräytti puhkuvan melodian.
@@ -8529,6 +8717,10 @@ func TestParseEmailFinnishMultipartRelatedIso885915OverBase64(t *testing.T) {
 			},
 			ExtraHeaders: map[string][]string{
 				"X-Clacks-Overhead": {"GNU Terry Pratchett"},
+				"X-Script/function/\t !\"#$%&'()*+,-./;<=>?@[\\]^_`{|}~": {
+					"TEST VALUE 1\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+					"TEST VALUE 2\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+				},
 			},
 		},
 		Text: `Albert osti fagotin ja töräytti puhkuvan melodian.
@@ -8699,6 +8891,10 @@ func TestParseEmailFinnishMultipartRelatedIso885915OverQuotedprintable(t *testin
 			},
 			ExtraHeaders: map[string][]string{
 				"X-Clacks-Overhead": {"GNU Terry Pratchett"},
+				"X-Script/function/\t !\"#$%&'()*+,-./;<=>?@[\\]^_`{|}~": {
+					"TEST VALUE 1\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+					"TEST VALUE 2\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+				},
 			},
 		},
 		Text: `Albert osti fagotin ja töräytti puhkuvan melodian.
@@ -8869,6 +9065,10 @@ func TestParseEmailFinnishMultipartMixedUtf8OverBase64(t *testing.T) {
 			},
 			ExtraHeaders: map[string][]string{
 				"X-Clacks-Overhead": {"GNU Terry Pratchett"},
+				"X-Script/function/\t !\"#$%&'()*+,-./;<=>?@[\\]^_`{|}~": {
+					"TEST VALUE 1\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+					"TEST VALUE 2\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+				},
 			},
 		},
 		Text: `Albert osti fagotin ja töräytti puhkuvan melodian.
@@ -9141,6 +9341,10 @@ func TestParseEmailFinnishMultipartMixedUtf8OverQuotedprintable(t *testing.T) {
 			},
 			ExtraHeaders: map[string][]string{
 				"X-Clacks-Overhead": {"GNU Terry Pratchett"},
+				"X-Script/function/\t !\"#$%&'()*+,-./;<=>?@[\\]^_`{|}~": {
+					"TEST VALUE 1\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+					"TEST VALUE 2\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+				},
 			},
 		},
 		Text: `Albert osti fagotin ja töräytti puhkuvan melodian.
@@ -9413,6 +9617,10 @@ func TestParseEmailFinnishMultipartMixedIso885915OverBase64(t *testing.T) {
 			},
 			ExtraHeaders: map[string][]string{
 				"X-Clacks-Overhead": {"GNU Terry Pratchett"},
+				"X-Script/function/\t !\"#$%&'()*+,-./;<=>?@[\\]^_`{|}~": {
+					"TEST VALUE 1\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+					"TEST VALUE 2\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+				},
 			},
 		},
 		Text: `Albert osti fagotin ja töräytti puhkuvan melodian.
@@ -9685,6 +9893,10 @@ func TestParseEmailFinnishMultipartMixedIso885915OverQuotedprintable(t *testing.
 			},
 			ExtraHeaders: map[string][]string{
 				"X-Clacks-Overhead": {"GNU Terry Pratchett"},
+				"X-Script/function/\t !\"#$%&'()*+,-./;<=>?@[\\]^_`{|}~": {
+					"TEST VALUE 1\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+					"TEST VALUE 2\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+				},
 			},
 		},
 		Text: `Albert osti fagotin ja töräytti puhkuvan melodian.
@@ -9959,6 +10171,10 @@ func TestParseEmailFinnishMultipartSignedUtf8OverBase64(t *testing.T) {
 			},
 			ExtraHeaders: map[string][]string{
 				"X-Clacks-Overhead": {"GNU Terry Pratchett"},
+				"X-Script/function/\t !\"#$%&'()*+,-./;<=>?@[\\]^_`{|}~": {
+					"TEST VALUE 1\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+					"TEST VALUE 2\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+				},
 			},
 		},
 		Text: `Albert osti fagotin ja töräytti puhkuvan melodian.
@@ -10111,6 +10327,10 @@ func TestParseEmailFinnishMultipartSignedUtf8OverQuotedprintable(t *testing.T) {
 			},
 			ExtraHeaders: map[string][]string{
 				"X-Clacks-Overhead": {"GNU Terry Pratchett"},
+				"X-Script/function/\t !\"#$%&'()*+,-./;<=>?@[\\]^_`{|}~": {
+					"TEST VALUE 1\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+					"TEST VALUE 2\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+				},
 			},
 		},
 		Text: `Albert osti fagotin ja töräytti puhkuvan melodian.
@@ -10263,6 +10483,10 @@ func TestParseEmailFinnishMultipartSignedIso885915OverBase64(t *testing.T) {
 			},
 			ExtraHeaders: map[string][]string{
 				"X-Clacks-Overhead": {"GNU Terry Pratchett"},
+				"X-Script/function/\t !\"#$%&'()*+,-./;<=>?@[\\]^_`{|}~": {
+					"TEST VALUE 1\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+					"TEST VALUE 2\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+				},
 			},
 		},
 		Text: `Albert osti fagotin ja töräytti puhkuvan melodian.
@@ -10415,6 +10639,10 @@ func TestParseEmailFinnishMultipartSignedIso885915OverQuotedprintable(t *testing
 			},
 			ExtraHeaders: map[string][]string{
 				"X-Clacks-Overhead": {"GNU Terry Pratchett"},
+				"X-Script/function/\t !\"#$%&'()*+,-./;<=>?@[\\]^_`{|}~": {
+					"TEST VALUE 1\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+					"TEST VALUE 2\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+				},
 			},
 		},
 		Text: `Albert osti fagotin ja töräytti puhkuvan melodian.
@@ -10564,6 +10792,10 @@ func TestParseEmailIcelandicPlaintextUtf8OverBase64(t *testing.T) {
 			},
 			ExtraHeaders: map[string][]string{
 				"X-Clacks-Overhead": {"GNU Terry Pratchett"},
+				"X-Script/function/\t !\"#$%&'()*+,-./;<=>?@[\\]^_`{|}~": {
+					"TEST VALUE 1\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+					"TEST VALUE 2\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+				},
 			},
 		},
 		Text: `Kæmi ný öxi hér, ykist þjófum nú bæði víl og ádrepa.
@@ -10693,6 +10925,10 @@ func TestParseEmailIcelandicPlaintextUtf8OverQuotedprintable(t *testing.T) {
 			},
 			ExtraHeaders: map[string][]string{
 				"X-Clacks-Overhead": {"GNU Terry Pratchett"},
+				"X-Script/function/\t !\"#$%&'()*+,-./;<=>?@[\\]^_`{|}~": {
+					"TEST VALUE 1\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+					"TEST VALUE 2\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+				},
 			},
 		},
 		Text: `Kæmi ný öxi hér, ykist þjófum nú bæði víl og ádrepa.
@@ -10822,6 +11058,10 @@ func TestParseEmailIcelandicPlaintextIso88591OverBase64(t *testing.T) {
 			},
 			ExtraHeaders: map[string][]string{
 				"X-Clacks-Overhead": {"GNU Terry Pratchett"},
+				"X-Script/function/\t !\"#$%&'()*+,-./;<=>?@[\\]^_`{|}~": {
+					"TEST VALUE 1\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+					"TEST VALUE 2\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+				},
 			},
 		},
 		Text: `Kæmi ný öxi hér, ykist þjófum nú bæði víl og ádrepa.
@@ -10951,6 +11191,10 @@ func TestParseEmailIcelandicPlaintextIso88591OverQuotedprintable(t *testing.T) {
 			},
 			ExtraHeaders: map[string][]string{
 				"X-Clacks-Overhead": {"GNU Terry Pratchett"},
+				"X-Script/function/\t !\"#$%&'()*+,-./;<=>?@[\\]^_`{|}~": {
+					"TEST VALUE 1\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+					"TEST VALUE 2\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+				},
 			},
 		},
 		Text: `Kæmi ný öxi hér, ykist þjófum nú bæði víl og ádrepa.
@@ -11081,6 +11325,10 @@ func TestParseEmailIcelandicMultipartRelatedUtf8OverBase64(t *testing.T) {
 			},
 			ExtraHeaders: map[string][]string{
 				"X-Clacks-Overhead": {"GNU Terry Pratchett"},
+				"X-Script/function/\t !\"#$%&'()*+,-./;<=>?@[\\]^_`{|}~": {
+					"TEST VALUE 1\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+					"TEST VALUE 2\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+				},
 			},
 		},
 		Text: `Kæmi ný öxi hér, ykist þjófum nú bæði víl og ádrepa.
@@ -11242,6 +11490,10 @@ func TestParseEmailIcelandicMultipartRelatedUtf8OverQuotedprintable(t *testing.T
 			},
 			ExtraHeaders: map[string][]string{
 				"X-Clacks-Overhead": {"GNU Terry Pratchett"},
+				"X-Script/function/\t !\"#$%&'()*+,-./;<=>?@[\\]^_`{|}~": {
+					"TEST VALUE 1\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+					"TEST VALUE 2\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+				},
 			},
 		},
 		Text: `Kæmi ný öxi hér, ykist þjófum nú bæði víl og ádrepa.
@@ -11403,6 +11655,10 @@ func TestParseEmailIcelandicMultipartRelatedIso88591OverBase64(t *testing.T) {
 			},
 			ExtraHeaders: map[string][]string{
 				"X-Clacks-Overhead": {"GNU Terry Pratchett"},
+				"X-Script/function/\t !\"#$%&'()*+,-./;<=>?@[\\]^_`{|}~": {
+					"TEST VALUE 1\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+					"TEST VALUE 2\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+				},
 			},
 		},
 		Text: `Kæmi ný öxi hér, ykist þjófum nú bæði víl og ádrepa.
@@ -11564,6 +11820,10 @@ func TestParseEmailIcelandicMultipartRelatedIso88591OverQuotedprintable(t *testi
 			},
 			ExtraHeaders: map[string][]string{
 				"X-Clacks-Overhead": {"GNU Terry Pratchett"},
+				"X-Script/function/\t !\"#$%&'()*+,-./;<=>?@[\\]^_`{|}~": {
+					"TEST VALUE 1\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+					"TEST VALUE 2\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+				},
 			},
 		},
 		Text: `Kæmi ný öxi hér, ykist þjófum nú bæði víl og ádrepa.
@@ -11725,6 +11985,10 @@ func TestParseEmailIcelandicMultipartMixedUtf8OverBase64(t *testing.T) {
 			},
 			ExtraHeaders: map[string][]string{
 				"X-Clacks-Overhead": {"GNU Terry Pratchett"},
+				"X-Script/function/\t !\"#$%&'()*+,-./;<=>?@[\\]^_`{|}~": {
+					"TEST VALUE 1\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+					"TEST VALUE 2\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+				},
 			},
 		},
 		Text: `Kæmi ný öxi hér, ykist þjófum nú bæði víl og ádrepa.
@@ -11988,6 +12252,10 @@ func TestParseEmailIcelandicMultipartMixedUtf8OverQuotedprintable(t *testing.T) 
 			},
 			ExtraHeaders: map[string][]string{
 				"X-Clacks-Overhead": {"GNU Terry Pratchett"},
+				"X-Script/function/\t !\"#$%&'()*+,-./;<=>?@[\\]^_`{|}~": {
+					"TEST VALUE 1\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+					"TEST VALUE 2\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+				},
 			},
 		},
 		Text: `Kæmi ný öxi hér, ykist þjófum nú bæði víl og ádrepa.
@@ -12251,6 +12519,10 @@ func TestParseEmailIcelandicMultipartMixedIso88591OverBase64(t *testing.T) {
 			},
 			ExtraHeaders: map[string][]string{
 				"X-Clacks-Overhead": {"GNU Terry Pratchett"},
+				"X-Script/function/\t !\"#$%&'()*+,-./;<=>?@[\\]^_`{|}~": {
+					"TEST VALUE 1\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+					"TEST VALUE 2\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+				},
 			},
 		},
 		Text: `Kæmi ný öxi hér, ykist þjófum nú bæði víl og ádrepa.
@@ -12514,6 +12786,10 @@ func TestParseEmailIcelandicMultipartMixedIso88591OverQuotedprintable(t *testing
 			},
 			ExtraHeaders: map[string][]string{
 				"X-Clacks-Overhead": {"GNU Terry Pratchett"},
+				"X-Script/function/\t !\"#$%&'()*+,-./;<=>?@[\\]^_`{|}~": {
+					"TEST VALUE 1\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+					"TEST VALUE 2\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+				},
 			},
 		},
 		Text: `Kæmi ný öxi hér, ykist þjófum nú bæði víl og ádrepa.
@@ -12779,6 +13055,10 @@ func TestParseEmailIcelandicMultipartSignedUtf8OverBase64(t *testing.T) {
 			},
 			ExtraHeaders: map[string][]string{
 				"X-Clacks-Overhead": {"GNU Terry Pratchett"},
+				"X-Script/function/\t !\"#$%&'()*+,-./;<=>?@[\\]^_`{|}~": {
+					"TEST VALUE 1\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+					"TEST VALUE 2\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+				},
 			},
 		},
 		Text: `Kæmi ný öxi hér, ykist þjófum nú bæði víl og ádrepa.
@@ -12928,6 +13208,10 @@ func TestParseEmailIcelandicMultipartSignedUtf8OverQuotedprintable(t *testing.T)
 			},
 			ExtraHeaders: map[string][]string{
 				"X-Clacks-Overhead": {"GNU Terry Pratchett"},
+				"X-Script/function/\t !\"#$%&'()*+,-./;<=>?@[\\]^_`{|}~": {
+					"TEST VALUE 1\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+					"TEST VALUE 2\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+				},
 			},
 		},
 		Text: `Kæmi ný öxi hér, ykist þjófum nú bæði víl og ádrepa.
@@ -13077,6 +13361,10 @@ func TestParseEmailIcelandicMultipartSignedIso88591OverBase64(t *testing.T) {
 			},
 			ExtraHeaders: map[string][]string{
 				"X-Clacks-Overhead": {"GNU Terry Pratchett"},
+				"X-Script/function/\t !\"#$%&'()*+,-./;<=>?@[\\]^_`{|}~": {
+					"TEST VALUE 1\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+					"TEST VALUE 2\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+				},
 			},
 		},
 		Text: `Kæmi ný öxi hér, ykist þjófum nú bæði víl og ádrepa.
@@ -13226,6 +13514,10 @@ func TestParseEmailIcelandicMultipartSignedIso88591OverQuotedprintable(t *testin
 			},
 			ExtraHeaders: map[string][]string{
 				"X-Clacks-Overhead": {"GNU Terry Pratchett"},
+				"X-Script/function/\t !\"#$%&'()*+,-./;<=>?@[\\]^_`{|}~": {
+					"TEST VALUE 1\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+					"TEST VALUE 2\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+				},
 			},
 		},
 		Text: `Kæmi ný öxi hér, ykist þjófum nú bæði víl og ádrepa.
@@ -13372,6 +13664,10 @@ func TestParseEmailJapanesePlaintextUtf8Over7bit(t *testing.T) {
 			},
 			ExtraHeaders: map[string][]string{
 				"X-Clacks-Overhead": {"GNU Terry Pratchett"},
+				"X-Script/function/\t !\"#$%&'()*+,-./;<=>?@[\\]^_`{|}~": {
+					"TEST VALUE 1\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+					"TEST VALUE 2\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+				},
 			},
 		},
 		Text: `色は匂えど
@@ -13519,6 +13815,10 @@ func TestParseEmailJapanesePlaintextUtf8OverBase64(t *testing.T) {
 			},
 			ExtraHeaders: map[string][]string{
 				"X-Clacks-Overhead": {"GNU Terry Pratchett"},
+				"X-Script/function/\t !\"#$%&'()*+,-./;<=>?@[\\]^_`{|}~": {
+					"TEST VALUE 1\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+					"TEST VALUE 2\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+				},
 			},
 		},
 		Text: `色は匂えど
@@ -13666,6 +13966,10 @@ func TestParseEmailJapanesePlaintextUtf8OverQuotedprintable(t *testing.T) {
 			},
 			ExtraHeaders: map[string][]string{
 				"X-Clacks-Overhead": {"GNU Terry Pratchett"},
+				"X-Script/function/\t !\"#$%&'()*+,-./;<=>?@[\\]^_`{|}~": {
+					"TEST VALUE 1\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+					"TEST VALUE 2\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+				},
 			},
 		},
 		Text: `色は匂えど
@@ -13813,6 +14117,10 @@ func TestParseEmailJapanesePlaintextIso2022jpOver7bit(t *testing.T) {
 			},
 			ExtraHeaders: map[string][]string{
 				"X-Clacks-Overhead": {"GNU Terry Pratchett"},
+				"X-Script/function/\t !\"#$%&'()*+,-./;<=>?@[\\]^_`{|}~": {
+					"TEST VALUE 1\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+					"TEST VALUE 2\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+				},
 			},
 		},
 		Text: `色は匂えど
@@ -13960,6 +14268,10 @@ func TestParseEmailJapanesePlaintextIso2022jpOverBase64(t *testing.T) {
 			},
 			ExtraHeaders: map[string][]string{
 				"X-Clacks-Overhead": {"GNU Terry Pratchett"},
+				"X-Script/function/\t !\"#$%&'()*+,-./;<=>?@[\\]^_`{|}~": {
+					"TEST VALUE 1\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+					"TEST VALUE 2\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+				},
 			},
 		},
 		Text: `色は匂えど
@@ -14107,6 +14419,10 @@ func TestParseEmailJapanesePlaintextIso2022jpOverQuotedprintable(t *testing.T) {
 			},
 			ExtraHeaders: map[string][]string{
 				"X-Clacks-Overhead": {"GNU Terry Pratchett"},
+				"X-Script/function/\t !\"#$%&'()*+,-./;<=>?@[\\]^_`{|}~": {
+					"TEST VALUE 1\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+					"TEST VALUE 2\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+				},
 			},
 		},
 		Text: `色は匂えど
@@ -14254,6 +14570,10 @@ func TestParseEmailJapanesePlaintextEucjpOverBase64(t *testing.T) {
 			},
 			ExtraHeaders: map[string][]string{
 				"X-Clacks-Overhead": {"GNU Terry Pratchett"},
+				"X-Script/function/\t !\"#$%&'()*+,-./;<=>?@[\\]^_`{|}~": {
+					"TEST VALUE 1\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+					"TEST VALUE 2\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+				},
 			},
 		},
 		Text: `色は匂えど
@@ -14401,6 +14721,10 @@ func TestParseEmailJapanesePlaintextEucjpOverQuotedprintable(t *testing.T) {
 			},
 			ExtraHeaders: map[string][]string{
 				"X-Clacks-Overhead": {"GNU Terry Pratchett"},
+				"X-Script/function/\t !\"#$%&'()*+,-./;<=>?@[\\]^_`{|}~": {
+					"TEST VALUE 1\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+					"TEST VALUE 2\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+				},
 			},
 		},
 		Text: `色は匂えど
@@ -14549,6 +14873,10 @@ func TestParseEmailJapaneseMultipartRelatedUtf8Over7bit(t *testing.T) {
 			},
 			ExtraHeaders: map[string][]string{
 				"X-Clacks-Overhead": {"GNU Terry Pratchett"},
+				"X-Script/function/\t !\"#$%&'()*+,-./;<=>?@[\\]^_`{|}~": {
+					"TEST VALUE 1\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+					"TEST VALUE 2\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+				},
 			},
 		},
 		Text: `色は匂えど
@@ -14764,6 +15092,10 @@ func TestParseEmailJapaneseMultipartRelatedUtf8OverBase64(t *testing.T) {
 			},
 			ExtraHeaders: map[string][]string{
 				"X-Clacks-Overhead": {"GNU Terry Pratchett"},
+				"X-Script/function/\t !\"#$%&'()*+,-./;<=>?@[\\]^_`{|}~": {
+					"TEST VALUE 1\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+					"TEST VALUE 2\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+				},
 			},
 		},
 		Text: `色は匂えど
@@ -14979,6 +15311,10 @@ func TestParseEmailJapaneseMultipartRelatedUtf8OverQuotedprintable(t *testing.T)
 			},
 			ExtraHeaders: map[string][]string{
 				"X-Clacks-Overhead": {"GNU Terry Pratchett"},
+				"X-Script/function/\t !\"#$%&'()*+,-./;<=>?@[\\]^_`{|}~": {
+					"TEST VALUE 1\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+					"TEST VALUE 2\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+				},
 			},
 		},
 		Text: `色は匂えど
@@ -15194,6 +15530,10 @@ func TestParseEmailJapaneseMultipartRelatedIso2022jpOver7bit(t *testing.T) {
 			},
 			ExtraHeaders: map[string][]string{
 				"X-Clacks-Overhead": {"GNU Terry Pratchett"},
+				"X-Script/function/\t !\"#$%&'()*+,-./;<=>?@[\\]^_`{|}~": {
+					"TEST VALUE 1\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+					"TEST VALUE 2\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+				},
 			},
 		},
 		Text: `色は匂えど
@@ -15409,6 +15749,10 @@ func TestParseEmailJapaneseMultipartRelatedIso2022jpOverBase64(t *testing.T) {
 			},
 			ExtraHeaders: map[string][]string{
 				"X-Clacks-Overhead": {"GNU Terry Pratchett"},
+				"X-Script/function/\t !\"#$%&'()*+,-./;<=>?@[\\]^_`{|}~": {
+					"TEST VALUE 1\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+					"TEST VALUE 2\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+				},
 			},
 		},
 		Text: `色は匂えど
@@ -15624,6 +15968,10 @@ func TestParseEmailJapaneseMultipartRelatedIso2022jpOverQuotedprintable(t *testi
 			},
 			ExtraHeaders: map[string][]string{
 				"X-Clacks-Overhead": {"GNU Terry Pratchett"},
+				"X-Script/function/\t !\"#$%&'()*+,-./;<=>?@[\\]^_`{|}~": {
+					"TEST VALUE 1\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+					"TEST VALUE 2\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+				},
 			},
 		},
 		Text: `色は匂えど
@@ -15839,6 +16187,10 @@ func TestParseEmailJapaneseMultipartRelatedEucjpOverBase64(t *testing.T) {
 			},
 			ExtraHeaders: map[string][]string{
 				"X-Clacks-Overhead": {"GNU Terry Pratchett"},
+				"X-Script/function/\t !\"#$%&'()*+,-./;<=>?@[\\]^_`{|}~": {
+					"TEST VALUE 1\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+					"TEST VALUE 2\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+				},
 			},
 		},
 		Text: `色は匂えど
@@ -16054,6 +16406,10 @@ func TestParseEmailJapaneseMultipartRelatedEucjpOverQuotedprintable(t *testing.T
 			},
 			ExtraHeaders: map[string][]string{
 				"X-Clacks-Overhead": {"GNU Terry Pratchett"},
+				"X-Script/function/\t !\"#$%&'()*+,-./;<=>?@[\\]^_`{|}~": {
+					"TEST VALUE 1\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+					"TEST VALUE 2\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+				},
 			},
 		},
 		Text: `色は匂えど
@@ -16269,6 +16625,10 @@ func TestParseEmailJapaneseMultipartMixedUtf8Over7bit(t *testing.T) {
 			},
 			ExtraHeaders: map[string][]string{
 				"X-Clacks-Overhead": {"GNU Terry Pratchett"},
+				"X-Script/function/\t !\"#$%&'()*+,-./;<=>?@[\\]^_`{|}~": {
+					"TEST VALUE 1\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+					"TEST VALUE 2\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+				},
 			},
 		},
 		Text: `色は匂えど
@@ -16586,6 +16946,10 @@ func TestParseEmailJapaneseMultipartMixedUtf8OverBase64(t *testing.T) {
 			},
 			ExtraHeaders: map[string][]string{
 				"X-Clacks-Overhead": {"GNU Terry Pratchett"},
+				"X-Script/function/\t !\"#$%&'()*+,-./;<=>?@[\\]^_`{|}~": {
+					"TEST VALUE 1\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+					"TEST VALUE 2\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+				},
 			},
 		},
 		Text: `色は匂えど
@@ -16903,6 +17267,10 @@ func TestParseEmailJapaneseMultipartMixedUtf8OverQuotedprintable(t *testing.T) {
 			},
 			ExtraHeaders: map[string][]string{
 				"X-Clacks-Overhead": {"GNU Terry Pratchett"},
+				"X-Script/function/\t !\"#$%&'()*+,-./;<=>?@[\\]^_`{|}~": {
+					"TEST VALUE 1\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+					"TEST VALUE 2\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+				},
 			},
 		},
 		Text: `色は匂えど
@@ -17220,6 +17588,10 @@ func TestParseEmailJapaneseMultipartMixedIso2022jpOver7bit(t *testing.T) {
 			},
 			ExtraHeaders: map[string][]string{
 				"X-Clacks-Overhead": {"GNU Terry Pratchett"},
+				"X-Script/function/\t !\"#$%&'()*+,-./;<=>?@[\\]^_`{|}~": {
+					"TEST VALUE 1\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+					"TEST VALUE 2\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+				},
 			},
 		},
 		Text: `色は匂えど
@@ -17537,6 +17909,10 @@ func TestParseEmailJapaneseMultipartMixedIso2022jpOverBase64(t *testing.T) {
 			},
 			ExtraHeaders: map[string][]string{
 				"X-Clacks-Overhead": {"GNU Terry Pratchett"},
+				"X-Script/function/\t !\"#$%&'()*+,-./;<=>?@[\\]^_`{|}~": {
+					"TEST VALUE 1\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+					"TEST VALUE 2\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+				},
 			},
 		},
 		Text: `色は匂えど
@@ -17854,6 +18230,10 @@ func TestParseEmailJapaneseMultipartMixedIso2022jpOverQuotedprintable(t *testing
 			},
 			ExtraHeaders: map[string][]string{
 				"X-Clacks-Overhead": {"GNU Terry Pratchett"},
+				"X-Script/function/\t !\"#$%&'()*+,-./;<=>?@[\\]^_`{|}~": {
+					"TEST VALUE 1\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+					"TEST VALUE 2\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+				},
 			},
 		},
 		Text: `色は匂えど
@@ -18171,6 +18551,10 @@ func TestParseEmailJapaneseMultipartMixedEucjpOverBase64(t *testing.T) {
 			},
 			ExtraHeaders: map[string][]string{
 				"X-Clacks-Overhead": {"GNU Terry Pratchett"},
+				"X-Script/function/\t !\"#$%&'()*+,-./;<=>?@[\\]^_`{|}~": {
+					"TEST VALUE 1\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+					"TEST VALUE 2\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+				},
 			},
 		},
 		Text: `色は匂えど
@@ -18488,6 +18872,10 @@ func TestParseEmailJapaneseMultipartMixedEucjpOverQuotedprintable(t *testing.T) 
 			},
 			ExtraHeaders: map[string][]string{
 				"X-Clacks-Overhead": {"GNU Terry Pratchett"},
+				"X-Script/function/\t !\"#$%&'()*+,-./;<=>?@[\\]^_`{|}~": {
+					"TEST VALUE 1\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+					"TEST VALUE 2\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+				},
 			},
 		},
 		Text: `色は匂えど
@@ -18807,6 +19195,10 @@ func TestParseEmailJapaneseMultipartSignedUtf8Over7bit(t *testing.T) {
 			},
 			ExtraHeaders: map[string][]string{
 				"X-Clacks-Overhead": {"GNU Terry Pratchett"},
+				"X-Script/function/\t !\"#$%&'()*+,-./;<=>?@[\\]^_`{|}~": {
+					"TEST VALUE 1\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+					"TEST VALUE 2\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+				},
 			},
 		},
 		Text: `色は匂えど
@@ -18974,6 +19366,10 @@ func TestParseEmailJapaneseMultipartSignedUtf8OverBase64(t *testing.T) {
 			},
 			ExtraHeaders: map[string][]string{
 				"X-Clacks-Overhead": {"GNU Terry Pratchett"},
+				"X-Script/function/\t !\"#$%&'()*+,-./;<=>?@[\\]^_`{|}~": {
+					"TEST VALUE 1\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+					"TEST VALUE 2\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+				},
 			},
 		},
 		Text: `色は匂えど
@@ -19141,6 +19537,10 @@ func TestParseEmailJapaneseMultipartSignedUtf8OverQuotedprintable(t *testing.T) 
 			},
 			ExtraHeaders: map[string][]string{
 				"X-Clacks-Overhead": {"GNU Terry Pratchett"},
+				"X-Script/function/\t !\"#$%&'()*+,-./;<=>?@[\\]^_`{|}~": {
+					"TEST VALUE 1\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+					"TEST VALUE 2\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+				},
 			},
 		},
 		Text: `色は匂えど
@@ -19308,6 +19708,10 @@ func TestParseEmailJapaneseMultipartSignedIso2022jpOver7bit(t *testing.T) {
 			},
 			ExtraHeaders: map[string][]string{
 				"X-Clacks-Overhead": {"GNU Terry Pratchett"},
+				"X-Script/function/\t !\"#$%&'()*+,-./;<=>?@[\\]^_`{|}~": {
+					"TEST VALUE 1\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+					"TEST VALUE 2\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+				},
 			},
 		},
 		Text: `色は匂えど
@@ -19475,6 +19879,10 @@ func TestParseEmailJapaneseMultipartSignedIso2022jpOverBase64(t *testing.T) {
 			},
 			ExtraHeaders: map[string][]string{
 				"X-Clacks-Overhead": {"GNU Terry Pratchett"},
+				"X-Script/function/\t !\"#$%&'()*+,-./;<=>?@[\\]^_`{|}~": {
+					"TEST VALUE 1\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+					"TEST VALUE 2\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+				},
 			},
 		},
 		Text: `色は匂えど
@@ -19642,6 +20050,10 @@ func TestParseEmailJapaneseMultipartSignedIso2022jpOverQuotedprintable(t *testin
 			},
 			ExtraHeaders: map[string][]string{
 				"X-Clacks-Overhead": {"GNU Terry Pratchett"},
+				"X-Script/function/\t !\"#$%&'()*+,-./;<=>?@[\\]^_`{|}~": {
+					"TEST VALUE 1\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+					"TEST VALUE 2\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+				},
 			},
 		},
 		Text: `色は匂えど
@@ -19809,6 +20221,10 @@ func TestParseEmailJapaneseMultipartSignedEucjpOverBase64(t *testing.T) {
 			},
 			ExtraHeaders: map[string][]string{
 				"X-Clacks-Overhead": {"GNU Terry Pratchett"},
+				"X-Script/function/\t !\"#$%&'()*+,-./;<=>?@[\\]^_`{|}~": {
+					"TEST VALUE 1\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+					"TEST VALUE 2\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+				},
 			},
 		},
 		Text: `色は匂えど
@@ -19976,6 +20392,10 @@ func TestParseEmailJapaneseMultipartSignedEucjpOverQuotedprintable(t *testing.T)
 			},
 			ExtraHeaders: map[string][]string{
 				"X-Clacks-Overhead": {"GNU Terry Pratchett"},
+				"X-Script/function/\t !\"#$%&'()*+,-./;<=>?@[\\]^_`{|}~": {
+					"TEST VALUE 1\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+					"TEST VALUE 2\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+				},
 			},
 		},
 		Text: `色は匂えど
@@ -20140,6 +20560,10 @@ func TestParseEmailKoreanPlaintextUtf8OverBase64(t *testing.T) {
 			},
 			ExtraHeaders: map[string][]string{
 				"X-Clacks-Overhead": {"GNU Terry Pratchett"},
+				"X-Script/function/\t !\"#$%&'()*+,-./;<=>?@[\\]^_`{|}~": {
+					"TEST VALUE 1\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+					"TEST VALUE 2\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+				},
 			},
 		},
 		Text: `키스의 고유조건은 입술끼리 만나야 하고 특별한 기술은 필요치 않다.`,
@@ -20267,6 +20691,10 @@ func TestParseEmailKoreanPlaintextUtf8OverQuotedprintable(t *testing.T) {
 			},
 			ExtraHeaders: map[string][]string{
 				"X-Clacks-Overhead": {"GNU Terry Pratchett"},
+				"X-Script/function/\t !\"#$%&'()*+,-./;<=>?@[\\]^_`{|}~": {
+					"TEST VALUE 1\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+					"TEST VALUE 2\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+				},
 			},
 		},
 		Text: `키스의 고유조건은 입술끼리 만나야 하고 특별한 기술은 필요치 않다.`,
@@ -20394,6 +20822,10 @@ func TestParseEmailKoreanPlaintextEuckrOverBase64(t *testing.T) {
 			},
 			ExtraHeaders: map[string][]string{
 				"X-Clacks-Overhead": {"GNU Terry Pratchett"},
+				"X-Script/function/\t !\"#$%&'()*+,-./;<=>?@[\\]^_`{|}~": {
+					"TEST VALUE 1\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+					"TEST VALUE 2\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+				},
 			},
 		},
 		Text: `키스의 고유조건은 입술끼리 만나야 하고 특별한 기술은 필요치 않다.`,
@@ -20521,6 +20953,10 @@ func TestParseEmailKoreanPlaintextEuckrOverQuotedprintable(t *testing.T) {
 			},
 			ExtraHeaders: map[string][]string{
 				"X-Clacks-Overhead": {"GNU Terry Pratchett"},
+				"X-Script/function/\t !\"#$%&'()*+,-./;<=>?@[\\]^_`{|}~": {
+					"TEST VALUE 1\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+					"TEST VALUE 2\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+				},
 			},
 		},
 		Text: `키스의 고유조건은 입술끼리 만나야 하고 특별한 기술은 필요치 않다.`,
@@ -20649,6 +21085,10 @@ func TestParseEmailKoreanMultipartRelatedUtf8OverBase64(t *testing.T) {
 			},
 			ExtraHeaders: map[string][]string{
 				"X-Clacks-Overhead": {"GNU Terry Pratchett"},
+				"X-Script/function/\t !\"#$%&'()*+,-./;<=>?@[\\]^_`{|}~": {
+					"TEST VALUE 1\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+					"TEST VALUE 2\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+				},
 			},
 		},
 		Text:         `키스의 고유조건은 입술끼리 만나야 하고 특별한 기술은 필요치 않다.`,
@@ -20804,6 +21244,10 @@ func TestParseEmailKoreanMultipartRelatedUtf8OverQuotedprintable(t *testing.T) {
 			},
 			ExtraHeaders: map[string][]string{
 				"X-Clacks-Overhead": {"GNU Terry Pratchett"},
+				"X-Script/function/\t !\"#$%&'()*+,-./;<=>?@[\\]^_`{|}~": {
+					"TEST VALUE 1\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+					"TEST VALUE 2\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+				},
 			},
 		},
 		Text:         `키스의 고유조건은 입술끼리 만나야 하고 특별한 기술은 필요치 않다.`,
@@ -20959,6 +21403,10 @@ func TestParseEmailKoreanMultipartRelatedEuckrOverBase64(t *testing.T) {
 			},
 			ExtraHeaders: map[string][]string{
 				"X-Clacks-Overhead": {"GNU Terry Pratchett"},
+				"X-Script/function/\t !\"#$%&'()*+,-./;<=>?@[\\]^_`{|}~": {
+					"TEST VALUE 1\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+					"TEST VALUE 2\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+				},
 			},
 		},
 		Text:         `키스의 고유조건은 입술끼리 만나야 하고 특별한 기술은 필요치 않다.`,
@@ -21114,6 +21562,10 @@ func TestParseEmailKoreanMultipartRelatedEuckrOverQuotedprintable(t *testing.T) 
 			},
 			ExtraHeaders: map[string][]string{
 				"X-Clacks-Overhead": {"GNU Terry Pratchett"},
+				"X-Script/function/\t !\"#$%&'()*+,-./;<=>?@[\\]^_`{|}~": {
+					"TEST VALUE 1\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+					"TEST VALUE 2\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+				},
 			},
 		},
 		Text:         `키스의 고유조건은 입술끼리 만나야 하고 특별한 기술은 필요치 않다.`,
@@ -21269,6 +21721,10 @@ func TestParseEmailKoreanMultipartMixedUtf8OverBase64(t *testing.T) {
 			},
 			ExtraHeaders: map[string][]string{
 				"X-Clacks-Overhead": {"GNU Terry Pratchett"},
+				"X-Script/function/\t !\"#$%&'()*+,-./;<=>?@[\\]^_`{|}~": {
+					"TEST VALUE 1\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+					"TEST VALUE 2\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+				},
 			},
 		},
 		Text:         `키스의 고유조건은 입술끼리 만나야 하고 특별한 기술은 필요치 않다.`,
@@ -21526,6 +21982,10 @@ func TestParseEmailKoreanMultipartMixedUtf8OverQuotedprintable(t *testing.T) {
 			},
 			ExtraHeaders: map[string][]string{
 				"X-Clacks-Overhead": {"GNU Terry Pratchett"},
+				"X-Script/function/\t !\"#$%&'()*+,-./;<=>?@[\\]^_`{|}~": {
+					"TEST VALUE 1\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+					"TEST VALUE 2\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+				},
 			},
 		},
 		Text:         `키스의 고유조건은 입술끼리 만나야 하고 특별한 기술은 필요치 않다.`,
@@ -21783,6 +22243,10 @@ func TestParseEmailKoreanMultipartMixedEuckrOverBase64(t *testing.T) {
 			},
 			ExtraHeaders: map[string][]string{
 				"X-Clacks-Overhead": {"GNU Terry Pratchett"},
+				"X-Script/function/\t !\"#$%&'()*+,-./;<=>?@[\\]^_`{|}~": {
+					"TEST VALUE 1\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+					"TEST VALUE 2\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+				},
 			},
 		},
 		Text:         `키스의 고유조건은 입술끼리 만나야 하고 특별한 기술은 필요치 않다.`,
@@ -22040,6 +22504,10 @@ func TestParseEmailKoreanMultipartMixedEuckrOverQuotedprintable(t *testing.T) {
 			},
 			ExtraHeaders: map[string][]string{
 				"X-Clacks-Overhead": {"GNU Terry Pratchett"},
+				"X-Script/function/\t !\"#$%&'()*+,-./;<=>?@[\\]^_`{|}~": {
+					"TEST VALUE 1\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+					"TEST VALUE 2\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+				},
 			},
 		},
 		Text:         `키스의 고유조건은 입술끼리 만나야 하고 특별한 기술은 필요치 않다.`,
@@ -22299,6 +22767,10 @@ func TestParseEmailKoreanMultipartSignedUtf8OverBase64(t *testing.T) {
 			},
 			ExtraHeaders: map[string][]string{
 				"X-Clacks-Overhead": {"GNU Terry Pratchett"},
+				"X-Script/function/\t !\"#$%&'()*+,-./;<=>?@[\\]^_`{|}~": {
+					"TEST VALUE 1\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+					"TEST VALUE 2\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+				},
 			},
 		},
 		Text: `키스의 고유조건은 입술끼리 만나야 하고 특별한 기술은 필요치 않다.`,
@@ -22446,6 +22918,10 @@ func TestParseEmailKoreanMultipartSignedUtf8OverQuotedprintable(t *testing.T) {
 			},
 			ExtraHeaders: map[string][]string{
 				"X-Clacks-Overhead": {"GNU Terry Pratchett"},
+				"X-Script/function/\t !\"#$%&'()*+,-./;<=>?@[\\]^_`{|}~": {
+					"TEST VALUE 1\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+					"TEST VALUE 2\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+				},
 			},
 		},
 		Text: `키스의 고유조건은 입술끼리 만나야 하고 특별한 기술은 필요치 않다.`,
@@ -22593,6 +23069,10 @@ func TestParseEmailKoreanMultipartSignedEuckrOverBase64(t *testing.T) {
 			},
 			ExtraHeaders: map[string][]string{
 				"X-Clacks-Overhead": {"GNU Terry Pratchett"},
+				"X-Script/function/\t !\"#$%&'()*+,-./;<=>?@[\\]^_`{|}~": {
+					"TEST VALUE 1\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+					"TEST VALUE 2\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+				},
 			},
 		},
 		Text: `키스의 고유조건은 입술끼리 만나야 하고 특별한 기술은 필요치 않다.`,
@@ -22740,6 +23220,10 @@ func TestParseEmailKoreanMultipartSignedEuckrOverQuotedprintable(t *testing.T) {
 			},
 			ExtraHeaders: map[string][]string{
 				"X-Clacks-Overhead": {"GNU Terry Pratchett"},
+				"X-Script/function/\t !\"#$%&'()*+,-./;<=>?@[\\]^_`{|}~": {
+					"TEST VALUE 1\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+					"TEST VALUE 2\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+				},
 			},
 		},
 		Text: `키스의 고유조건은 입술끼리 만나야 하고 특별한 기술은 필요치 않다.`,
@@ -22884,6 +23368,10 @@ func TestParseEmailPolishPlaintextUtf8OverBase64(t *testing.T) {
 			},
 			ExtraHeaders: map[string][]string{
 				"X-Clacks-Overhead": {"GNU Terry Pratchett"},
+				"X-Script/function/\t !\"#$%&'()*+,-./;<=>?@[\\]^_`{|}~": {
+					"TEST VALUE 1\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+					"TEST VALUE 2\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+				},
 			},
 		},
 		Text: `Jeżu klątw, spłódź Finom część gry hańb!
@@ -23018,6 +23506,10 @@ func TestParseEmailPolishPlaintextUtf8OverQuotedprintable(t *testing.T) {
 			},
 			ExtraHeaders: map[string][]string{
 				"X-Clacks-Overhead": {"GNU Terry Pratchett"},
+				"X-Script/function/\t !\"#$%&'()*+,-./;<=>?@[\\]^_`{|}~": {
+					"TEST VALUE 1\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+					"TEST VALUE 2\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+				},
 			},
 		},
 		Text: `Jeżu klątw, spłódź Finom część gry hańb!
@@ -23152,6 +23644,10 @@ func TestParseEmailPolishPlaintextIso88592OverBase64(t *testing.T) {
 			},
 			ExtraHeaders: map[string][]string{
 				"X-Clacks-Overhead": {"GNU Terry Pratchett"},
+				"X-Script/function/\t !\"#$%&'()*+,-./;<=>?@[\\]^_`{|}~": {
+					"TEST VALUE 1\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+					"TEST VALUE 2\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+				},
 			},
 		},
 		Text: `Jeżu klątw, spłódź Finom część gry hańb!
@@ -23286,6 +23782,10 @@ func TestParseEmailPolishPlaintextIso88592OverQuotedprintable(t *testing.T) {
 			},
 			ExtraHeaders: map[string][]string{
 				"X-Clacks-Overhead": {"GNU Terry Pratchett"},
+				"X-Script/function/\t !\"#$%&'()*+,-./;<=>?@[\\]^_`{|}~": {
+					"TEST VALUE 1\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+					"TEST VALUE 2\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+				},
 			},
 		},
 		Text: `Jeżu klątw, spłódź Finom część gry hańb!
@@ -23421,6 +23921,10 @@ func TestParseEmailPolishMultipartRelatedUtf8OverBase64(t *testing.T) {
 			},
 			ExtraHeaders: map[string][]string{
 				"X-Clacks-Overhead": {"GNU Terry Pratchett"},
+				"X-Script/function/\t !\"#$%&'()*+,-./;<=>?@[\\]^_`{|}~": {
+					"TEST VALUE 1\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+					"TEST VALUE 2\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+				},
 			},
 		},
 		Text: `Jeżu klątw, spłódź Finom część gry hańb!
@@ -23597,6 +24101,10 @@ func TestParseEmailPolishMultipartRelatedUtf8OverQuotedprintable(t *testing.T) {
 			},
 			ExtraHeaders: map[string][]string{
 				"X-Clacks-Overhead": {"GNU Terry Pratchett"},
+				"X-Script/function/\t !\"#$%&'()*+,-./;<=>?@[\\]^_`{|}~": {
+					"TEST VALUE 1\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+					"TEST VALUE 2\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+				},
 			},
 		},
 		Text: `Jeżu klątw, spłódź Finom część gry hańb!
@@ -23773,6 +24281,10 @@ func TestParseEmailPolishMultipartRelatedIso88592OverBase64(t *testing.T) {
 			},
 			ExtraHeaders: map[string][]string{
 				"X-Clacks-Overhead": {"GNU Terry Pratchett"},
+				"X-Script/function/\t !\"#$%&'()*+,-./;<=>?@[\\]^_`{|}~": {
+					"TEST VALUE 1\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+					"TEST VALUE 2\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+				},
 			},
 		},
 		Text: `Jeżu klątw, spłódź Finom część gry hańb!
@@ -23949,6 +24461,10 @@ func TestParseEmailPolishMultipartRelatedIso88592OverQuotedprintable(t *testing.
 			},
 			ExtraHeaders: map[string][]string{
 				"X-Clacks-Overhead": {"GNU Terry Pratchett"},
+				"X-Script/function/\t !\"#$%&'()*+,-./;<=>?@[\\]^_`{|}~": {
+					"TEST VALUE 1\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+					"TEST VALUE 2\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+				},
 			},
 		},
 		Text: `Jeżu klątw, spłódź Finom część gry hańb!
@@ -24125,6 +24641,10 @@ func TestParseEmailPolishMultipartMixedUtf8OverBase64(t *testing.T) {
 			},
 			ExtraHeaders: map[string][]string{
 				"X-Clacks-Overhead": {"GNU Terry Pratchett"},
+				"X-Script/function/\t !\"#$%&'()*+,-./;<=>?@[\\]^_`{|}~": {
+					"TEST VALUE 1\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+					"TEST VALUE 2\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+				},
 			},
 		},
 		Text: `Jeżu klątw, spłódź Finom część gry hańb!
@@ -24403,6 +24923,10 @@ func TestParseEmailPolishMultipartMixedUtf8OverQuotedprintable(t *testing.T) {
 			},
 			ExtraHeaders: map[string][]string{
 				"X-Clacks-Overhead": {"GNU Terry Pratchett"},
+				"X-Script/function/\t !\"#$%&'()*+,-./;<=>?@[\\]^_`{|}~": {
+					"TEST VALUE 1\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+					"TEST VALUE 2\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+				},
 			},
 		},
 		Text: `Jeżu klątw, spłódź Finom część gry hańb!
@@ -24681,6 +25205,10 @@ func TestParseEmailPolishMultipartMixedIso88592OverBase64(t *testing.T) {
 			},
 			ExtraHeaders: map[string][]string{
 				"X-Clacks-Overhead": {"GNU Terry Pratchett"},
+				"X-Script/function/\t !\"#$%&'()*+,-./;<=>?@[\\]^_`{|}~": {
+					"TEST VALUE 1\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+					"TEST VALUE 2\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+				},
 			},
 		},
 		Text: `Jeżu klątw, spłódź Finom część gry hańb!
@@ -24959,6 +25487,10 @@ func TestParseEmailPolishMultipartMixedIso88592OverQuotedprintable(t *testing.T)
 			},
 			ExtraHeaders: map[string][]string{
 				"X-Clacks-Overhead": {"GNU Terry Pratchett"},
+				"X-Script/function/\t !\"#$%&'()*+,-./;<=>?@[\\]^_`{|}~": {
+					"TEST VALUE 1\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+					"TEST VALUE 2\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+				},
 			},
 		},
 		Text: `Jeżu klątw, spłódź Finom część gry hańb!
@@ -25239,6 +25771,10 @@ func TestParseEmailPolishMultipartSignedUtf8OverBase64(t *testing.T) {
 			},
 			ExtraHeaders: map[string][]string{
 				"X-Clacks-Overhead": {"GNU Terry Pratchett"},
+				"X-Script/function/\t !\"#$%&'()*+,-./;<=>?@[\\]^_`{|}~": {
+					"TEST VALUE 1\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+					"TEST VALUE 2\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+				},
 			},
 		},
 		Text: `Jeżu klątw, spłódź Finom część gry hańb!
@@ -25393,6 +25929,10 @@ func TestParseEmailPolishMultipartSignedUtf8OverQuotedprintable(t *testing.T) {
 			},
 			ExtraHeaders: map[string][]string{
 				"X-Clacks-Overhead": {"GNU Terry Pratchett"},
+				"X-Script/function/\t !\"#$%&'()*+,-./;<=>?@[\\]^_`{|}~": {
+					"TEST VALUE 1\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+					"TEST VALUE 2\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+				},
 			},
 		},
 		Text: `Jeżu klątw, spłódź Finom część gry hańb!
@@ -25547,6 +26087,10 @@ func TestParseEmailPolishMultipartSignedIso88592OverBase64(t *testing.T) {
 			},
 			ExtraHeaders: map[string][]string{
 				"X-Clacks-Overhead": {"GNU Terry Pratchett"},
+				"X-Script/function/\t !\"#$%&'()*+,-./;<=>?@[\\]^_`{|}~": {
+					"TEST VALUE 1\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+					"TEST VALUE 2\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+				},
 			},
 		},
 		Text: `Jeżu klątw, spłódź Finom część gry hańb!
@@ -25701,6 +26245,10 @@ func TestParseEmailPolishMultipartSignedIso88592OverQuotedprintable(t *testing.T
 			},
 			ExtraHeaders: map[string][]string{
 				"X-Clacks-Overhead": {"GNU Terry Pratchett"},
+				"X-Script/function/\t !\"#$%&'()*+,-./;<=>?@[\\]^_`{|}~": {
+					"TEST VALUE 1\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+					"TEST VALUE 2\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+				},
 			},
 		},
 		Text: `Jeżu klątw, spłódź Finom część gry hańb!

--- a/tests/test_chinese_multipart_mixed_gb18030_over_base64.txt
+++ b/tests/test_chinese_multipart_mixed_gb18030_over_base64.txt
@@ -30,6 +30,12 @@ Resent-Message-ID: <Message-Id-1@example.net>
 Content-Type: multIpARt/mixed; charset="gB18030"; BOUNDARY="MixedBoundaryString"
 Content-Transfer-Encoding: base64
 X-Clacks-Overhead: GNU Terry Pratchett
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 1	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 2	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
 
 
 --MixedBoundaryString

--- a/tests/test_chinese_multipart_mixed_gb18030_over_quoted-printable.txt
+++ b/tests/test_chinese_multipart_mixed_gb18030_over_quoted-printable.txt
@@ -30,6 +30,12 @@ Resent-Message-ID: <Message-Id-1@example.net>
 Content-Type: mULTIPArT/miXed; cHArSET="gB18030"; BOUNDArY="MixedBoundaryString"
 Content-Transfer-Encoding: quOTED-PRINTABlE
 X-Clacks-Overhead: GNU Terry Pratchett
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 1	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 2	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
 
 
 --MixedBoundaryString

--- a/tests/test_chinese_multipart_mixed_gbk_over_base64.txt
+++ b/tests/test_chinese_multipart_mixed_gbk_over_base64.txt
@@ -30,6 +30,12 @@ Resent-Message-ID: <Message-Id-1@example.net>
 Content-Type: mulTIparT/mixED; CHARset="GBK"; BOUNDARy="MixedBoundaryString"
 Content-Transfer-Encoding: BASe64
 X-Clacks-Overhead: GNU Terry Pratchett
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 1	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 2	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
 
 
 --MixedBoundaryString

--- a/tests/test_chinese_multipart_mixed_gbk_over_quoted-printable.txt
+++ b/tests/test_chinese_multipart_mixed_gbk_over_quoted-printable.txt
@@ -30,6 +30,12 @@ Resent-Message-ID: <Message-Id-1@example.net>
 Content-Type: mULTIPART/MIXED; CHarSet="gbk"; BoUNDARY="MixedBoundaryString"
 Content-Transfer-Encoding: QUOTeD-printable
 X-Clacks-Overhead: GNU Terry Pratchett
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 1	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 2	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
 
 
 --MixedBoundaryString

--- a/tests/test_chinese_multipart_related_gb18030_over_base64.txt
+++ b/tests/test_chinese_multipart_related_gb18030_over_base64.txt
@@ -30,6 +30,12 @@ Resent-Message-ID: <Message-Id-1@example.net>
 Content-Type: MUltIparT/related; chaRSet="gb18030"; BOUNDARY="RelatedBoundaryString"
 Content-Transfer-Encoding: BASE64
 X-Clacks-Overhead: GNU Terry Pratchett
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 1	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 2	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
 
 
 --RelatedBoundaryString

--- a/tests/test_chinese_multipart_related_gb18030_over_quoted-printable.txt
+++ b/tests/test_chinese_multipart_related_gb18030_over_quoted-printable.txt
@@ -30,6 +30,12 @@ Resent-Message-ID: <Message-Id-1@example.net>
 Content-Type: multipaRT/RELATED; CHARSEt="gB18030"; bOUnDARY="RelatedBoundaryString"
 Content-Transfer-Encoding: QUOTED-PRiNtaBlE
 X-Clacks-Overhead: GNU Terry Pratchett
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 1	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 2	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
 
 
 --RelatedBoundaryString

--- a/tests/test_chinese_multipart_related_gbk_over_base64.txt
+++ b/tests/test_chinese_multipart_related_gbk_over_base64.txt
@@ -30,6 +30,12 @@ Resent-Message-ID: <Message-Id-1@example.net>
 Content-Type: multiparT/RELATED; CHARSet="gbk"; boundaRy="RelatedBoundaryString"
 Content-Transfer-Encoding: baSE64
 X-Clacks-Overhead: GNU Terry Pratchett
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 1	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 2	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
 
 
 --RelatedBoundaryString

--- a/tests/test_chinese_multipart_related_gbk_over_quoted-printable.txt
+++ b/tests/test_chinese_multipart_related_gbk_over_quoted-printable.txt
@@ -30,6 +30,12 @@ Resent-Message-ID: <Message-Id-1@example.net>
 Content-Type: multiParT/RELated; chaRseT="GbK"; BOUNDARY="RelatedBoundaryString"
 Content-Transfer-Encoding: QUOTED-pRINTABLE
 X-Clacks-Overhead: GNU Terry Pratchett
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 1	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 2	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
 
 
 --RelatedBoundaryString

--- a/tests/test_chinese_multipart_signed_gb18030_over_base64.txt
+++ b/tests/test_chinese_multipart_signed_gb18030_over_base64.txt
@@ -34,6 +34,12 @@ Content-Type: MulTIPART/SIGnED;
               BOUNDARY=SignedBoundaryString
 Content-Transfer-Encoding: BAsE64
 X-Clacks-Overhead: GNU Terry Pratchett
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 1	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 2	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
 
 
 --SignedBoundaryString

--- a/tests/test_chinese_multipart_signed_gb18030_over_quoted-printable.txt
+++ b/tests/test_chinese_multipart_signed_gb18030_over_quoted-printable.txt
@@ -34,6 +34,12 @@ Content-Type: MULTIPART/sIgned;
               bOundary=SignedBoundaryString
 Content-Transfer-Encoding: quoted-PRIntable
 X-Clacks-Overhead: GNU Terry Pratchett
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 1	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 2	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
 
 
 --SignedBoundaryString

--- a/tests/test_chinese_multipart_signed_gbk_over_base64.txt
+++ b/tests/test_chinese_multipart_signed_gbk_over_base64.txt
@@ -34,6 +34,12 @@ Content-Type: mULTIPART/sIgned;
               BOUndary=SignedBoundaryString
 Content-Transfer-Encoding: base64
 X-Clacks-Overhead: GNU Terry Pratchett
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 1	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 2	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
 
 
 --SignedBoundaryString

--- a/tests/test_chinese_multipart_signed_gbk_over_quoted-printable.txt
+++ b/tests/test_chinese_multipart_signed_gbk_over_quoted-printable.txt
@@ -34,6 +34,12 @@ Content-Type: MULTIpArt/sIGNED;
               BoUndARY=SignedBoundaryString
 Content-Transfer-Encoding: QUOTED-PRINTable
 X-Clacks-Overhead: GNU Terry Pratchett
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 1	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 2	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
 
 
 --SignedBoundaryString

--- a/tests/test_chinese_plaintext_gb18030_over_base64.txt
+++ b/tests/test_chinese_plaintext_gb18030_over_base64.txt
@@ -30,6 +30,12 @@ Resent-Message-ID: <Message-Id-1@example.net>
 Content-Type: text/PlAIN; CHARSeT=GB18030
 Content-Transfer-Encoding: BASE64
 X-Clacks-Overhead: GNU Terry Pratchett
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 1	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 2	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
 
 
 yq/K0sqryr/KqcrPo6zKyMqoo6zKxMqzyq7KqKGjCsrPyrHKscrKytDK08qooaMKyq7KsaOsysrK

--- a/tests/test_chinese_plaintext_gb18030_over_quoted-printable.txt
+++ b/tests/test_chinese_plaintext_gb18030_over_quoted-printable.txt
@@ -30,6 +30,12 @@ Resent-Message-ID: <Message-Id-1@example.net>
 Content-Type: text/plain; chARseT=gb18030
 Content-Transfer-Encoding: QUOTED-PRINTABle
 X-Clacks-Overhead: GNU Terry Pratchett
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 1	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 2	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
 
 
 =CA=AF=CA=D2=CA=AB=CA=BF=CA=A9=CA=CF=A3=AC=CA=C8=CA=A8=A3=AC=CA=C4=CA=B3=CA=

--- a/tests/test_chinese_plaintext_gbk_over_base64.txt
+++ b/tests/test_chinese_plaintext_gbk_over_base64.txt
@@ -30,6 +30,12 @@ Resent-Message-ID: <Message-Id-1@example.net>
 Content-Type: TEXT/PLAIN; CHarset=Gbk
 Content-Transfer-Encoding: BASE64
 X-Clacks-Overhead: GNU Terry Pratchett
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 1	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 2	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
 
 
 yq/K0sqryr/KqcrPo6zKyMqoo6zKxMqzyq7KqKGjCsrPyrHKscrKytDK08qooaMKyq7KsaOsysrK

--- a/tests/test_chinese_plaintext_gbk_over_quoted-printable.txt
+++ b/tests/test_chinese_plaintext_gbk_over_quoted-printable.txt
@@ -30,6 +30,12 @@ Resent-Message-ID: <Message-Id-1@example.net>
 Content-Type: text/plAin; chArset=gbK
 Content-Transfer-Encoding: QUOTED-PRINTabLE
 X-Clacks-Overhead: GNU Terry Pratchett
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 1	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 2	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
 
 
 =CA=AF=CA=D2=CA=AB=CA=BF=CA=A9=CA=CF=A3=AC=CA=C8=CA=A8=A3=AC=CA=C4=CA=B3=CA=

--- a/tests/test_english_multipart_mixed_ascii_over_7bit.txt
+++ b/tests/test_english_multipart_mixed_ascii_over_7bit.txt
@@ -30,6 +30,12 @@ Resent-Message-ID: <Message-Id-1@example.net>
 Content-Type: MULtiPARt/mIXed; Charset="ascII"; bouNDARY="MixedBoundaryString"
 Content-Transfer-Encoding: 7BiT
 X-Clacks-Overhead: GNU Terry Pratchett
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 1	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 2	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
 
 
 --MixedBoundaryString

--- a/tests/test_english_multipart_mixed_ascii_over_base64.txt
+++ b/tests/test_english_multipart_mixed_ascii_over_base64.txt
@@ -30,6 +30,12 @@ Resent-Message-ID: <Message-Id-1@example.net>
 Content-Type: multipart/MIXEd; charset="ascii"; bouNDARY="MixedBoundaryString"
 Content-Transfer-Encoding: BASE64
 X-Clacks-Overhead: GNU Terry Pratchett
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 1	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 2	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
 
 
 --MixedBoundaryString

--- a/tests/test_english_multipart_mixed_ascii_over_quoted-printable.txt
+++ b/tests/test_english_multipart_mixed_ascii_over_quoted-printable.txt
@@ -30,6 +30,12 @@ Resent-Message-ID: <Message-Id-1@example.net>
 Content-Type: multIPART/MIXED; CHARseT="AscIi"; bOUNDARY="MixedBoundaryString"
 Content-Transfer-Encoding: QUOTED-PriNTABLE
 X-Clacks-Overhead: GNU Terry Pratchett
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 1	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 2	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
 
 
 --MixedBoundaryString

--- a/tests/test_english_multipart_mixed_utf-8_over_7bit.txt
+++ b/tests/test_english_multipart_mixed_utf-8_over_7bit.txt
@@ -30,6 +30,12 @@ Resent-Message-ID: <Message-Id-1@example.net>
 Content-Type: multipart/MIxed; CHARSET="UTF-8"; BOUndAry="MixedBoundaryString"
 Content-Transfer-Encoding: 7bit
 X-Clacks-Overhead: GNU Terry Pratchett
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 1	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 2	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
 
 
 --MixedBoundaryString

--- a/tests/test_english_multipart_mixed_utf-8_over_base64.txt
+++ b/tests/test_english_multipart_mixed_utf-8_over_base64.txt
@@ -30,6 +30,12 @@ Resent-Message-ID: <Message-Id-1@example.net>
 Content-Type: MULTiPart/MiXeD; CHARsEt="Utf-8"; boundary="MixedBoundaryString"
 Content-Transfer-Encoding: basE64
 X-Clacks-Overhead: GNU Terry Pratchett
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 1	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 2	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
 
 
 --MixedBoundaryString

--- a/tests/test_english_multipart_mixed_utf-8_over_quoted-printable.txt
+++ b/tests/test_english_multipart_mixed_utf-8_over_quoted-printable.txt
@@ -30,6 +30,12 @@ Resent-Message-ID: <Message-Id-1@example.net>
 Content-Type: MULTipart/mixed; chArSEt="UTf-8"; boundary="MixedBoundaryString"
 Content-Transfer-Encoding: quotED-PRINTABLE
 X-Clacks-Overhead: GNU Terry Pratchett
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 1	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 2	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
 
 
 --MixedBoundaryString

--- a/tests/test_english_multipart_related_ascii_over_7bit.txt
+++ b/tests/test_english_multipart_related_ascii_over_7bit.txt
@@ -30,6 +30,12 @@ Resent-Message-ID: <Message-Id-1@example.net>
 Content-Type: MuLtiPARt/relaTED; CHarset="ASCIi"; BoUnDaRY="RelatedBoundaryString"
 Content-Transfer-Encoding: 7biT
 X-Clacks-Overhead: GNU Terry Pratchett
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 1	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 2	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
 
 
 --RelatedBoundaryString

--- a/tests/test_english_multipart_related_ascii_over_base64.txt
+++ b/tests/test_english_multipart_related_ascii_over_base64.txt
@@ -30,6 +30,12 @@ Resent-Message-ID: <Message-Id-1@example.net>
 Content-Type: MULtiPARt/rELateD; chaRset="ASCii"; BOUndARY="RelatedBoundaryString"
 Content-Transfer-Encoding: BASE64
 X-Clacks-Overhead: GNU Terry Pratchett
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 1	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 2	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
 
 
 --RelatedBoundaryString

--- a/tests/test_english_multipart_related_ascii_over_quoted-printable.txt
+++ b/tests/test_english_multipart_related_ascii_over_quoted-printable.txt
@@ -30,6 +30,12 @@ Resent-Message-ID: <Message-Id-1@example.net>
 Content-Type: mULTIpART/reLAted; charset="asCIi"; bOUNdARY="RelatedBoundaryString"
 Content-Transfer-Encoding: qUOTED-PRINtaBle
 X-Clacks-Overhead: GNU Terry Pratchett
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 1	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 2	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
 
 
 --RelatedBoundaryString

--- a/tests/test_english_multipart_related_utf-8_over_7bit.txt
+++ b/tests/test_english_multipart_related_utf-8_over_7bit.txt
@@ -30,6 +30,12 @@ Resent-Message-ID: <Message-Id-1@example.net>
 Content-Type: multipaRt/relAteD; CHARSET="UTF-8"; bOUNdarY="RelatedBoundaryString"
 Content-Transfer-Encoding: 7bit
 X-Clacks-Overhead: GNU Terry Pratchett
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 1	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 2	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
 
 
 --RelatedBoundaryString

--- a/tests/test_english_multipart_related_utf-8_over_base64.txt
+++ b/tests/test_english_multipart_related_utf-8_over_base64.txt
@@ -30,6 +30,12 @@ Resent-Message-ID: <Message-Id-1@example.net>
 Content-Type: MULTIPART/RELatED; charset="utf-8"; bOundARY="RelatedBoundaryString"
 Content-Transfer-Encoding: bASE64
 X-Clacks-Overhead: GNU Terry Pratchett
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 1	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 2	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
 
 
 --RelatedBoundaryString

--- a/tests/test_english_multipart_related_utf-8_over_quoted-printable.txt
+++ b/tests/test_english_multipart_related_utf-8_over_quoted-printable.txt
@@ -30,6 +30,12 @@ Resent-Message-ID: <Message-Id-1@example.net>
 Content-Type: multipart/RELATEd; cHARSET="uTF-8"; BOUNDARY="RelatedBoundaryString"
 Content-Transfer-Encoding: QUOTED-PRinTable
 X-Clacks-Overhead: GNU Terry Pratchett
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 1	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 2	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
 
 
 --RelatedBoundaryString

--- a/tests/test_english_multipart_signed_ascii_over_7bit.txt
+++ b/tests/test_english_multipart_signed_ascii_over_7bit.txt
@@ -34,6 +34,12 @@ Content-Type: MULTIpaRT/sigNEd;
               BOUNdARy=SignedBoundaryString
 Content-Transfer-Encoding: 7biT
 X-Clacks-Overhead: GNU Terry Pratchett
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 1	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 2	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
 
 
 --SignedBoundaryString

--- a/tests/test_english_multipart_signed_ascii_over_base64.txt
+++ b/tests/test_english_multipart_signed_ascii_over_base64.txt
@@ -34,6 +34,12 @@ Content-Type: MUltIpaRT/siGNed;
               boundARY=SignedBoundaryString
 Content-Transfer-Encoding: baSE64
 X-Clacks-Overhead: GNU Terry Pratchett
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 1	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 2	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
 
 
 --SignedBoundaryString

--- a/tests/test_english_multipart_signed_ascii_over_quoted-printable.txt
+++ b/tests/test_english_multipart_signed_ascii_over_quoted-printable.txt
@@ -34,6 +34,12 @@ Content-Type: multipart/signEd;
               boundary=SignedBoundaryString
 Content-Transfer-Encoding: quoteD-PRINTABLE
 X-Clacks-Overhead: GNU Terry Pratchett
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 1	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 2	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
 
 
 --SignedBoundaryString

--- a/tests/test_english_multipart_signed_utf-8_over_7bit.txt
+++ b/tests/test_english_multipart_signed_utf-8_over_7bit.txt
@@ -34,6 +34,12 @@ Content-Type: MUlTIpart/signeD;
               boundary=SignedBoundaryString
 Content-Transfer-Encoding: 7bit
 X-Clacks-Overhead: GNU Terry Pratchett
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 1	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 2	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
 
 
 --SignedBoundaryString

--- a/tests/test_english_multipart_signed_utf-8_over_base64.txt
+++ b/tests/test_english_multipart_signed_utf-8_over_base64.txt
@@ -34,6 +34,12 @@ Content-Type: MULTIpART/siGNEd;
               BOUNDARY=SignedBoundaryString
 Content-Transfer-Encoding: BaSe64
 X-Clacks-Overhead: GNU Terry Pratchett
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 1	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 2	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
 
 
 --SignedBoundaryString

--- a/tests/test_english_multipart_signed_utf-8_over_quoted-printable.txt
+++ b/tests/test_english_multipart_signed_utf-8_over_quoted-printable.txt
@@ -34,6 +34,12 @@ Content-Type: Multipart/siGNed;
               BOUNDARY=SignedBoundaryString
 Content-Transfer-Encoding: QUOTed-prinTablE
 X-Clacks-Overhead: GNU Terry Pratchett
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 1	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 2	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
 
 
 --SignedBoundaryString

--- a/tests/test_english_no_text_content.txt
+++ b/tests/test_english_no_text_content.txt
@@ -15,6 +15,12 @@ Content-Type: applicaTION/PDF; NAME="attached-pdf-name.pdf"
 Content-Disposition: AttachmenT; FILENAMe="attached-pdf-filename.pdf"
 Content-Transfer-Encoding: BASE64
 X-Clacks-Overhead: GNU Terry Pratchett
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 1	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 2	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
 
 JVBERi0xLg10cmFpbGVyPDwvUm9vdDw8L1BhZ2VzPDwvS2lkc1s8PC9NZWRpYUJveFswIDAgMyAz
 XT4+XT4+Pj4+Pg==

--- a/tests/test_english_plaintext_ascii_over_7bit.txt
+++ b/tests/test_english_plaintext_ascii_over_7bit.txt
@@ -19,6 +19,12 @@ Keywords: Keyword 1, Keyword 2
 Content-Type: tExT/pLaiN; charset=AsCIi
 Content-Transfer-Encoding: 7bIt
 X-Clacks-Overhead: GNU Terry Pratchett
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 1	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 2	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
 
 
 The quick brown fox jumps over a lazy dog.

--- a/tests/test_english_plaintext_ascii_over_base64.txt
+++ b/tests/test_english_plaintext_ascii_over_base64.txt
@@ -30,6 +30,12 @@ Resent-Message-ID: <Message-Id-1@example.net>
 Content-Type: teXt/PLain; ChARSEt=asciI
 Content-Transfer-Encoding: BAsE64
 X-Clacks-Overhead: GNU Terry Pratchett
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 1	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 2	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
 
 
 VGhlIHF1aWNrIGJyb3duIGZveCBqdW1wcyBvdmVyIGEgbGF6eSBkb2cuCkdsaWIgam9ja3MgcXVp

--- a/tests/test_english_plaintext_ascii_over_quoted-printable.txt
+++ b/tests/test_english_plaintext_ascii_over_quoted-printable.txt
@@ -30,6 +30,12 @@ Resent-Message-ID: <Message-Id-1@example.net>
 Content-Type: TexT/PlAiN; charSET=AScii
 Content-Transfer-Encoding: QuOtED-prInTaBlE
 X-Clacks-Overhead: GNU Terry Pratchett
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 1	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 2	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
 
 
 The quick brown fox jumps over a lazy dog.

--- a/tests/test_english_plaintext_utf-8_over_7bit.txt
+++ b/tests/test_english_plaintext_utf-8_over_7bit.txt
@@ -30,6 +30,12 @@ Resent-Message-ID: <Message-Id-1@example.net>
 Content-Type: tEXt/PLain; ChARSEt=utF-8
 Content-Transfer-Encoding: 7BiT
 X-Clacks-Overhead: GNU Terry Pratchett
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 1	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 2	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
 
 
 The quick brown fox jumps over a lazy dog.

--- a/tests/test_english_plaintext_utf-8_over_base64.txt
+++ b/tests/test_english_plaintext_utf-8_over_base64.txt
@@ -30,6 +30,12 @@ Resent-Message-ID: <Message-Id-1@example.net>
 Content-Type: TEXT/plAiN; CHaRSet=UTf-8
 Content-Transfer-Encoding: BaSe64
 X-Clacks-Overhead: GNU Terry Pratchett
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 1	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 2	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
 
 
 VGhlIHF1aWNrIGJyb3duIGZveCBqdW1wcyBvdmVyIGEgbGF6eSBkb2cuCkdsaWIgam9ja3MgcXVp

--- a/tests/test_english_plaintext_utf-8_over_quoted-printable.txt
+++ b/tests/test_english_plaintext_utf-8_over_quoted-printable.txt
@@ -30,6 +30,12 @@ Resent-Message-ID: <Message-Id-1@example.net>
 Content-Type: Text/pLAIN; charsET=UTF-8
 Content-Transfer-Encoding: quOTEd-printABLE
 X-Clacks-Overhead: GNU Terry Pratchett
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 1	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 2	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
 
 
 The quick brown fox jumps over a lazy dog.

--- a/tests/test_finnish_multipart_mixed_iso-8859-15_over_base64.txt
+++ b/tests/test_finnish_multipart_mixed_iso-8859-15_over_base64.txt
@@ -30,6 +30,12 @@ Resent-Message-ID: <Message-Id-1@example.net>
 Content-Type: Multipart/mixed; chaRSeT="ISO-8859-15"; BOUNdARY="MixedBoundaryString"
 Content-Transfer-Encoding: Base64
 X-Clacks-Overhead: GNU Terry Pratchett
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 1	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 2	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
 
 
 --MixedBoundaryString

--- a/tests/test_finnish_multipart_mixed_iso-8859-15_over_quoted-printable.txt
+++ b/tests/test_finnish_multipart_mixed_iso-8859-15_over_quoted-printable.txt
@@ -30,6 +30,12 @@ Resent-Message-ID: <Message-Id-1@example.net>
 Content-Type: multiparT/MIXED; CHARSET="ISO-8859-15"; BOUNDARY="MixedBoundaryString"
 Content-Transfer-Encoding: QUoTed-printable
 X-Clacks-Overhead: GNU Terry Pratchett
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 1	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 2	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
 
 
 --MixedBoundaryString

--- a/tests/test_finnish_multipart_mixed_utf-8_over_base64.txt
+++ b/tests/test_finnish_multipart_mixed_utf-8_over_base64.txt
@@ -30,6 +30,12 @@ Resent-Message-ID: <Message-Id-1@example.net>
 Content-Type: multipart/miXeD; CHaRSET="utf-8"; bounDarY="MixedBoundaryString"
 Content-Transfer-Encoding: BASE64
 X-Clacks-Overhead: GNU Terry Pratchett
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 1	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 2	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
 
 
 --MixedBoundaryString

--- a/tests/test_finnish_multipart_mixed_utf-8_over_quoted-printable.txt
+++ b/tests/test_finnish_multipart_mixed_utf-8_over_quoted-printable.txt
@@ -30,6 +30,12 @@ Resent-Message-ID: <Message-Id-1@example.net>
 Content-Type: MULTiPaRt/miXeD; cHaRSET="UTF-8"; BOUNDARy="MixedBoundaryString"
 Content-Transfer-Encoding: qUoTED-PRINTABle
 X-Clacks-Overhead: GNU Terry Pratchett
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 1	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 2	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
 
 
 --MixedBoundaryString

--- a/tests/test_finnish_multipart_related_iso-8859-15_over_base64.txt
+++ b/tests/test_finnish_multipart_related_iso-8859-15_over_base64.txt
@@ -30,6 +30,12 @@ Resent-Message-ID: <Message-Id-1@example.net>
 Content-Type: MULTIPARt/reLaTED; CHARSET="ISO-8859-15"; boundarY="RelatedBoundaryString"
 Content-Transfer-Encoding: BASe64
 X-Clacks-Overhead: GNU Terry Pratchett
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 1	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 2	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
 
 
 --RelatedBoundaryString

--- a/tests/test_finnish_multipart_related_iso-8859-15_over_quoted-printable.txt
+++ b/tests/test_finnish_multipart_related_iso-8859-15_over_quoted-printable.txt
@@ -30,6 +30,12 @@ Resent-Message-ID: <Message-Id-1@example.net>
 Content-Type: MUltiPARt/RELaTED; chARSet="ISo-8859-15"; Boundary="RelatedBoundaryString"
 Content-Transfer-Encoding: quoted-pRiNTaBle
 X-Clacks-Overhead: GNU Terry Pratchett
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 1	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 2	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
 
 
 --RelatedBoundaryString

--- a/tests/test_finnish_multipart_related_utf-8_over_base64.txt
+++ b/tests/test_finnish_multipart_related_utf-8_over_base64.txt
@@ -30,6 +30,12 @@ Resent-Message-ID: <Message-Id-1@example.net>
 Content-Type: MulTiPART/RELAtED; CHaRset="Utf-8"; BOUNDARY="RelatedBoundaryString"
 Content-Transfer-Encoding: BASE64
 X-Clacks-Overhead: GNU Terry Pratchett
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 1	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 2	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
 
 
 --RelatedBoundaryString

--- a/tests/test_finnish_multipart_related_utf-8_over_quoted-printable.txt
+++ b/tests/test_finnish_multipart_related_utf-8_over_quoted-printable.txt
@@ -30,6 +30,12 @@ Resent-Message-ID: <Message-Id-1@example.net>
 Content-Type: mULTIPART/RELATed; cHarset="UtF-8"; BOUNDAry="RelatedBoundaryString"
 Content-Transfer-Encoding: qUoted-printaBLE
 X-Clacks-Overhead: GNU Terry Pratchett
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 1	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 2	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
 
 
 --RelatedBoundaryString

--- a/tests/test_finnish_multipart_signed_iso-8859-15_over_base64.txt
+++ b/tests/test_finnish_multipart_signed_iso-8859-15_over_base64.txt
@@ -34,6 +34,12 @@ Content-Type: MULtipart/sIGned;
               BOUNdary=SignedBoundaryString
 Content-Transfer-Encoding: base64
 X-Clacks-Overhead: GNU Terry Pratchett
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 1	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 2	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
 
 
 --SignedBoundaryString

--- a/tests/test_finnish_multipart_signed_iso-8859-15_over_quoted-printable.txt
+++ b/tests/test_finnish_multipart_signed_iso-8859-15_over_quoted-printable.txt
@@ -34,6 +34,12 @@ Content-Type: multIPaRT/SIGNED;
               BOUNDARy=SignedBoundaryString
 Content-Transfer-Encoding: QuOted-printablE
 X-Clacks-Overhead: GNU Terry Pratchett
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 1	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 2	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
 
 
 --SignedBoundaryString

--- a/tests/test_finnish_multipart_signed_utf-8_over_base64.txt
+++ b/tests/test_finnish_multipart_signed_utf-8_over_base64.txt
@@ -34,6 +34,12 @@ Content-Type: MULTIPART/sIgned;
               BOUNDARy=SignedBoundaryString
 Content-Transfer-Encoding: BAse64
 X-Clacks-Overhead: GNU Terry Pratchett
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 1	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 2	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
 
 
 --SignedBoundaryString

--- a/tests/test_finnish_multipart_signed_utf-8_over_quoted-printable.txt
+++ b/tests/test_finnish_multipart_signed_utf-8_over_quoted-printable.txt
@@ -34,6 +34,12 @@ Content-Type: mULTIPART/SIGNeD;
               boUNDARY=SignedBoundaryString
 Content-Transfer-Encoding: quoted-priNTaBLE
 X-Clacks-Overhead: GNU Terry Pratchett
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 1	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 2	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
 
 
 --SignedBoundaryString

--- a/tests/test_finnish_plaintext_iso-8859-15_over_base64.txt
+++ b/tests/test_finnish_plaintext_iso-8859-15_over_base64.txt
@@ -30,6 +30,12 @@ Resent-Message-ID: <Message-Id-1@example.net>
 Content-Type: TEXT/PLAIN; CHARset=iSO-8859-15
 Content-Transfer-Encoding: BASE64
 X-Clacks-Overhead: GNU Terry Pratchett
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 1	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 2	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
 
 
 QWxiZXJ0IG9zdGkgZmFnb3RpbiBqYSB09nLkeXR0aSBwdWhrdXZhbiBtZWxvZGlhbi4KTG9ydW4g

--- a/tests/test_finnish_plaintext_iso-8859-15_over_quoted-printable.txt
+++ b/tests/test_finnish_plaintext_iso-8859-15_over_quoted-printable.txt
@@ -30,6 +30,12 @@ Resent-Message-ID: <Message-Id-1@example.net>
 Content-Type: text/plaIN; ChARSET=ISO-8859-15
 Content-Transfer-Encoding: qUoTED-PRINTABLe
 X-Clacks-Overhead: GNU Terry Pratchett
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 1	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 2	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
 
 
 Albert osti fagotin ja t=F6r=E4ytti puhkuvan melodian.

--- a/tests/test_finnish_plaintext_utf-8_over_base64.txt
+++ b/tests/test_finnish_plaintext_utf-8_over_base64.txt
@@ -30,6 +30,12 @@ Resent-Message-ID: <Message-Id-1@example.net>
 Content-Type: TEXT/pLain; charset=utF-8
 Content-Transfer-Encoding: BASe64
 X-Clacks-Overhead: GNU Terry Pratchett
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 1	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 2	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
 
 
 QWxiZXJ0IG9zdGkgZmFnb3RpbiBqYSB0w7Zyw6R5dHRpIHB1aGt1dmFuIG1lbG9kaWFuLgpMb3J1

--- a/tests/test_finnish_plaintext_utf-8_over_quoted-printable.txt
+++ b/tests/test_finnish_plaintext_utf-8_over_quoted-printable.txt
@@ -30,6 +30,12 @@ Resent-Message-ID: <Message-Id-1@example.net>
 Content-Type: TEXT/pLain; charset=uTf-8
 Content-Transfer-Encoding: QUOtEd-printable
 X-Clacks-Overhead: GNU Terry Pratchett
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 1	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 2	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
 
 
 Albert osti fagotin ja t=C3=B6r=C3=A4ytti puhkuvan melodian.

--- a/tests/test_icelandic_multipart_mixed_iso-8859-1_over_base64.txt
+++ b/tests/test_icelandic_multipart_mixed_iso-8859-1_over_base64.txt
@@ -30,6 +30,12 @@ Resent-Message-ID: <Message-Id-1@example.net>
 Content-Type: mulTIpArt/mixed; charSET="iSO-8859-1"; BOUnDarY="MixedBoundaryString"
 Content-Transfer-Encoding: bASE64
 X-Clacks-Overhead: GNU Terry Pratchett
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 1	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 2	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
 
 
 --MixedBoundaryString

--- a/tests/test_icelandic_multipart_mixed_iso-8859-1_over_quoted-printable.txt
+++ b/tests/test_icelandic_multipart_mixed_iso-8859-1_over_quoted-printable.txt
@@ -30,6 +30,12 @@ Resent-Message-ID: <Message-Id-1@example.net>
 Content-Type: MultiparT/mIXeD; CHARSET="ISo-8859-1"; bouNDARY="MixedBoundaryString"
 Content-Transfer-Encoding: QUOTED-PRINtable
 X-Clacks-Overhead: GNU Terry Pratchett
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 1	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 2	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
 
 
 --MixedBoundaryString

--- a/tests/test_icelandic_multipart_mixed_utf-8_over_base64.txt
+++ b/tests/test_icelandic_multipart_mixed_utf-8_over_base64.txt
@@ -30,6 +30,12 @@ Resent-Message-ID: <Message-Id-1@example.net>
 Content-Type: MultipArT/MIxED; Charset="utf-8"; boundArY="MixedBoundaryString"
 Content-Transfer-Encoding: Base64
 X-Clacks-Overhead: GNU Terry Pratchett
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 1	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 2	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
 
 
 --MixedBoundaryString

--- a/tests/test_icelandic_multipart_mixed_utf-8_over_quoted-printable.txt
+++ b/tests/test_icelandic_multipart_mixed_utf-8_over_quoted-printable.txt
@@ -30,6 +30,12 @@ Resent-Message-ID: <Message-Id-1@example.net>
 Content-Type: multipart/mIxED; charset="utf-8"; bounDaRY="MixedBoundaryString"
 Content-Transfer-Encoding: QUOTED-PrinTaBLE
 X-Clacks-Overhead: GNU Terry Pratchett
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 1	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 2	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
 
 
 --MixedBoundaryString

--- a/tests/test_icelandic_multipart_related_iso-8859-1_over_base64.txt
+++ b/tests/test_icelandic_multipart_related_iso-8859-1_over_base64.txt
@@ -30,6 +30,12 @@ Resent-Message-ID: <Message-Id-1@example.net>
 Content-Type: multIPART/RELATED; charseT="ISo-8859-1"; BOUNDarY="RelatedBoundaryString"
 Content-Transfer-Encoding: Base64
 X-Clacks-Overhead: GNU Terry Pratchett
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 1	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 2	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
 
 
 --RelatedBoundaryString

--- a/tests/test_icelandic_multipart_related_iso-8859-1_over_quoted-printable.txt
+++ b/tests/test_icelandic_multipart_related_iso-8859-1_over_quoted-printable.txt
@@ -30,6 +30,12 @@ Resent-Message-ID: <Message-Id-1@example.net>
 Content-Type: muLTIPaRt/relaTeD; cHaRSET="ISO-8859-1"; BOundARY="RelatedBoundaryString"
 Content-Transfer-Encoding: QUOTED-pRintable
 X-Clacks-Overhead: GNU Terry Pratchett
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 1	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 2	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
 
 
 --RelatedBoundaryString

--- a/tests/test_icelandic_multipart_related_utf-8_over_base64.txt
+++ b/tests/test_icelandic_multipart_related_utf-8_over_base64.txt
@@ -30,6 +30,12 @@ Resent-Message-ID: <Message-Id-1@example.net>
 Content-Type: Multipart/reLaTEd; charset="utf-8"; boUNDARY="RelatedBoundaryString"
 Content-Transfer-Encoding: BASE64
 X-Clacks-Overhead: GNU Terry Pratchett
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 1	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 2	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
 
 
 --RelatedBoundaryString

--- a/tests/test_icelandic_multipart_related_utf-8_over_quoted-printable.txt
+++ b/tests/test_icelandic_multipart_related_utf-8_over_quoted-printable.txt
@@ -30,6 +30,12 @@ Resent-Message-ID: <Message-Id-1@example.net>
 Content-Type: multIPaRT/RELaTed; chaRsET="UtF-8"; BOUNDARY="RelatedBoundaryString"
 Content-Transfer-Encoding: QUOted-PRINTABLE
 X-Clacks-Overhead: GNU Terry Pratchett
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 1	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 2	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
 
 
 --RelatedBoundaryString

--- a/tests/test_icelandic_multipart_signed_iso-8859-1_over_base64.txt
+++ b/tests/test_icelandic_multipart_signed_iso-8859-1_over_base64.txt
@@ -34,6 +34,12 @@ Content-Type: multipART/SIGNED;
               BOUNDaRy=SignedBoundaryString
 Content-Transfer-Encoding: base64
 X-Clacks-Overhead: GNU Terry Pratchett
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 1	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 2	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
 
 
 --SignedBoundaryString

--- a/tests/test_icelandic_multipart_signed_iso-8859-1_over_quoted-printable.txt
+++ b/tests/test_icelandic_multipart_signed_iso-8859-1_over_quoted-printable.txt
@@ -34,6 +34,12 @@ Content-Type: muLTiPART/SIGNeD;
               BoUNDary=SignedBoundaryString
 Content-Transfer-Encoding: quoted-prINtABLE
 X-Clacks-Overhead: GNU Terry Pratchett
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 1	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 2	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
 
 
 --SignedBoundaryString

--- a/tests/test_icelandic_multipart_signed_utf-8_over_base64.txt
+++ b/tests/test_icelandic_multipart_signed_utf-8_over_base64.txt
@@ -34,6 +34,12 @@ Content-Type: multipArt/SIGNED;
               bOUnDARY=SignedBoundaryString
 Content-Transfer-Encoding: BASE64
 X-Clacks-Overhead: GNU Terry Pratchett
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 1	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 2	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
 
 
 --SignedBoundaryString

--- a/tests/test_icelandic_multipart_signed_utf-8_over_quoted-printable.txt
+++ b/tests/test_icelandic_multipart_signed_utf-8_over_quoted-printable.txt
@@ -34,6 +34,12 @@ Content-Type: multipARt/SIGNED;
               bOUNDARY=SignedBoundaryString
 Content-Transfer-Encoding: QUOTED-PrintabLe
 X-Clacks-Overhead: GNU Terry Pratchett
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 1	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 2	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
 
 
 --SignedBoundaryString

--- a/tests/test_icelandic_plaintext_iso-8859-1_over_base64.txt
+++ b/tests/test_icelandic_plaintext_iso-8859-1_over_base64.txt
@@ -30,6 +30,12 @@ Resent-Message-ID: <Message-Id-1@example.net>
 Content-Type: TEXT/PLaiN; Charset=iso-8859-1
 Content-Transfer-Encoding: BaSe64
 X-Clacks-Overhead: GNU Terry Pratchett
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 1	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 2	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
 
 
 S+ZtaSBu/SD2eGkgaOlyLCB5a2lzdCD+avNmdW0gbvogYubwaSB27Wwgb2cg4WRyZXBhLgpTdm8g

--- a/tests/test_icelandic_plaintext_iso-8859-1_over_quoted-printable.txt
+++ b/tests/test_icelandic_plaintext_iso-8859-1_over_quoted-printable.txt
@@ -30,6 +30,12 @@ Resent-Message-ID: <Message-Id-1@example.net>
 Content-Type: text/plAIN; ChaRset=iso-8859-1
 Content-Transfer-Encoding: quoTED-PRINTABle
 X-Clacks-Overhead: GNU Terry Pratchett
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 1	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 2	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
 
 
 K=E6mi n=FD =F6xi h=E9r, ykist =FEj=F3fum n=FA b=E6=F0i v=EDl og =E1drepa.

--- a/tests/test_icelandic_plaintext_utf-8_over_base64.txt
+++ b/tests/test_icelandic_plaintext_utf-8_over_base64.txt
@@ -30,6 +30,12 @@ Resent-Message-ID: <Message-Id-1@example.net>
 Content-Type: text/PLAIN; ChArset=utf-8
 Content-Transfer-Encoding: base64
 X-Clacks-Overhead: GNU Terry Pratchett
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 1	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 2	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
 
 
 S8OmbWkgbsO9IMO2eGkgaMOpciwgeWtpc3Qgw75qw7NmdW0gbsO6IGLDpsOwaSB2w61sIG9nIMOh

--- a/tests/test_icelandic_plaintext_utf-8_over_quoted-printable.txt
+++ b/tests/test_icelandic_plaintext_utf-8_over_quoted-printable.txt
@@ -30,6 +30,12 @@ Resent-Message-ID: <Message-Id-1@example.net>
 Content-Type: texT/pLAIN; CHARSET=utf-8
 Content-Transfer-Encoding: quoteD-pRINTABLE
 X-Clacks-Overhead: GNU Terry Pratchett
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 1	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 2	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
 
 
 K=C3=A6mi n=C3=BD =C3=B6xi h=C3=A9r, ykist =C3=BEj=C3=B3fum n=C3=BA b=C3=A6=

--- a/tests/test_japanese_multipart_mixed_euc-jp_over_base64.txt
+++ b/tests/test_japanese_multipart_mixed_euc-jp_over_base64.txt
@@ -30,6 +30,12 @@ Resent-Message-ID: <Message-Id-1@example.net>
 Content-Type: mULTIPART/MIXed; chARSET="EUC-JP"; BOUNDarY="MixedBoundaryString"
 Content-Transfer-Encoding: Base64
 X-Clacks-Overhead: GNU Terry Pratchett
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 1	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 2	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
 
 
 --MixedBoundaryString

--- a/tests/test_japanese_multipart_mixed_euc-jp_over_quoted-printable.txt
+++ b/tests/test_japanese_multipart_mixed_euc-jp_over_quoted-printable.txt
@@ -30,6 +30,12 @@ Resent-Message-ID: <Message-Id-1@example.net>
 Content-Type: MuLTIPART/MIXEd; ChArset="euc-Jp"; BOUNDARY="MixedBoundaryString"
 Content-Transfer-Encoding: QUOTeD-PRiNtable
 X-Clacks-Overhead: GNU Terry Pratchett
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 1	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 2	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
 
 
 --MixedBoundaryString

--- a/tests/test_japanese_multipart_mixed_iso-2022-jp_over_7bit.txt
+++ b/tests/test_japanese_multipart_mixed_iso-2022-jp_over_7bit.txt
@@ -30,6 +30,12 @@ Resent-Message-ID: <Message-Id-1@example.net>
 Content-Type: multiparT/mIXED; CHARSET="ISO-2022-JP"; BOUNDArY="MixedBoundaryString"
 Content-Transfer-Encoding: 7Bit
 X-Clacks-Overhead: GNU Terry Pratchett
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 1	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 2	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
 
 
 --MixedBoundaryString

--- a/tests/test_japanese_multipart_mixed_iso-2022-jp_over_base64.txt
+++ b/tests/test_japanese_multipart_mixed_iso-2022-jp_over_base64.txt
@@ -30,6 +30,12 @@ Resent-Message-ID: <Message-Id-1@example.net>
 Content-Type: multiPaRT/MiXed; cHarset="iso-2022-jp"; BOuNdary="MixedBoundaryString"
 Content-Transfer-Encoding: base64
 X-Clacks-Overhead: GNU Terry Pratchett
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 1	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 2	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
 
 
 --MixedBoundaryString

--- a/tests/test_japanese_multipart_mixed_iso-2022-jp_over_quoted-printable.txt
+++ b/tests/test_japanese_multipart_mixed_iso-2022-jp_over_quoted-printable.txt
@@ -30,6 +30,12 @@ Resent-Message-ID: <Message-Id-1@example.net>
 Content-Type: MULTIPART/MIxEd; charset="iso-2022-jP"; boundary="MixedBoundaryString"
 Content-Transfer-Encoding: quoteD-PRINTABLE
 X-Clacks-Overhead: GNU Terry Pratchett
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 1	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 2	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
 
 
 --MixedBoundaryString

--- a/tests/test_japanese_multipart_mixed_utf-8_over_7bit.txt
+++ b/tests/test_japanese_multipart_mixed_utf-8_over_7bit.txt
@@ -30,6 +30,12 @@ Resent-Message-ID: <Message-Id-1@example.net>
 Content-Type: mULTipART/mIXEd; cHArseT="utf-8"; boundary="MixedBoundaryString"
 Content-Transfer-Encoding: 7Bit
 X-Clacks-Overhead: GNU Terry Pratchett
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 1	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 2	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
 
 
 --MixedBoundaryString

--- a/tests/test_japanese_multipart_mixed_utf-8_over_base64.txt
+++ b/tests/test_japanese_multipart_mixed_utf-8_over_base64.txt
@@ -30,6 +30,12 @@ Resent-Message-ID: <Message-Id-1@example.net>
 Content-Type: muLtipart/mixed; chArsET="UTF-8"; BOUNDARy="MixedBoundaryString"
 Content-Transfer-Encoding: BASe64
 X-Clacks-Overhead: GNU Terry Pratchett
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 1	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 2	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
 
 
 --MixedBoundaryString

--- a/tests/test_japanese_multipart_mixed_utf-8_over_quoted-printable.txt
+++ b/tests/test_japanese_multipart_mixed_utf-8_over_quoted-printable.txt
@@ -30,6 +30,12 @@ Resent-Message-ID: <Message-Id-1@example.net>
 Content-Type: mulTIpart/Mixed; charset="uTF-8"; bOUNdary="MixedBoundaryString"
 Content-Transfer-Encoding: quoted-prINTABLE
 X-Clacks-Overhead: GNU Terry Pratchett
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 1	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 2	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
 
 
 --MixedBoundaryString

--- a/tests/test_japanese_multipart_related_euc-jp_over_base64.txt
+++ b/tests/test_japanese_multipart_related_euc-jp_over_base64.txt
@@ -30,6 +30,12 @@ Resent-Message-ID: <Message-Id-1@example.net>
 Content-Type: MULTIPART/RELAted; CharSEt="euc-jp"; BOundARY="RelatedBoundaryString"
 Content-Transfer-Encoding: BASe64
 X-Clacks-Overhead: GNU Terry Pratchett
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 1	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 2	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
 
 
 --RelatedBoundaryString

--- a/tests/test_japanese_multipart_related_euc-jp_over_quoted-printable.txt
+++ b/tests/test_japanese_multipart_related_euc-jp_over_quoted-printable.txt
@@ -30,6 +30,12 @@ Resent-Message-ID: <Message-Id-1@example.net>
 Content-Type: muLTIPART/RELATEd; chArset="euc-jp"; BOUNDARy="RelatedBoundaryString"
 Content-Transfer-Encoding: QUoted-printable
 X-Clacks-Overhead: GNU Terry Pratchett
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 1	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 2	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
 
 
 --RelatedBoundaryString

--- a/tests/test_japanese_multipart_related_iso-2022-jp_over_7bit.txt
+++ b/tests/test_japanese_multipart_related_iso-2022-jp_over_7bit.txt
@@ -30,6 +30,12 @@ Resent-Message-ID: <Message-Id-1@example.net>
 Content-Type: MULTiParT/RELATED; CHARSEt="ISO-2022-jp"; BOUNDARy="RelatedBoundaryString"
 Content-Transfer-Encoding: 7BIt
 X-Clacks-Overhead: GNU Terry Pratchett
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 1	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 2	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
 
 
 --RelatedBoundaryString

--- a/tests/test_japanese_multipart_related_iso-2022-jp_over_base64.txt
+++ b/tests/test_japanese_multipart_related_iso-2022-jp_over_base64.txt
@@ -30,6 +30,12 @@ Resent-Message-ID: <Message-Id-1@example.net>
 Content-Type: mulTiPaRT/ReLated; charset="iso-2022-JP"; BOUNdary="RelatedBoundaryString"
 Content-Transfer-Encoding: baSE64
 X-Clacks-Overhead: GNU Terry Pratchett
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 1	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 2	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
 
 
 --RelatedBoundaryString

--- a/tests/test_japanese_multipart_related_iso-2022-jp_over_quoted-printable.txt
+++ b/tests/test_japanese_multipart_related_iso-2022-jp_over_quoted-printable.txt
@@ -30,6 +30,12 @@ Resent-Message-ID: <Message-Id-1@example.net>
 Content-Type: multipaRT/RELATED; CHARSEt="Iso-2022-JP"; BOUNDAry="RelatedBoundaryString"
 Content-Transfer-Encoding: qUoted-printaBLE
 X-Clacks-Overhead: GNU Terry Pratchett
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 1	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 2	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
 
 
 --RelatedBoundaryString

--- a/tests/test_japanese_multipart_related_utf-8_over_7bit.txt
+++ b/tests/test_japanese_multipart_related_utf-8_over_7bit.txt
@@ -30,6 +30,12 @@ Resent-Message-ID: <Message-Id-1@example.net>
 Content-Type: multipaRT/RELATED; CharsET="utF-8"; BOUNDARY="RelatedBoundaryString"
 Content-Transfer-Encoding: 7BiT
 X-Clacks-Overhead: GNU Terry Pratchett
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 1	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 2	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
 
 
 --RelatedBoundaryString

--- a/tests/test_japanese_multipart_related_utf-8_over_base64.txt
+++ b/tests/test_japanese_multipart_related_utf-8_over_base64.txt
@@ -30,6 +30,12 @@ Resent-Message-ID: <Message-Id-1@example.net>
 Content-Type: multiparT/rELATED; CHARsEt="utf-8"; boUNdARY="RelatedBoundaryString"
 Content-Transfer-Encoding: BASE64
 X-Clacks-Overhead: GNU Terry Pratchett
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 1	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 2	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
 
 
 --RelatedBoundaryString

--- a/tests/test_japanese_multipart_related_utf-8_over_quoted-printable.txt
+++ b/tests/test_japanese_multipart_related_utf-8_over_quoted-printable.txt
@@ -30,6 +30,12 @@ Resent-Message-ID: <Message-Id-1@example.net>
 Content-Type: MULTIPART/ReLated; CHARSET="UTF-8"; BoUNdary="RelatedBoundaryString"
 Content-Transfer-Encoding: quoted-pRiNTaBle
 X-Clacks-Overhead: GNU Terry Pratchett
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 1	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 2	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
 
 
 --RelatedBoundaryString

--- a/tests/test_japanese_multipart_signed_euc-jp_over_base64.txt
+++ b/tests/test_japanese_multipart_signed_euc-jp_over_base64.txt
@@ -34,6 +34,12 @@ Content-Type: MULTipart/signeD;
               boundarY=SignedBoundaryString
 Content-Transfer-Encoding: basE64
 X-Clacks-Overhead: GNU Terry Pratchett
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 1	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 2	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
 
 
 --SignedBoundaryString

--- a/tests/test_japanese_multipart_signed_euc-jp_over_quoted-printable.txt
+++ b/tests/test_japanese_multipart_signed_euc-jp_over_quoted-printable.txt
@@ -34,6 +34,12 @@ Content-Type: muLtipart/signed;
               Boundary=SignedBoundaryString
 Content-Transfer-Encoding: qUotED-PRINTABLe
 X-Clacks-Overhead: GNU Terry Pratchett
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 1	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 2	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
 
 
 --SignedBoundaryString

--- a/tests/test_japanese_multipart_signed_iso-2022-jp_over_7bit.txt
+++ b/tests/test_japanese_multipart_signed_iso-2022-jp_over_7bit.txt
@@ -34,6 +34,12 @@ Content-Type: mUlTipART/SIGNED;
               BOUNdAry=SignedBoundaryString
 Content-Transfer-Encoding: 7bit
 X-Clacks-Overhead: GNU Terry Pratchett
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 1	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 2	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
 
 
 --SignedBoundaryString

--- a/tests/test_japanese_multipart_signed_iso-2022-jp_over_base64.txt
+++ b/tests/test_japanese_multipart_signed_iso-2022-jp_over_base64.txt
@@ -34,6 +34,12 @@ Content-Type: multipart/sigNEd;
               BoUnDArY=SignedBoundaryString
 Content-Transfer-Encoding: BASE64
 X-Clacks-Overhead: GNU Terry Pratchett
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 1	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 2	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
 
 
 --SignedBoundaryString

--- a/tests/test_japanese_multipart_signed_iso-2022-jp_over_quoted-printable.txt
+++ b/tests/test_japanese_multipart_signed_iso-2022-jp_over_quoted-printable.txt
@@ -34,6 +34,12 @@ Content-Type: multiparT/SiGNED;
               BOUNDARy=SignedBoundaryString
 Content-Transfer-Encoding: quoTed-PRINTABLE
 X-Clacks-Overhead: GNU Terry Pratchett
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 1	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 2	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
 
 
 --SignedBoundaryString

--- a/tests/test_japanese_multipart_signed_utf-8_over_7bit.txt
+++ b/tests/test_japanese_multipart_signed_utf-8_over_7bit.txt
@@ -34,6 +34,12 @@ Content-Type: MULTIpart/SIGNED;
               bOUNDARY=SignedBoundaryString
 Content-Transfer-Encoding: 7BIT
 X-Clacks-Overhead: GNU Terry Pratchett
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 1	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 2	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
 
 
 --SignedBoundaryString

--- a/tests/test_japanese_multipart_signed_utf-8_over_base64.txt
+++ b/tests/test_japanese_multipart_signed_utf-8_over_base64.txt
@@ -34,6 +34,12 @@ Content-Type: MULTIPaRT/sigNED;
               bOundary=SignedBoundaryString
 Content-Transfer-Encoding: baSe64
 X-Clacks-Overhead: GNU Terry Pratchett
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 1	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 2	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
 
 
 --SignedBoundaryString

--- a/tests/test_japanese_multipart_signed_utf-8_over_quoted-printable.txt
+++ b/tests/test_japanese_multipart_signed_utf-8_over_quoted-printable.txt
@@ -34,6 +34,12 @@ Content-Type: multipARt/signed;
               bOuNdAry=SignedBoundaryString
 Content-Transfer-Encoding: quoteD-PRINTABLE
 X-Clacks-Overhead: GNU Terry Pratchett
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 1	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 2	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
 
 
 --SignedBoundaryString

--- a/tests/test_japanese_plaintext_euc-jp_over_base64.txt
+++ b/tests/test_japanese_plaintext_euc-jp_over_base64.txt
@@ -30,6 +30,12 @@ Resent-Message-ID: <Message-Id-1@example.net>
 Content-Type: TEXt/PLAIn; charset=euC-jP
 Content-Transfer-Encoding: BASE64
 X-Clacks-Overhead: GNU Terry Pratchett
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 1	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 2	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
 
 
 v6ekz8b3pKikyQq7tqTqpMyk66TyCrLmpKzApMOvpL4Kvu+kyqTppPMKza2w2aTOsfy7swq6o8b8

--- a/tests/test_japanese_plaintext_euc-jp_over_quoted-printable.txt
+++ b/tests/test_japanese_plaintext_euc-jp_over_quoted-printable.txt
@@ -30,6 +30,12 @@ Resent-Message-ID: <Message-Id-1@example.net>
 Content-Type: text/plaIN; cHARSET=Euc-jp
 Content-Transfer-Encoding: quoteD-PRINTABLE
 X-Clacks-Overhead: GNU Terry Pratchett
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 1	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 2	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
 
 
 =BF=A7=A4=CF=C6=F7=A4=A8=A4=C9

--- a/tests/test_japanese_plaintext_iso-2022-jp_over_7bit.txt
+++ b/tests/test_japanese_plaintext_iso-2022-jp_over_7bit.txt
@@ -30,6 +30,12 @@ Resent-Message-ID: <Message-Id-1@example.net>
 Content-Type: text/pLAIN; charset=iso-2022-JP
 Content-Transfer-Encoding: 7BIT
 X-Clacks-Overhead: GNU Terry Pratchett
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 1	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 2	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
 
 
 色は匂えど

--- a/tests/test_japanese_plaintext_iso-2022-jp_over_base64.txt
+++ b/tests/test_japanese_plaintext_iso-2022-jp_over_base64.txt
@@ -30,6 +30,12 @@ Resent-Message-ID: <Message-Id-1@example.net>
 Content-Type: TExT/plain; charseT=isO-2022-JP
 Content-Transfer-Encoding: BASE64
 X-Clacks-Overhead: GNU Terry Pratchett
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 1	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 2	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
 
 
 GyRCPyckT0Z3JCgkSRsoQgobJEI7NiRqJEwkayRyGyhCChskQjJmJCxAJEMvJD4bKEIKGyRCPm8k

--- a/tests/test_japanese_plaintext_iso-2022-jp_over_quoted-printable.txt
+++ b/tests/test_japanese_plaintext_iso-2022-jp_over_quoted-printable.txt
@@ -30,6 +30,12 @@ Resent-Message-ID: <Message-Id-1@example.net>
 Content-Type: Text/plain; charsET=isO-2022-JP
 Content-Transfer-Encoding: QUoted-PRINTABLE
 X-Clacks-Overhead: GNU Terry Pratchett
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 1	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 2	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
 
 
 =1B$B?'$OFw$($I=1B(B

--- a/tests/test_japanese_plaintext_utf-8_over_7bit.txt
+++ b/tests/test_japanese_plaintext_utf-8_over_7bit.txt
@@ -30,6 +30,12 @@ Resent-Message-ID: <Message-Id-1@example.net>
 Content-Type: tEXT/pLain; charSeT=UTF-8
 Content-Transfer-Encoding: 7BIT
 X-Clacks-Overhead: GNU Terry Pratchett
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 1	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 2	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
 
 
 色は匂えど

--- a/tests/test_japanese_plaintext_utf-8_over_base64.txt
+++ b/tests/test_japanese_plaintext_utf-8_over_base64.txt
@@ -30,6 +30,12 @@ Resent-Message-ID: <Message-Id-1@example.net>
 Content-Type: TEXT/PLAIN; cHarseT=utf-8
 Content-Transfer-Encoding: BaSE64
 X-Clacks-Overhead: GNU Terry Pratchett
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 1	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 2	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
 
 
 6Imy44Gv5YyC44GI44GpCuaVo+OCiuOBrOOCi+OCkgrmiJHjgYzkuJboqrDjgZ4K5bi444Gq44KJ

--- a/tests/test_japanese_plaintext_utf-8_over_quoted-printable.txt
+++ b/tests/test_japanese_plaintext_utf-8_over_quoted-printable.txt
@@ -30,6 +30,12 @@ Resent-Message-ID: <Message-Id-1@example.net>
 Content-Type: text/plain; CHarSET=UTF-8
 Content-Transfer-Encoding: QUOTEd-PRINTAble
 X-Clacks-Overhead: GNU Terry Pratchett
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 1	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 2	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
 
 
 =E8=89=B2=E3=81=AF=E5=8C=82=E3=81=88=E3=81=A9

--- a/tests/test_korean_multipart_mixed_euc-kr_over_base64.txt
+++ b/tests/test_korean_multipart_mixed_euc-kr_over_base64.txt
@@ -30,6 +30,12 @@ Resent-Message-ID: <Message-Id-1@example.net>
 Content-Type: multiparT/MIxEd; charseT="euC-KR"; BOUNDARY="MixedBoundaryString"
 Content-Transfer-Encoding: BASE64
 X-Clacks-Overhead: GNU Terry Pratchett
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 1	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 2	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
 
 
 --MixedBoundaryString

--- a/tests/test_korean_multipart_mixed_euc-kr_over_quoted-printable.txt
+++ b/tests/test_korean_multipart_mixed_euc-kr_over_quoted-printable.txt
@@ -30,6 +30,12 @@ Resent-Message-ID: <Message-Id-1@example.net>
 Content-Type: multiparT/MIXED; charset="euC-kR"; BoUNDARY="MixedBoundaryString"
 Content-Transfer-Encoding: QUOTEd-priNTABLE
 X-Clacks-Overhead: GNU Terry Pratchett
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 1	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 2	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
 
 
 --MixedBoundaryString

--- a/tests/test_korean_multipart_mixed_utf-8_over_base64.txt
+++ b/tests/test_korean_multipart_mixed_utf-8_over_base64.txt
@@ -30,6 +30,12 @@ Resent-Message-ID: <Message-Id-1@example.net>
 Content-Type: MULTIPART/mixEd; CHARSET="UTF-8"; BOundary="MixedBoundaryString"
 Content-Transfer-Encoding: base64
 X-Clacks-Overhead: GNU Terry Pratchett
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 1	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 2	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
 
 
 --MixedBoundaryString

--- a/tests/test_korean_multipart_mixed_utf-8_over_quoted-printable.txt
+++ b/tests/test_korean_multipart_mixed_utf-8_over_quoted-printable.txt
@@ -30,6 +30,12 @@ Resent-Message-ID: <Message-Id-1@example.net>
 Content-Type: MulTiPART/MIXED; CHARSET="UtF-8"; BoUNDARY="MixedBoundaryString"
 Content-Transfer-Encoding: QUOTED-pRIntable
 X-Clacks-Overhead: GNU Terry Pratchett
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 1	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 2	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
 
 
 --MixedBoundaryString

--- a/tests/test_korean_multipart_related_euc-kr_over_base64.txt
+++ b/tests/test_korean_multipart_related_euc-kr_over_base64.txt
@@ -30,6 +30,12 @@ Resent-Message-ID: <Message-Id-1@example.net>
 Content-Type: MulTipart/relatED; ChARsEt="euc-kr"; boundaRY="RelatedBoundaryString"
 Content-Transfer-Encoding: baSE64
 X-Clacks-Overhead: GNU Terry Pratchett
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 1	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 2	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
 
 
 --RelatedBoundaryString

--- a/tests/test_korean_multipart_related_euc-kr_over_quoted-printable.txt
+++ b/tests/test_korean_multipart_related_euc-kr_over_quoted-printable.txt
@@ -30,6 +30,12 @@ Resent-Message-ID: <Message-Id-1@example.net>
 Content-Type: multipArt/RELATED; ChArset="euc-kr"; bouNDARY="RelatedBoundaryString"
 Content-Transfer-Encoding: QUOTED-PrinTABLE
 X-Clacks-Overhead: GNU Terry Pratchett
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 1	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 2	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
 
 
 --RelatedBoundaryString

--- a/tests/test_korean_multipart_related_utf-8_over_base64.txt
+++ b/tests/test_korean_multipart_related_utf-8_over_base64.txt
@@ -30,6 +30,12 @@ Resent-Message-ID: <Message-Id-1@example.net>
 Content-Type: multipart/relaTed; cHarsET="utF-8"; BoUNDArY="RelatedBoundaryString"
 Content-Transfer-Encoding: Base64
 X-Clacks-Overhead: GNU Terry Pratchett
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 1	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 2	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
 
 
 --RelatedBoundaryString

--- a/tests/test_korean_multipart_related_utf-8_over_quoted-printable.txt
+++ b/tests/test_korean_multipart_related_utf-8_over_quoted-printable.txt
@@ -30,6 +30,12 @@ Resent-Message-ID: <Message-Id-1@example.net>
 Content-Type: multipart/RElATED; ChArSet="utf-8"; boUnDARY="RelatedBoundaryString"
 Content-Transfer-Encoding: QUOTED-PRintaBLe
 X-Clacks-Overhead: GNU Terry Pratchett
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 1	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 2	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
 
 
 --RelatedBoundaryString

--- a/tests/test_korean_multipart_signed_euc-kr_over_base64.txt
+++ b/tests/test_korean_multipart_signed_euc-kr_over_base64.txt
@@ -34,6 +34,12 @@ Content-Type: MULTIPART/SIgned;
               BOUNdAry=SignedBoundaryString
 Content-Transfer-Encoding: base64
 X-Clacks-Overhead: GNU Terry Pratchett
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 1	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 2	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
 
 
 --SignedBoundaryString

--- a/tests/test_korean_multipart_signed_euc-kr_over_quoted-printable.txt
+++ b/tests/test_korean_multipart_signed_euc-kr_over_quoted-printable.txt
@@ -34,6 +34,12 @@ Content-Type: MuLTiPaRt/signED;
               boundary=SignedBoundaryString
 Content-Transfer-Encoding: qUOtED-PRINTAbLe
 X-Clacks-Overhead: GNU Terry Pratchett
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 1	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 2	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
 
 
 --SignedBoundaryString

--- a/tests/test_korean_multipart_signed_utf-8_over_base64.txt
+++ b/tests/test_korean_multipart_signed_utf-8_over_base64.txt
@@ -34,6 +34,12 @@ Content-Type: MULTIPARt/signed;
               BOUNdary=SignedBoundaryString
 Content-Transfer-Encoding: BASE64
 X-Clacks-Overhead: GNU Terry Pratchett
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 1	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 2	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
 
 
 --SignedBoundaryString

--- a/tests/test_korean_multipart_signed_utf-8_over_quoted-printable.txt
+++ b/tests/test_korean_multipart_signed_utf-8_over_quoted-printable.txt
@@ -34,6 +34,12 @@ Content-Type: multiparT/sIGNED;
               bounDaRY=SignedBoundaryString
 Content-Transfer-Encoding: QuOtEd-prinTaBLE
 X-Clacks-Overhead: GNU Terry Pratchett
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 1	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 2	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
 
 
 --SignedBoundaryString

--- a/tests/test_korean_plaintext_euc-kr_over_base64.txt
+++ b/tests/test_korean_plaintext_euc-kr_over_base64.txt
@@ -30,6 +30,12 @@ Resent-Message-ID: <Message-Id-1@example.net>
 Content-Type: TExT/plain; chaRSeT=EUC-KR
 Content-Transfer-Encoding: BASE64
 X-Clacks-Overhead: GNU Terry Pratchett
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 1	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 2	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
 
 
 xbC9usDHILDtwK/BtrDHwLogwNS8+rOiuK4guLizqr7fIMfPsO0gxq+6sMfRILHivPrAuiDHyr/k

--- a/tests/test_korean_plaintext_euc-kr_over_quoted-printable.txt
+++ b/tests/test_korean_plaintext_euc-kr_over_quoted-printable.txt
@@ -30,6 +30,12 @@ Resent-Message-ID: <Message-Id-1@example.net>
 Content-Type: teXt/pLain; ChARSEt=EUc-KR
 Content-Transfer-Encoding: quoted-printabLe
 X-Clacks-Overhead: GNU Terry Pratchett
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 1	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 2	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
 
 
 =C5=B0=BD=BA=C0=C7 =B0=ED=C0=AF=C1=B6=B0=C7=C0=BA =C0=D4=BC=FA=B3=A2=B8=AE =

--- a/tests/test_korean_plaintext_utf-8_over_base64.txt
+++ b/tests/test_korean_plaintext_utf-8_over_base64.txt
@@ -30,6 +30,12 @@ Resent-Message-ID: <Message-Id-1@example.net>
 Content-Type: Text/Plain; charSet=UTF-8
 Content-Transfer-Encoding: BAsE64
 X-Clacks-Overhead: GNU Terry Pratchett
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 1	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 2	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
 
 
 7YKk7Iqk7J2YIOqzoOycoOyhsOqxtOydgCDsnoXsiKDrgbzrpqwg66eM64KY7JW8IO2VmOqzoCDt

--- a/tests/test_korean_plaintext_utf-8_over_quoted-printable.txt
+++ b/tests/test_korean_plaintext_utf-8_over_quoted-printable.txt
@@ -30,6 +30,12 @@ Resent-Message-ID: <Message-Id-1@example.net>
 Content-Type: texT/PlAIN; CHARSeT=Utf-8
 Content-Transfer-Encoding: quoted-prinTABLe
 X-Clacks-Overhead: GNU Terry Pratchett
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 1	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 2	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
 
 
 =ED=82=A4=EC=8A=A4=EC=9D=98 =EA=B3=A0=EC=9C=A0=EC=A1=B0=EA=B1=B4=EC=9D=80 =

--- a/tests/test_polish_multipart_mixed_iso-8859-2_over_base64.txt
+++ b/tests/test_polish_multipart_mixed_iso-8859-2_over_base64.txt
@@ -30,6 +30,12 @@ Resent-Message-ID: <Message-Id-1@example.net>
 Content-Type: MULTIPART/Mixed; charseT="ISO-8859-2"; boUndary="MixedBoundaryString"
 Content-Transfer-Encoding: base64
 X-Clacks-Overhead: GNU Terry Pratchett
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 1	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 2	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
 
 
 --MixedBoundaryString

--- a/tests/test_polish_multipart_mixed_iso-8859-2_over_quoted-printable.txt
+++ b/tests/test_polish_multipart_mixed_iso-8859-2_over_quoted-printable.txt
@@ -30,6 +30,12 @@ Resent-Message-ID: <Message-Id-1@example.net>
 Content-Type: multipart/mIxed; charset="iso-8859-2"; BOUNDARY="MixedBoundaryString"
 Content-Transfer-Encoding: quoted-PRINTABLE
 X-Clacks-Overhead: GNU Terry Pratchett
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 1	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 2	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
 
 
 --MixedBoundaryString

--- a/tests/test_polish_multipart_mixed_utf-8_over_base64.txt
+++ b/tests/test_polish_multipart_mixed_utf-8_over_base64.txt
@@ -30,6 +30,12 @@ Resent-Message-ID: <Message-Id-1@example.net>
 Content-Type: multipart/mIXED; charset="utf-8"; bouNDARY="MixedBoundaryString"
 Content-Transfer-Encoding: BASE64
 X-Clacks-Overhead: GNU Terry Pratchett
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 1	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 2	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
 
 
 --MixedBoundaryString

--- a/tests/test_polish_multipart_mixed_utf-8_over_quoted-printable.txt
+++ b/tests/test_polish_multipart_mixed_utf-8_over_quoted-printable.txt
@@ -30,6 +30,12 @@ Resent-Message-ID: <Message-Id-1@example.net>
 Content-Type: multipart/mixed; cHARset="Utf-8"; boundary="MixedBoundaryString"
 Content-Transfer-Encoding: quoteD-PRintable
 X-Clacks-Overhead: GNU Terry Pratchett
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 1	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 2	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
 
 
 --MixedBoundaryString

--- a/tests/test_polish_multipart_related_iso-8859-2_over_base64.txt
+++ b/tests/test_polish_multipart_related_iso-8859-2_over_base64.txt
@@ -30,6 +30,12 @@ Resent-Message-ID: <Message-Id-1@example.net>
 Content-Type: MULTIPART/rElated; charSeT="ISO-8859-2"; BOUNdaRy="RelatedBoundaryString"
 Content-Transfer-Encoding: bAsE64
 X-Clacks-Overhead: GNU Terry Pratchett
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 1	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 2	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
 
 
 --RelatedBoundaryString

--- a/tests/test_polish_multipart_related_iso-8859-2_over_quoted-printable.txt
+++ b/tests/test_polish_multipart_related_iso-8859-2_over_quoted-printable.txt
@@ -30,6 +30,12 @@ Resent-Message-ID: <Message-Id-1@example.net>
 Content-Type: MULTIPaRt/related; CHARsEt="IsO-8859-2"; boundARy="RelatedBoundaryString"
 Content-Transfer-Encoding: qUOTEd-printABlE
 X-Clacks-Overhead: GNU Terry Pratchett
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 1	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 2	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
 
 
 --RelatedBoundaryString

--- a/tests/test_polish_multipart_related_utf-8_over_base64.txt
+++ b/tests/test_polish_multipart_related_utf-8_over_base64.txt
@@ -30,6 +30,12 @@ Resent-Message-ID: <Message-Id-1@example.net>
 Content-Type: MultIpart/RelatED; cHARSET="UTF-8"; BOUnDArY="RelatedBoundaryString"
 Content-Transfer-Encoding: BASE64
 X-Clacks-Overhead: GNU Terry Pratchett
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 1	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 2	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
 
 
 --RelatedBoundaryString

--- a/tests/test_polish_multipart_related_utf-8_over_quoted-printable.txt
+++ b/tests/test_polish_multipart_related_utf-8_over_quoted-printable.txt
@@ -30,6 +30,12 @@ Resent-Message-ID: <Message-Id-1@example.net>
 Content-Type: multipart/reLATED; CHARSeT="utf-8"; bouNDARY="RelatedBoundaryString"
 Content-Transfer-Encoding: QUOTED-PRintable
 X-Clacks-Overhead: GNU Terry Pratchett
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 1	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 2	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
 
 
 --RelatedBoundaryString

--- a/tests/test_polish_multipart_signed_iso-8859-2_over_base64.txt
+++ b/tests/test_polish_multipart_signed_iso-8859-2_over_base64.txt
@@ -34,6 +34,12 @@ Content-Type: MulTiparT/SIgneD;
               bOunDARY=SignedBoundaryString
 Content-Transfer-Encoding: BaSe64
 X-Clacks-Overhead: GNU Terry Pratchett
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 1	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 2	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
 
 
 --SignedBoundaryString

--- a/tests/test_polish_multipart_signed_iso-8859-2_over_quoted-printable.txt
+++ b/tests/test_polish_multipart_signed_iso-8859-2_over_quoted-printable.txt
@@ -34,6 +34,12 @@ Content-Type: MUlTIpart/signed;
               boUNDARY=SignedBoundaryString
 Content-Transfer-Encoding: QUOTeD-PriNTABLE
 X-Clacks-Overhead: GNU Terry Pratchett
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 1	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 2	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
 
 
 --SignedBoundaryString

--- a/tests/test_polish_multipart_signed_utf-8_over_base64.txt
+++ b/tests/test_polish_multipart_signed_utf-8_over_base64.txt
@@ -34,6 +34,12 @@ Content-Type: multiparT/sIGNED;
               boundArY=SignedBoundaryString
 Content-Transfer-Encoding: BAsE64
 X-Clacks-Overhead: GNU Terry Pratchett
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 1	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 2	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
 
 
 --SignedBoundaryString

--- a/tests/test_polish_multipart_signed_utf-8_over_quoted-printable.txt
+++ b/tests/test_polish_multipart_signed_utf-8_over_quoted-printable.txt
@@ -34,6 +34,12 @@ Content-Type: multipaRt/SiGned;
               bOUNDaRy=SignedBoundaryString
 Content-Transfer-Encoding: quoted-pRINTABLE
 X-Clacks-Overhead: GNU Terry Pratchett
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 1	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 2	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
 
 
 --SignedBoundaryString

--- a/tests/test_polish_plaintext_iso-8859-2_over_base64.txt
+++ b/tests/test_polish_plaintext_iso-8859-2_over_base64.txt
@@ -30,6 +30,12 @@ Resent-Message-ID: <Message-Id-1@example.net>
 Content-Type: TEXT/pLain; charsET=IsO-8859-2
 Content-Transfer-Encoding: bAsE64
 X-Clacks-Overhead: GNU Terry Pratchett
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 1	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 2	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
 
 
 SmW/dSBrbLF0dywgc3Cz82S8IEZpbm9tIGN66rbmIGdyeSBoYfFiIQpQ82pkvL9lLCBrafEgdOog

--- a/tests/test_polish_plaintext_iso-8859-2_over_quoted-printable.txt
+++ b/tests/test_polish_plaintext_iso-8859-2_over_quoted-printable.txt
@@ -30,6 +30,12 @@ Resent-Message-ID: <Message-Id-1@example.net>
 Content-Type: texT/pLain; charset=iso-8859-2
 Content-Transfer-Encoding: QUOTED-PrIntAbLE
 X-Clacks-Overhead: GNU Terry Pratchett
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 1	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 2	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
 
 
 Je=BFu kl=B1tw, sp=B3=F3d=BC Finom cz=EA=B6=E6 gry ha=F1b!

--- a/tests/test_polish_plaintext_utf-8_over_base64.txt
+++ b/tests/test_polish_plaintext_utf-8_over_base64.txt
@@ -30,6 +30,12 @@ Resent-Message-ID: <Message-Id-1@example.net>
 Content-Type: text/plAIn; cHARSET=UTF-8
 Content-Transfer-Encoding: base64
 X-Clacks-Overhead: GNU Terry Pratchett
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 1	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 2	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
 
 
 SmXFvHUga2zEhXR3LCBzcMWCw7NkxbogRmlub20gY3rEmcWbxIcgZ3J5IGhhxYRiIQpQw7NqZMW6

--- a/tests/test_polish_plaintext_utf-8_over_quoted-printable.txt
+++ b/tests/test_polish_plaintext_utf-8_over_quoted-printable.txt
@@ -30,6 +30,12 @@ Resent-Message-ID: <Message-Id-1@example.net>
 Content-Type: TExT/PLAIN; CHARSET=UTF-8
 Content-Transfer-Encoding: QuOted-prInTaBLe
 X-Clacks-Overhead: GNU Terry Pratchett
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 1	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 2	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
 
 
 Je=C5=BCu kl=C4=85tw, sp=C5=82=C3=B3d=C5=BA Finom cz=C4=99=C5=9B=C4=87 gry =


### PR DESCRIPTION
Add tests for all characters permitted in header field names and bodies, as outlined in [RFC 5322](https://www.rfc-editor.org/rfc/rfc5322#section-2.2).

Use two distinct values for the same custom header to ensure the preservation of all values. Divide each example value across multiple lines to verify proper unfolding functionality.

The test values encompass a space and a horizontal tab for thoroughness. Placing the space and tab adjacently will prevent the collapse of multiple whitespace characters into a single one.