### PR TITLE
[ISSUE-49] Fix panic on `windows-874` (and other correct `windows-`) labels

### DIFF
--- a/decoders.go
+++ b/decoders.go
@@ -18,8 +18,16 @@ import (
 
 func decodeHeader(s string) (string, error) {
 	CharsetReader := func(label string, input io.Reader) (io.Reader, error) {
-		label = strings.Replace(label, "windows-", "cp", -1)
 		enc, _ := charset.Lookup(label)
+		if enc == nil {
+			normalizedLabel := strings.Replace(label, "windows-", "cp", -1)
+			enc, _ = charset.Lookup(normalizedLabel)
+		}
+		if enc == nil {
+			return nil, fmt.Errorf(
+				"letters.decoders.decodeHeader.CharsetReader: cannot lookup encoding %s",
+				label)
+		}
 		return enc.NewDecoder().Reader(input), nil
 	}
 	mimeDecoder := mime.WordDecoder{CharsetReader: CharsetReader}

--- a/letters_test.go
+++ b/letters_test.go
@@ -26280,3 +26280,4215 @@ Chwyć małżonkę, strój bądź pleśń z fugi.`,
 
 	testEmailFromFile(t, fp, expectedEmail)
 }
+
+func TestParseEmailThaiPlaintextIso885911OverBase64(t *testing.T) {
+	fp := "tests/test_thai_plaintext_iso-8859-11_over_base64.txt"
+	tz, _ := time.LoadLocation("Asia/Bangkok")
+	expectedDate, _ := time.Parse(
+		time.RFC1123Z+" (MST)",
+		time.Date(2019, time.April, 1, 7, 55, 0, 0, tz).Format(time.RFC1123Z+" (MST)"))
+	expectedEmail := Email{
+		Headers: Headers{
+			Date:    expectedDate,
+			Subject: "📧 Test แพนแกรมภาษาไทย",
+			ReplyTo: []*mail.Address{
+				{
+					Name:    "อลิซ ผู้ส่งจดหมาย",
+					Address: "alis.phusngcdhmay@example.net",
+				},
+			},
+			Sender: &mail.Address{
+				Name:    "อลิซ ผู้ส่งจดหมาย",
+				Address: "alis.phusngcdhmay@example.com",
+			},
+			From: []*mail.Address{
+				{
+					Name:    "อลิซ ผู้ส่งจดหมาย",
+					Address: "alis.phusngcdhmay@example.com",
+				},
+				{
+					Name:    "อลิซ ผู้ส่งจดหมาย",
+					Address: "alis.phusngcdhmay@example.net",
+				},
+			},
+			To: []*mail.Address{
+				{
+					Name:    "บ๊อบ ผู้รับ",
+					Address: "bob.phurab@example.com",
+				},
+				{
+					Name:    "คาโรล ผู้รับ",
+					Address: "carol.phurab@example.com",
+				},
+			},
+			Cc: []*mail.Address{
+				{
+					Name:    "แดน ผู้รับ",
+					Address: "dan.phurab@example.com",
+				},
+				{
+					Name:    "อีฟ ผู้รับ",
+					Address: "eve.phurab@example.com",
+				},
+			},
+			Bcc: []*mail.Address{
+				{
+					Name:    "แฟรงค์ ผู้รับ",
+					Address: "frank.phurab@example.com",
+				},
+				{
+					Name:    "เกรซ ผู้รับ",
+					Address: "grace.phurab@example.com",
+				},
+			},
+			MessageID:  "Message-Id-1@example.com",
+			InReplyTo:  []MessageId{"Message-Id-0@example.com"},
+			References: []MessageId{"Message-Id-0@example.com"},
+			Comments:   "Message Header Comment",
+			Keywords:   []string{"Keyword 1", "Keyword 2"},
+			ResentDate: expectedDate,
+			ResentFrom: []*mail.Address{
+				{
+					Name:    "อลิซ ผู้ส่งจดหมาย",
+					Address: "alis.phusngcdhmay@example.net",
+				},
+				{
+					Name:    "อลิซ ผู้ส่งจดหมาย",
+					Address: "alis.phusngcdhmay@example.com",
+				},
+			},
+			ResentSender: &mail.Address{
+				Name:    "อลิซ ผู้ส่งจดหมาย",
+				Address: "alis.phusngcdhmay@example.net",
+			},
+			ResentTo: []*mail.Address{
+				{
+					Name:    "บ๊อบ ผู้รับ",
+					Address: "bob.phurab@example.net",
+				},
+				{
+					Name:    "คาโรล ผู้รับ",
+					Address: "carol.phurab@example.net",
+				},
+			},
+			ResentCc: []*mail.Address{
+				{
+					Name:    "แดน ผู้รับ",
+					Address: "dan.phurab@example.net",
+				},
+				{
+					Name:    "อีฟ ผู้รับ",
+					Address: "eve.phurab@example.net",
+				},
+			},
+			ResentBcc: []*mail.Address{
+				{
+					Name:    "แฟรงค์ ผู้รับ",
+					Address: "frank.phurab@example.net",
+				},
+				{
+					Name:    "เกรซ ผู้รับ",
+					Address: "grace.phurab@example.net",
+				},
+			},
+			ResentMessageID: "Message-Id-1@example.net",
+			ContentType: ContentTypeHeader{
+				ContentType: "text/plain",
+				Params: map[string]string{
+					"charset": "iso-8859-11",
+				},
+			},
+			ExtraHeaders: map[string][]string{
+				"X-Clacks-Overhead": {"GNU Terry Pratchett"},
+			},
+		},
+		Text: `เป็นมนุษย์สุดประเสริฐเลิศคุณค่า กว่าบรรดาฝูงสัตว์เดรัจฉาน จงฝ่าฟันพัฒนาวิชาการ อย่าล้างผลาญฤๅเข่นฆ่าบีฑาใคร ไม่ถือโทษโกรธแช่งซัดฮึดฮัดด่า หัดอภัยเหมือนกีฬาอัชฌาสัย ปฏิบัติประพฤติกฎกำหนดใจ พูดจาให้จ๊ะๆ จ๋าๆ น่าฟังเอยฯ
+
+นายสังฆภัณฑ์ เฮงพิทักษ์ฝั่ง ผู้เฒ่าซึ่งมีอาชีพเป็นฅนขายฃวด ถูกตำรวจปฏิบัติการจับฟ้องศาล ฐานลักนาฬิกาคุณหญิงฉัตรชฎา ฌานสมาธิ`,
+	}
+
+	testEmailFromFile(t, fp, expectedEmail)
+}
+
+func TestParseEmailThaiPlaintextIso885911OverQuotedprintable(t *testing.T) {
+	fp := "tests/test_thai_plaintext_iso-8859-11_over_quoted-printable.txt"
+	tz, _ := time.LoadLocation("Asia/Bangkok")
+	expectedDate, _ := time.Parse(
+		time.RFC1123Z+" (MST)",
+		time.Date(2019, time.April, 1, 7, 55, 0, 0, tz).Format(time.RFC1123Z+" (MST)"))
+	expectedEmail := Email{
+		Headers: Headers{
+			Date:    expectedDate,
+			Subject: "📧 Test แพนแกรมภาษาไทย",
+			ReplyTo: []*mail.Address{
+				{
+					Name:    "อลิซ ผู้ส่งจดหมาย",
+					Address: "alis.phusngcdhmay@example.net",
+				},
+			},
+			Sender: &mail.Address{
+				Name:    "อลิซ ผู้ส่งจดหมาย",
+				Address: "alis.phusngcdhmay@example.com",
+			},
+			From: []*mail.Address{
+				{
+					Name:    "อลิซ ผู้ส่งจดหมาย",
+					Address: "alis.phusngcdhmay@example.com",
+				},
+				{
+					Name:    "อลิซ ผู้ส่งจดหมาย",
+					Address: "alis.phusngcdhmay@example.net",
+				},
+			},
+			To: []*mail.Address{
+				{
+					Name:    "บ๊อบ ผู้รับ",
+					Address: "bob.phurab@example.com",
+				},
+				{
+					Name:    "คาโรล ผู้รับ",
+					Address: "carol.phurab@example.com",
+				},
+			},
+			Cc: []*mail.Address{
+				{
+					Name:    "แดน ผู้รับ",
+					Address: "dan.phurab@example.com",
+				},
+				{
+					Name:    "อีฟ ผู้รับ",
+					Address: "eve.phurab@example.com",
+				},
+			},
+			Bcc: []*mail.Address{
+				{
+					Name:    "แฟรงค์ ผู้รับ",
+					Address: "frank.phurab@example.com",
+				},
+				{
+					Name:    "เกรซ ผู้รับ",
+					Address: "grace.phurab@example.com",
+				},
+			},
+			MessageID:  "Message-Id-1@example.com",
+			InReplyTo:  []MessageId{"Message-Id-0@example.com"},
+			References: []MessageId{"Message-Id-0@example.com"},
+			Comments:   "Message Header Comment",
+			Keywords:   []string{"Keyword 1", "Keyword 2"},
+			ResentDate: expectedDate,
+			ResentFrom: []*mail.Address{
+				{
+					Name:    "อลิซ ผู้ส่งจดหมาย",
+					Address: "alis.phusngcdhmay@example.net",
+				},
+				{
+					Name:    "อลิซ ผู้ส่งจดหมาย",
+					Address: "alis.phusngcdhmay@example.com",
+				},
+			},
+			ResentSender: &mail.Address{
+				Name:    "อลิซ ผู้ส่งจดหมาย",
+				Address: "alis.phusngcdhmay@example.net",
+			},
+			ResentTo: []*mail.Address{
+				{
+					Name:    "บ๊อบ ผู้รับ",
+					Address: "bob.phurab@example.net",
+				},
+				{
+					Name:    "คาโรล ผู้รับ",
+					Address: "carol.phurab@example.net",
+				},
+			},
+			ResentCc: []*mail.Address{
+				{
+					Name:    "แดน ผู้รับ",
+					Address: "dan.phurab@example.net",
+				},
+				{
+					Name:    "อีฟ ผู้รับ",
+					Address: "eve.phurab@example.net",
+				},
+			},
+			ResentBcc: []*mail.Address{
+				{
+					Name:    "แฟรงค์ ผู้รับ",
+					Address: "frank.phurab@example.net",
+				},
+				{
+					Name:    "เกรซ ผู้รับ",
+					Address: "grace.phurab@example.net",
+				},
+			},
+			ResentMessageID: "Message-Id-1@example.net",
+			ContentType: ContentTypeHeader{
+				ContentType: "text/plain",
+				Params: map[string]string{
+					"charset": "iso-8859-11",
+				},
+			},
+			ExtraHeaders: map[string][]string{
+				"X-Clacks-Overhead": {"GNU Terry Pratchett"},
+			},
+		},
+		Text: `เป็นมนุษย์สุดประเสริฐเลิศคุณค่า กว่าบรรดาฝูงสัตว์เดรัจฉาน จงฝ่าฟันพัฒนาวิชาการ อย่าล้างผลาญฤๅเข่นฆ่าบีฑาใคร ไม่ถือโทษโกรธแช่งซัดฮึดฮัดด่า หัดอภัยเหมือนกีฬาอัชฌาสัย ปฏิบัติประพฤติกฎกำหนดใจ พูดจาให้จ๊ะๆ จ๋าๆ น่าฟังเอยฯ
+
+นายสังฆภัณฑ์ เฮงพิทักษ์ฝั่ง ผู้เฒ่าซึ่งมีอาชีพเป็นฅนขายฃวด ถูกตำรวจปฏิบัติการจับฟ้องศาล ฐานลักนาฬิกาคุณหญิงฉัตรชฎา ฌานสมาธิ`,
+	}
+
+	testEmailFromFile(t, fp, expectedEmail)
+}
+
+func TestParseEmailThaiPlaintextWindows874OverBase64(t *testing.T) {
+	fp := "tests/test_thai_plaintext_windows-874_over_base64.txt"
+	tz, _ := time.LoadLocation("Asia/Bangkok")
+	expectedDate, _ := time.Parse(
+		time.RFC1123Z+" (MST)",
+		time.Date(2019, time.April, 1, 7, 55, 0, 0, tz).Format(time.RFC1123Z+" (MST)"))
+	expectedEmail := Email{
+		Headers: Headers{
+			Date:    expectedDate,
+			Subject: "📧 Test แพนแกรมภาษาไทย",
+			ReplyTo: []*mail.Address{
+				{
+					Name:    "อลิซ ผู้ส่งจดหมาย",
+					Address: "alis.phusngcdhmay@example.net",
+				},
+			},
+			Sender: &mail.Address{
+				Name:    "อลิซ ผู้ส่งจดหมาย",
+				Address: "alis.phusngcdhmay@example.com",
+			},
+			From: []*mail.Address{
+				{
+					Name:    "อลิซ ผู้ส่งจดหมาย",
+					Address: "alis.phusngcdhmay@example.com",
+				},
+				{
+					Name:    "อลิซ ผู้ส่งจดหมาย",
+					Address: "alis.phusngcdhmay@example.net",
+				},
+			},
+			To: []*mail.Address{
+				{
+					Name:    "บ๊อบ ผู้รับ",
+					Address: "bob.phurab@example.com",
+				},
+				{
+					Name:    "คาโรล ผู้รับ",
+					Address: "carol.phurab@example.com",
+				},
+			},
+			Cc: []*mail.Address{
+				{
+					Name:    "แดน ผู้รับ",
+					Address: "dan.phurab@example.com",
+				},
+				{
+					Name:    "อีฟ ผู้รับ",
+					Address: "eve.phurab@example.com",
+				},
+			},
+			Bcc: []*mail.Address{
+				{
+					Name:    "แฟรงค์ ผู้รับ",
+					Address: "frank.phurab@example.com",
+				},
+				{
+					Name:    "เกรซ ผู้รับ",
+					Address: "grace.phurab@example.com",
+				},
+			},
+			MessageID:  "Message-Id-1@example.com",
+			InReplyTo:  []MessageId{"Message-Id-0@example.com"},
+			References: []MessageId{"Message-Id-0@example.com"},
+			Comments:   "Message Header Comment",
+			Keywords:   []string{"Keyword 1", "Keyword 2"},
+			ResentDate: expectedDate,
+			ResentFrom: []*mail.Address{
+				{
+					Name:    "อลิซ ผู้ส่งจดหมาย",
+					Address: "alis.phusngcdhmay@example.net",
+				},
+				{
+					Name:    "อลิซ ผู้ส่งจดหมาย",
+					Address: "alis.phusngcdhmay@example.com",
+				},
+			},
+			ResentSender: &mail.Address{
+				Name:    "อลิซ ผู้ส่งจดหมาย",
+				Address: "alis.phusngcdhmay@example.net",
+			},
+			ResentTo: []*mail.Address{
+				{
+					Name:    "บ๊อบ ผู้รับ",
+					Address: "bob.phurab@example.net",
+				},
+				{
+					Name:    "คาโรล ผู้รับ",
+					Address: "carol.phurab@example.net",
+				},
+			},
+			ResentCc: []*mail.Address{
+				{
+					Name:    "แดน ผู้รับ",
+					Address: "dan.phurab@example.net",
+				},
+				{
+					Name:    "อีฟ ผู้รับ",
+					Address: "eve.phurab@example.net",
+				},
+			},
+			ResentBcc: []*mail.Address{
+				{
+					Name:    "แฟรงค์ ผู้รับ",
+					Address: "frank.phurab@example.net",
+				},
+				{
+					Name:    "เกรซ ผู้รับ",
+					Address: "grace.phurab@example.net",
+				},
+			},
+			ResentMessageID: "Message-Id-1@example.net",
+			ContentType: ContentTypeHeader{
+				ContentType: "text/plain",
+				Params: map[string]string{
+					"charset": "windows-874",
+				},
+			},
+			ExtraHeaders: map[string][]string{
+				"X-Clacks-Overhead": {"GNU Terry Pratchett"},
+			},
+		},
+		Text: `เป็นมนุษย์สุดประเสริฐเลิศคุณค่า กว่าบรรดาฝูงสัตว์เดรัจฉาน จงฝ่าฟันพัฒนาวิชาการ อย่าล้างผลาญฤๅเข่นฆ่าบีฑาใคร ไม่ถือโทษโกรธแช่งซัดฮึดฮัดด่า หัดอภัยเหมือนกีฬาอัชฌาสัย ปฏิบัติประพฤติกฎกำหนดใจ พูดจาให้จ๊ะๆ จ๋าๆ น่าฟังเอยฯ
+
+นายสังฆภัณฑ์ เฮงพิทักษ์ฝั่ง ผู้เฒ่าซึ่งมีอาชีพเป็นฅนขายฃวด ถูกตำรวจปฏิบัติการจับฟ้องศาล ฐานลักนาฬิกาคุณหญิงฉัตรชฎา ฌานสมาธิ`,
+	}
+
+	testEmailFromFile(t, fp, expectedEmail)
+}
+
+func TestParseEmailThaiPlaintextWindows874OverQuotedprintable(t *testing.T) {
+	fp := "tests/test_thai_plaintext_windows-874_over_quoted-printable.txt"
+	tz, _ := time.LoadLocation("Asia/Bangkok")
+	expectedDate, _ := time.Parse(
+		time.RFC1123Z+" (MST)",
+		time.Date(2019, time.April, 1, 7, 55, 0, 0, tz).Format(time.RFC1123Z+" (MST)"))
+	expectedEmail := Email{
+		Headers: Headers{
+			Date:    expectedDate,
+			Subject: "📧 Test แพนแกรมภาษาไทย",
+			ReplyTo: []*mail.Address{
+				{
+					Name:    "อลิซ ผู้ส่งจดหมาย",
+					Address: "alis.phusngcdhmay@example.net",
+				},
+			},
+			Sender: &mail.Address{
+				Name:    "อลิซ ผู้ส่งจดหมาย",
+				Address: "alis.phusngcdhmay@example.com",
+			},
+			From: []*mail.Address{
+				{
+					Name:    "อลิซ ผู้ส่งจดหมาย",
+					Address: "alis.phusngcdhmay@example.com",
+				},
+				{
+					Name:    "อลิซ ผู้ส่งจดหมาย",
+					Address: "alis.phusngcdhmay@example.net",
+				},
+			},
+			To: []*mail.Address{
+				{
+					Name:    "บ๊อบ ผู้รับ",
+					Address: "bob.phurab@example.com",
+				},
+				{
+					Name:    "คาโรล ผู้รับ",
+					Address: "carol.phurab@example.com",
+				},
+			},
+			Cc: []*mail.Address{
+				{
+					Name:    "แดน ผู้รับ",
+					Address: "dan.phurab@example.com",
+				},
+				{
+					Name:    "อีฟ ผู้รับ",
+					Address: "eve.phurab@example.com",
+				},
+			},
+			Bcc: []*mail.Address{
+				{
+					Name:    "แฟรงค์ ผู้รับ",
+					Address: "frank.phurab@example.com",
+				},
+				{
+					Name:    "เกรซ ผู้รับ",
+					Address: "grace.phurab@example.com",
+				},
+			},
+			MessageID:  "Message-Id-1@example.com",
+			InReplyTo:  []MessageId{"Message-Id-0@example.com"},
+			References: []MessageId{"Message-Id-0@example.com"},
+			Comments:   "Message Header Comment",
+			Keywords:   []string{"Keyword 1", "Keyword 2"},
+			ResentDate: expectedDate,
+			ResentFrom: []*mail.Address{
+				{
+					Name:    "อลิซ ผู้ส่งจดหมาย",
+					Address: "alis.phusngcdhmay@example.net",
+				},
+				{
+					Name:    "อลิซ ผู้ส่งจดหมาย",
+					Address: "alis.phusngcdhmay@example.com",
+				},
+			},
+			ResentSender: &mail.Address{
+				Name:    "อลิซ ผู้ส่งจดหมาย",
+				Address: "alis.phusngcdhmay@example.net",
+			},
+			ResentTo: []*mail.Address{
+				{
+					Name:    "บ๊อบ ผู้รับ",
+					Address: "bob.phurab@example.net",
+				},
+				{
+					Name:    "คาโรล ผู้รับ",
+					Address: "carol.phurab@example.net",
+				},
+			},
+			ResentCc: []*mail.Address{
+				{
+					Name:    "แดน ผู้รับ",
+					Address: "dan.phurab@example.net",
+				},
+				{
+					Name:    "อีฟ ผู้รับ",
+					Address: "eve.phurab@example.net",
+				},
+			},
+			ResentBcc: []*mail.Address{
+				{
+					Name:    "แฟรงค์ ผู้รับ",
+					Address: "frank.phurab@example.net",
+				},
+				{
+					Name:    "เกรซ ผู้รับ",
+					Address: "grace.phurab@example.net",
+				},
+			},
+			ResentMessageID: "Message-Id-1@example.net",
+			ContentType: ContentTypeHeader{
+				ContentType: "text/plain",
+				Params: map[string]string{
+					"charset": "windows-874",
+				},
+			},
+			ExtraHeaders: map[string][]string{
+				"X-Clacks-Overhead": {"GNU Terry Pratchett"},
+			},
+		},
+		Text: `เป็นมนุษย์สุดประเสริฐเลิศคุณค่า กว่าบรรดาฝูงสัตว์เดรัจฉาน จงฝ่าฟันพัฒนาวิชาการ อย่าล้างผลาญฤๅเข่นฆ่าบีฑาใคร ไม่ถือโทษโกรธแช่งซัดฮึดฮัดด่า หัดอภัยเหมือนกีฬาอัชฌาสัย ปฏิบัติประพฤติกฎกำหนดใจ พูดจาให้จ๊ะๆ จ๋าๆ น่าฟังเอยฯ
+
+นายสังฆภัณฑ์ เฮงพิทักษ์ฝั่ง ผู้เฒ่าซึ่งมีอาชีพเป็นฅนขายฃวด ถูกตำรวจปฏิบัติการจับฟ้องศาล ฐานลักนาฬิกาคุณหญิงฉัตรชฎา ฌานสมาธิ`,
+	}
+
+	testEmailFromFile(t, fp, expectedEmail)
+}
+
+func TestParseEmailThaiPlaintextTis620OverBase64(t *testing.T) {
+	fp := "tests/test_thai_plaintext_tis-620_over_base64.txt"
+	tz, _ := time.LoadLocation("Asia/Bangkok")
+	expectedDate, _ := time.Parse(
+		time.RFC1123Z+" (MST)",
+		time.Date(2019, time.April, 1, 7, 55, 0, 0, tz).Format(time.RFC1123Z+" (MST)"))
+	expectedEmail := Email{
+		Headers: Headers{
+			Date:    expectedDate,
+			Subject: "📧 Test แพนแกรมภาษาไทย",
+			ReplyTo: []*mail.Address{
+				{
+					Name:    "อลิซ ผู้ส่งจดหมาย",
+					Address: "alis.phusngcdhmay@example.net",
+				},
+			},
+			Sender: &mail.Address{
+				Name:    "อลิซ ผู้ส่งจดหมาย",
+				Address: "alis.phusngcdhmay@example.com",
+			},
+			From: []*mail.Address{
+				{
+					Name:    "อลิซ ผู้ส่งจดหมาย",
+					Address: "alis.phusngcdhmay@example.com",
+				},
+				{
+					Name:    "อลิซ ผู้ส่งจดหมาย",
+					Address: "alis.phusngcdhmay@example.net",
+				},
+			},
+			To: []*mail.Address{
+				{
+					Name:    "บ๊อบ ผู้รับ",
+					Address: "bob.phurab@example.com",
+				},
+				{
+					Name:    "คาโรล ผู้รับ",
+					Address: "carol.phurab@example.com",
+				},
+			},
+			Cc: []*mail.Address{
+				{
+					Name:    "แดน ผู้รับ",
+					Address: "dan.phurab@example.com",
+				},
+				{
+					Name:    "อีฟ ผู้รับ",
+					Address: "eve.phurab@example.com",
+				},
+			},
+			Bcc: []*mail.Address{
+				{
+					Name:    "แฟรงค์ ผู้รับ",
+					Address: "frank.phurab@example.com",
+				},
+				{
+					Name:    "เกรซ ผู้รับ",
+					Address: "grace.phurab@example.com",
+				},
+			},
+			MessageID:  "Message-Id-1@example.com",
+			InReplyTo:  []MessageId{"Message-Id-0@example.com"},
+			References: []MessageId{"Message-Id-0@example.com"},
+			Comments:   "Message Header Comment",
+			Keywords:   []string{"Keyword 1", "Keyword 2"},
+			ResentDate: expectedDate,
+			ResentFrom: []*mail.Address{
+				{
+					Name:    "อลิซ ผู้ส่งจดหมาย",
+					Address: "alis.phusngcdhmay@example.net",
+				},
+				{
+					Name:    "อลิซ ผู้ส่งจดหมาย",
+					Address: "alis.phusngcdhmay@example.com",
+				},
+			},
+			ResentSender: &mail.Address{
+				Name:    "อลิซ ผู้ส่งจดหมาย",
+				Address: "alis.phusngcdhmay@example.net",
+			},
+			ResentTo: []*mail.Address{
+				{
+					Name:    "บ๊อบ ผู้รับ",
+					Address: "bob.phurab@example.net",
+				},
+				{
+					Name:    "คาโรล ผู้รับ",
+					Address: "carol.phurab@example.net",
+				},
+			},
+			ResentCc: []*mail.Address{
+				{
+					Name:    "แดน ผู้รับ",
+					Address: "dan.phurab@example.net",
+				},
+				{
+					Name:    "อีฟ ผู้รับ",
+					Address: "eve.phurab@example.net",
+				},
+			},
+			ResentBcc: []*mail.Address{
+				{
+					Name:    "แฟรงค์ ผู้รับ",
+					Address: "frank.phurab@example.net",
+				},
+				{
+					Name:    "เกรซ ผู้รับ",
+					Address: "grace.phurab@example.net",
+				},
+			},
+			ResentMessageID: "Message-Id-1@example.net",
+			ContentType: ContentTypeHeader{
+				ContentType: "text/plain",
+				Params: map[string]string{
+					"charset": "tis-620",
+				},
+			},
+			ExtraHeaders: map[string][]string{
+				"X-Clacks-Overhead": {"GNU Terry Pratchett"},
+			},
+		},
+		Text: `เป็นมนุษย์สุดประเสริฐเลิศคุณค่า กว่าบรรดาฝูงสัตว์เดรัจฉาน จงฝ่าฟันพัฒนาวิชาการ อย่าล้างผลาญฤๅเข่นฆ่าบีฑาใคร ไม่ถือโทษโกรธแช่งซัดฮึดฮัดด่า หัดอภัยเหมือนกีฬาอัชฌาสัย ปฏิบัติประพฤติกฎกำหนดใจ พูดจาให้จ๊ะๆ จ๋าๆ น่าฟังเอยฯ
+
+นายสังฆภัณฑ์ เฮงพิทักษ์ฝั่ง ผู้เฒ่าซึ่งมีอาชีพเป็นฅนขายฃวด ถูกตำรวจปฏิบัติการจับฟ้องศาล ฐานลักนาฬิกาคุณหญิงฉัตรชฎา ฌานสมาธิ`,
+	}
+
+	testEmailFromFile(t, fp, expectedEmail)
+}
+
+func TestParseEmailThaiPlaintextTis620OverQuotedprintable(t *testing.T) {
+	fp := "tests/test_thai_plaintext_tis-620_over_quoted-printable.txt"
+	tz, _ := time.LoadLocation("Asia/Bangkok")
+	expectedDate, _ := time.Parse(
+		time.RFC1123Z+" (MST)",
+		time.Date(2019, time.April, 1, 7, 55, 0, 0, tz).Format(time.RFC1123Z+" (MST)"))
+	expectedEmail := Email{
+		Headers: Headers{
+			Date:    expectedDate,
+			Subject: "📧 Test แพนแกรมภาษาไทย",
+			ReplyTo: []*mail.Address{
+				{
+					Name:    "อลิซ ผู้ส่งจดหมาย",
+					Address: "alis.phusngcdhmay@example.net",
+				},
+			},
+			Sender: &mail.Address{
+				Name:    "อลิซ ผู้ส่งจดหมาย",
+				Address: "alis.phusngcdhmay@example.com",
+			},
+			From: []*mail.Address{
+				{
+					Name:    "อลิซ ผู้ส่งจดหมาย",
+					Address: "alis.phusngcdhmay@example.com",
+				},
+				{
+					Name:    "อลิซ ผู้ส่งจดหมาย",
+					Address: "alis.phusngcdhmay@example.net",
+				},
+			},
+			To: []*mail.Address{
+				{
+					Name:    "บ๊อบ ผู้รับ",
+					Address: "bob.phurab@example.com",
+				},
+				{
+					Name:    "คาโรล ผู้รับ",
+					Address: "carol.phurab@example.com",
+				},
+			},
+			Cc: []*mail.Address{
+				{
+					Name:    "แดน ผู้รับ",
+					Address: "dan.phurab@example.com",
+				},
+				{
+					Name:    "อีฟ ผู้รับ",
+					Address: "eve.phurab@example.com",
+				},
+			},
+			Bcc: []*mail.Address{
+				{
+					Name:    "แฟรงค์ ผู้รับ",
+					Address: "frank.phurab@example.com",
+				},
+				{
+					Name:    "เกรซ ผู้รับ",
+					Address: "grace.phurab@example.com",
+				},
+			},
+			MessageID:  "Message-Id-1@example.com",
+			InReplyTo:  []MessageId{"Message-Id-0@example.com"},
+			References: []MessageId{"Message-Id-0@example.com"},
+			Comments:   "Message Header Comment",
+			Keywords:   []string{"Keyword 1", "Keyword 2"},
+			ResentDate: expectedDate,
+			ResentFrom: []*mail.Address{
+				{
+					Name:    "อลิซ ผู้ส่งจดหมาย",
+					Address: "alis.phusngcdhmay@example.net",
+				},
+				{
+					Name:    "อลิซ ผู้ส่งจดหมาย",
+					Address: "alis.phusngcdhmay@example.com",
+				},
+			},
+			ResentSender: &mail.Address{
+				Name:    "อลิซ ผู้ส่งจดหมาย",
+				Address: "alis.phusngcdhmay@example.net",
+			},
+			ResentTo: []*mail.Address{
+				{
+					Name:    "บ๊อบ ผู้รับ",
+					Address: "bob.phurab@example.net",
+				},
+				{
+					Name:    "คาโรล ผู้รับ",
+					Address: "carol.phurab@example.net",
+				},
+			},
+			ResentCc: []*mail.Address{
+				{
+					Name:    "แดน ผู้รับ",
+					Address: "dan.phurab@example.net",
+				},
+				{
+					Name:    "อีฟ ผู้รับ",
+					Address: "eve.phurab@example.net",
+				},
+			},
+			ResentBcc: []*mail.Address{
+				{
+					Name:    "แฟรงค์ ผู้รับ",
+					Address: "frank.phurab@example.net",
+				},
+				{
+					Name:    "เกรซ ผู้รับ",
+					Address: "grace.phurab@example.net",
+				},
+			},
+			ResentMessageID: "Message-Id-1@example.net",
+			ContentType: ContentTypeHeader{
+				ContentType: "text/plain",
+				Params: map[string]string{
+					"charset": "tis-620",
+				},
+			},
+			ExtraHeaders: map[string][]string{
+				"X-Clacks-Overhead": {"GNU Terry Pratchett"},
+			},
+		},
+		Text: `เป็นมนุษย์สุดประเสริฐเลิศคุณค่า กว่าบรรดาฝูงสัตว์เดรัจฉาน จงฝ่าฟันพัฒนาวิชาการ อย่าล้างผลาญฤๅเข่นฆ่าบีฑาใคร ไม่ถือโทษโกรธแช่งซัดฮึดฮัดด่า หัดอภัยเหมือนกีฬาอัชฌาสัย ปฏิบัติประพฤติกฎกำหนดใจ พูดจาให้จ๊ะๆ จ๋าๆ น่าฟังเอยฯ
+
+นายสังฆภัณฑ์ เฮงพิทักษ์ฝั่ง ผู้เฒ่าซึ่งมีอาชีพเป็นฅนขายฃวด ถูกตำรวจปฏิบัติการจับฟ้องศาล ฐานลักนาฬิกาคุณหญิงฉัตรชฎา ฌานสมาธิ`,
+	}
+
+	testEmailFromFile(t, fp, expectedEmail)
+}
+
+func TestParseEmailThaiMultipartRelatedIso885911OverBase64(t *testing.T) {
+	fp := "tests/test_thai_multipart_related_iso-8859-11_over_base64.txt"
+	tz, _ := time.LoadLocation("Asia/Bangkok")
+	expectedDate, _ := time.Parse(
+		time.RFC1123Z+" (MST)",
+		time.Date(2019, time.April, 1, 7, 55, 0, 0, tz).Format(time.RFC1123Z+" (MST)"))
+	expectedEmail := Email{
+		Headers: Headers{
+			Date:    expectedDate,
+			Subject: "📧 Test แพนแกรมภาษาไทย",
+			ReplyTo: []*mail.Address{
+				{
+					Name:    "อลิซ ผู้ส่งจดหมาย",
+					Address: "alis.phusngcdhmay@example.net",
+				},
+			},
+			Sender: &mail.Address{
+				Name:    "อลิซ ผู้ส่งจดหมาย",
+				Address: "alis.phusngcdhmay@example.com",
+			},
+			From: []*mail.Address{
+				{
+					Name:    "อลิซ ผู้ส่งจดหมาย",
+					Address: "alis.phusngcdhmay@example.com",
+				},
+				{
+					Name:    "อลิซ ผู้ส่งจดหมาย",
+					Address: "alis.phusngcdhmay@example.net",
+				},
+			},
+			To: []*mail.Address{
+				{
+					Name:    "บ๊อบ ผู้รับ",
+					Address: "bob.phurab@example.com",
+				},
+				{
+					Name:    "คาโรล ผู้รับ",
+					Address: "carol.phurab@example.com",
+				},
+			},
+			Cc: []*mail.Address{
+				{
+					Name:    "แดน ผู้รับ",
+					Address: "dan.phurab@example.com",
+				},
+				{
+					Name:    "อีฟ ผู้รับ",
+					Address: "eve.phurab@example.com",
+				},
+			},
+			Bcc: []*mail.Address{
+				{
+					Name:    "แฟรงค์ ผู้รับ",
+					Address: "frank.phurab@example.com",
+				},
+				{
+					Name:    "เกรซ ผู้รับ",
+					Address: "grace.phurab@example.com",
+				},
+			},
+			MessageID:  "Message-Id-1@example.com",
+			InReplyTo:  []MessageId{"Message-Id-0@example.com"},
+			References: []MessageId{"Message-Id-0@example.com"},
+			Comments:   "Message Header Comment",
+			Keywords:   []string{"Keyword 1", "Keyword 2"},
+			ResentDate: expectedDate,
+			ResentFrom: []*mail.Address{
+				{
+					Name:    "อลิซ ผู้ส่งจดหมาย",
+					Address: "alis.phusngcdhmay@example.net",
+				},
+				{
+					Name:    "อลิซ ผู้ส่งจดหมาย",
+					Address: "alis.phusngcdhmay@example.com",
+				},
+			},
+			ResentSender: &mail.Address{
+				Name:    "อลิซ ผู้ส่งจดหมาย",
+				Address: "alis.phusngcdhmay@example.net",
+			},
+			ResentTo: []*mail.Address{
+				{
+					Name:    "บ๊อบ ผู้รับ",
+					Address: "bob.phurab@example.net",
+				},
+				{
+					Name:    "คาโรล ผู้รับ",
+					Address: "carol.phurab@example.net",
+				},
+			},
+			ResentCc: []*mail.Address{
+				{
+					Name:    "แดน ผู้รับ",
+					Address: "dan.phurab@example.net",
+				},
+				{
+					Name:    "อีฟ ผู้รับ",
+					Address: "eve.phurab@example.net",
+				},
+			},
+			ResentBcc: []*mail.Address{
+				{
+					Name:    "แฟรงค์ ผู้รับ",
+					Address: "frank.phurab@example.net",
+				},
+				{
+					Name:    "เกรซ ผู้รับ",
+					Address: "grace.phurab@example.net",
+				},
+			},
+			ResentMessageID: "Message-Id-1@example.net",
+			ContentType: ContentTypeHeader{
+				ContentType: "multipart/related",
+				Params: map[string]string{
+					"boundary": "RelatedBoundaryString",
+					"charset":  "iso-8859-11",
+				},
+			},
+			ExtraHeaders: map[string][]string{
+				"X-Clacks-Overhead": {"GNU Terry Pratchett"},
+			},
+		},
+		Text: `เป็นมนุษย์สุดประเสริฐเลิศคุณค่า กว่าบรรดาฝูงสัตว์เดรัจฉาน จงฝ่าฟันพัฒนาวิชาการ อย่าล้างผลาญฤๅเข่นฆ่าบีฑาใคร ไม่ถือโทษโกรธแช่งซัดฮึดฮัดด่า หัดอภัยเหมือนกีฬาอัชฌาสัย ปฏิบัติประพฤติกฎกำหนดใจ พูดจาให้จ๊ะๆ จ๋าๆ น่าฟังเอยฯ
+
+นายสังฆภัณฑ์ เฮงพิทักษ์ฝั่ง ผู้เฒ่าซึ่งมีอาชีพเป็นฅนขายฃวด ถูกตำรวจปฏิบัติการจับฟ้องศาล ฐานลักนาฬิกาคุณหญิงฉัตรชฎา ฌานสมาธิ`,
+		EnrichedText: `<bold>เป็นมนุษย์สุดประเสริฐเลิศคุณค่า</bold> <italic>กว่าบรรดาฝูงสัตว์เดรัจฉาน</italic> <fixed>จงฝ่าฟันพัฒนาวิชาการ</fixed> <underline>อย่าล้างผลาญฤๅเข่นฆ่าบีฑาใคร</underline> ไม่ถือโทษโกรธแช่งซัดฮึดฮัดด่า หัดอภัยเหมือนกีฬาอัชฌาสัย ปฏิบัติประพฤติกฎกำหนดใจ พูดจาให้จ๊ะๆ จ๋าๆ น่าฟังเอยฯ
+
+นายสังฆภัณฑ์ เฮงพิทักษ์ฝั่ง ผู้เฒ่าซึ่งมีอาชีพเป็นฅนขายฃวด ถูกตำรวจปฏิบัติการจับฟ้องศาล ฐานลักนาฬิกาคุณหญิงฉัตรชฎา ฌานสมาธิ`,
+		HTML: `<html>
+<div dir="ltr">
+<p>เป็นมนุษย์สุดประเสริฐเลิศคุณค่า กว่าบรรดาฝูงสัตว์เดรัจฉาน จงฝ่าฟันพัฒนาวิชาการ อย่าล้างผลาญฤๅเข่นฆ่าบีฑาใคร ไม่ถือโทษโกรธแช่งซัดฮึดฮัดด่า หัดอภัยเหมือนกีฬาอัชฌาสัย ปฏิบัติประพฤติกฎกำหนดใจ พูดจาให้จ๊ะๆ จ๋าๆ น่าฟังเอยฯ</p>
+
+<p>นายสังฆภัณฑ์ เฮงพิทักษ์ฝั่ง ผู้เฒ่าซึ่งมีอาชีพเป็นฅนขายฃวด ถูกตำรวจปฏิบัติการจับฟ้องศาล ฐานลักนาฬิกาคุณหญิงฉัตรชฎา ฌานสมาธิ</p>
+</div>
+</html>`,
+		InlineFiles: []InlineFile{
+			{
+				ContentID: "inline-jpg-image.jpg@example.com",
+				ContentType: ContentTypeHeader{
+					ContentType: "image/jpeg",
+					Params: map[string]string{
+						"name": "inline-jpg-image-name.jpg",
+					},
+				},
+				ContentDisposition: ContentDispositionHeader{
+					ContentDisposition: inline,
+					Params: map[string]string{
+						"filename": "inline-jpg-image-filename.jpg",
+					},
+				},
+				Data: []byte{255, 216, 255, 219, 0, 67, 0, 3, 2, 2, 2, 2, 2, 3, 2, 2, 2, 3, 3, 3, 3, 4,
+					6, 4, 4, 4, 4, 4, 8, 6, 6, 5, 6, 9, 8, 10, 10, 9, 8, 9, 9, 10, 12, 15, 12, 10, 11, 14, 11, 9, 9,
+					13, 17, 13, 14, 15, 16, 16, 17, 16, 10, 12, 18, 19, 18, 16, 19, 15, 16, 16, 16, 255, 201, 0, 11, 8,
+					0, 1, 0, 1, 1, 1, 17, 0, 255, 204, 0, 6, 0, 16, 16, 5, 255, 218, 0, 8, 1, 1, 0, 0, 63, 0, 210, 207,
+					32, 255, 217},
+			},
+		},
+	}
+
+	testEmailFromFile(t, fp, expectedEmail)
+}
+func TestParseEmailThaiMultipartRelatedIso885911OverQuotedprintable(t *testing.T) {
+	fp := "tests/test_thai_multipart_related_iso-8859-11_over_quoted-printable.txt"
+	tz, _ := time.LoadLocation("Asia/Bangkok")
+	expectedDate, _ := time.Parse(
+		time.RFC1123Z+" (MST)",
+		time.Date(2019, time.April, 1, 7, 55, 0, 0, tz).Format(time.RFC1123Z+" (MST)"))
+	expectedEmail := Email{
+		Headers: Headers{
+			Date:    expectedDate,
+			Subject: "📧 Test แพนแกรมภาษาไทย",
+			ReplyTo: []*mail.Address{
+				{
+					Name:    "อลิซ ผู้ส่งจดหมาย",
+					Address: "alis.phusngcdhmay@example.net",
+				},
+			},
+			Sender: &mail.Address{
+				Name:    "อลิซ ผู้ส่งจดหมาย",
+				Address: "alis.phusngcdhmay@example.com",
+			},
+			From: []*mail.Address{
+				{
+					Name:    "อลิซ ผู้ส่งจดหมาย",
+					Address: "alis.phusngcdhmay@example.com",
+				},
+				{
+					Name:    "อลิซ ผู้ส่งจดหมาย",
+					Address: "alis.phusngcdhmay@example.net",
+				},
+			},
+			To: []*mail.Address{
+				{
+					Name:    "บ๊อบ ผู้รับ",
+					Address: "bob.phurab@example.com",
+				},
+				{
+					Name:    "คาโรล ผู้รับ",
+					Address: "carol.phurab@example.com",
+				},
+			},
+			Cc: []*mail.Address{
+				{
+					Name:    "แดน ผู้รับ",
+					Address: "dan.phurab@example.com",
+				},
+				{
+					Name:    "อีฟ ผู้รับ",
+					Address: "eve.phurab@example.com",
+				},
+			},
+			Bcc: []*mail.Address{
+				{
+					Name:    "แฟรงค์ ผู้รับ",
+					Address: "frank.phurab@example.com",
+				},
+				{
+					Name:    "เกรซ ผู้รับ",
+					Address: "grace.phurab@example.com",
+				},
+			},
+			MessageID:  "Message-Id-1@example.com",
+			InReplyTo:  []MessageId{"Message-Id-0@example.com"},
+			References: []MessageId{"Message-Id-0@example.com"},
+			Comments:   "Message Header Comment",
+			Keywords:   []string{"Keyword 1", "Keyword 2"},
+			ResentDate: expectedDate,
+			ResentFrom: []*mail.Address{
+				{
+					Name:    "อลิซ ผู้ส่งจดหมาย",
+					Address: "alis.phusngcdhmay@example.net",
+				},
+				{
+					Name:    "อลิซ ผู้ส่งจดหมาย",
+					Address: "alis.phusngcdhmay@example.com",
+				},
+			},
+			ResentSender: &mail.Address{
+				Name:    "อลิซ ผู้ส่งจดหมาย",
+				Address: "alis.phusngcdhmay@example.net",
+			},
+			ResentTo: []*mail.Address{
+				{
+					Name:    "บ๊อบ ผู้รับ",
+					Address: "bob.phurab@example.net",
+				},
+				{
+					Name:    "คาโรล ผู้รับ",
+					Address: "carol.phurab@example.net",
+				},
+			},
+			ResentCc: []*mail.Address{
+				{
+					Name:    "แดน ผู้รับ",
+					Address: "dan.phurab@example.net",
+				},
+				{
+					Name:    "อีฟ ผู้รับ",
+					Address: "eve.phurab@example.net",
+				},
+			},
+			ResentBcc: []*mail.Address{
+				{
+					Name:    "แฟรงค์ ผู้รับ",
+					Address: "frank.phurab@example.net",
+				},
+				{
+					Name:    "เกรซ ผู้รับ",
+					Address: "grace.phurab@example.net",
+				},
+			},
+			ResentMessageID: "Message-Id-1@example.net",
+			ContentType: ContentTypeHeader{
+				ContentType: "multipart/related",
+				Params: map[string]string{
+					"boundary": "RelatedBoundaryString",
+					"charset":  "iso-8859-11",
+				},
+			},
+			ExtraHeaders: map[string][]string{
+				"X-Clacks-Overhead": {"GNU Terry Pratchett"},
+			},
+		},
+		Text: `เป็นมนุษย์สุดประเสริฐเลิศคุณค่า กว่าบรรดาฝูงสัตว์เดรัจฉาน จงฝ่าฟันพัฒนาวิชาการ อย่าล้างผลาญฤๅเข่นฆ่าบีฑาใคร ไม่ถือโทษโกรธแช่งซัดฮึดฮัดด่า หัดอภัยเหมือนกีฬาอัชฌาสัย ปฏิบัติประพฤติกฎกำหนดใจ พูดจาให้จ๊ะๆ จ๋าๆ น่าฟังเอยฯ
+
+นายสังฆภัณฑ์ เฮงพิทักษ์ฝั่ง ผู้เฒ่าซึ่งมีอาชีพเป็นฅนขายฃวด ถูกตำรวจปฏิบัติการจับฟ้องศาล ฐานลักนาฬิกาคุณหญิงฉัตรชฎา ฌานสมาธิ`,
+		EnrichedText: `<bold>เป็นมนุษย์สุดประเสริฐเลิศคุณค่า</bold> <italic>กว่าบรรดาฝูงสัตว์เดรัจฉาน</italic> <fixed>จงฝ่าฟันพัฒนาวิชาการ</fixed> <underline>อย่าล้างผลาญฤๅเข่นฆ่าบีฑาใคร</underline> ไม่ถือโทษโกรธแช่งซัดฮึดฮัดด่า หัดอภัยเหมือนกีฬาอัชฌาสัย ปฏิบัติประพฤติกฎกำหนดใจ พูดจาให้จ๊ะๆ จ๋าๆ น่าฟังเอยฯ
+
+นายสังฆภัณฑ์ เฮงพิทักษ์ฝั่ง ผู้เฒ่าซึ่งมีอาชีพเป็นฅนขายฃวด ถูกตำรวจปฏิบัติการจับฟ้องศาล ฐานลักนาฬิกาคุณหญิงฉัตรชฎา ฌานสมาธิ`,
+		HTML: `<html>
+<div dir="ltr">
+<p>เป็นมนุษย์สุดประเสริฐเลิศคุณค่า กว่าบรรดาฝูงสัตว์เดรัจฉาน จงฝ่าฟันพัฒนาวิชาการ อย่าล้างผลาญฤๅเข่นฆ่าบีฑาใคร ไม่ถือโทษโกรธแช่งซัดฮึดฮัดด่า หัดอภัยเหมือนกีฬาอัชฌาสัย ปฏิบัติประพฤติกฎกำหนดใจ พูดจาให้จ๊ะๆ จ๋าๆ น่าฟังเอยฯ</p>
+
+<p>นายสังฆภัณฑ์ เฮงพิทักษ์ฝั่ง ผู้เฒ่าซึ่งมีอาชีพเป็นฅนขายฃวด ถูกตำรวจปฏิบัติการจับฟ้องศาล ฐานลักนาฬิกาคุณหญิงฉัตรชฎา ฌานสมาธิ</p>
+</div>
+</html>`,
+		InlineFiles: []InlineFile{
+			{
+				ContentID: "inline-jpg-image.jpg@example.com",
+				ContentType: ContentTypeHeader{
+					ContentType: "image/jpeg",
+					Params: map[string]string{
+						"name": "inline-jpg-image-name.jpg",
+					},
+				},
+				ContentDisposition: ContentDispositionHeader{
+					ContentDisposition: inline,
+					Params: map[string]string{
+						"filename": "inline-jpg-image-filename.jpg",
+					},
+				},
+				Data: []byte{255, 216, 255, 219, 0, 67, 0, 3, 2, 2, 2, 2, 2, 3, 2, 2, 2, 3, 3, 3, 3, 4,
+					6, 4, 4, 4, 4, 4, 8, 6, 6, 5, 6, 9, 8, 10, 10, 9, 8, 9, 9, 10, 12, 15, 12, 10, 11, 14, 11, 9, 9,
+					13, 17, 13, 14, 15, 16, 16, 17, 16, 10, 12, 18, 19, 18, 16, 19, 15, 16, 16, 16, 255, 201, 0, 11, 8,
+					0, 1, 0, 1, 1, 1, 17, 0, 255, 204, 0, 6, 0, 16, 16, 5, 255, 218, 0, 8, 1, 1, 0, 0, 63, 0, 210, 207,
+					32, 255, 217},
+			},
+		},
+	}
+
+	testEmailFromFile(t, fp, expectedEmail)
+}
+func TestParseEmailThaiMultipartRelatedWindows874OverBase64(t *testing.T) {
+	fp := "tests/test_thai_multipart_related_windows-874_over_base64.txt"
+	tz, _ := time.LoadLocation("Asia/Bangkok")
+	expectedDate, _ := time.Parse(
+		time.RFC1123Z+" (MST)",
+		time.Date(2019, time.April, 1, 7, 55, 0, 0, tz).Format(time.RFC1123Z+" (MST)"))
+	expectedEmail := Email{
+		Headers: Headers{
+			Date:    expectedDate,
+			Subject: "📧 Test แพนแกรมภาษาไทย",
+			ReplyTo: []*mail.Address{
+				{
+					Name:    "อลิซ ผู้ส่งจดหมาย",
+					Address: "alis.phusngcdhmay@example.net",
+				},
+			},
+			Sender: &mail.Address{
+				Name:    "อลิซ ผู้ส่งจดหมาย",
+				Address: "alis.phusngcdhmay@example.com",
+			},
+			From: []*mail.Address{
+				{
+					Name:    "อลิซ ผู้ส่งจดหมาย",
+					Address: "alis.phusngcdhmay@example.com",
+				},
+				{
+					Name:    "อลิซ ผู้ส่งจดหมาย",
+					Address: "alis.phusngcdhmay@example.net",
+				},
+			},
+			To: []*mail.Address{
+				{
+					Name:    "บ๊อบ ผู้รับ",
+					Address: "bob.phurab@example.com",
+				},
+				{
+					Name:    "คาโรล ผู้รับ",
+					Address: "carol.phurab@example.com",
+				},
+			},
+			Cc: []*mail.Address{
+				{
+					Name:    "แดน ผู้รับ",
+					Address: "dan.phurab@example.com",
+				},
+				{
+					Name:    "อีฟ ผู้รับ",
+					Address: "eve.phurab@example.com",
+				},
+			},
+			Bcc: []*mail.Address{
+				{
+					Name:    "แฟรงค์ ผู้รับ",
+					Address: "frank.phurab@example.com",
+				},
+				{
+					Name:    "เกรซ ผู้รับ",
+					Address: "grace.phurab@example.com",
+				},
+			},
+			MessageID:  "Message-Id-1@example.com",
+			InReplyTo:  []MessageId{"Message-Id-0@example.com"},
+			References: []MessageId{"Message-Id-0@example.com"},
+			Comments:   "Message Header Comment",
+			Keywords:   []string{"Keyword 1", "Keyword 2"},
+			ResentDate: expectedDate,
+			ResentFrom: []*mail.Address{
+				{
+					Name:    "อลิซ ผู้ส่งจดหมาย",
+					Address: "alis.phusngcdhmay@example.net",
+				},
+				{
+					Name:    "อลิซ ผู้ส่งจดหมาย",
+					Address: "alis.phusngcdhmay@example.com",
+				},
+			},
+			ResentSender: &mail.Address{
+				Name:    "อลิซ ผู้ส่งจดหมาย",
+				Address: "alis.phusngcdhmay@example.net",
+			},
+			ResentTo: []*mail.Address{
+				{
+					Name:    "บ๊อบ ผู้รับ",
+					Address: "bob.phurab@example.net",
+				},
+				{
+					Name:    "คาโรล ผู้รับ",
+					Address: "carol.phurab@example.net",
+				},
+			},
+			ResentCc: []*mail.Address{
+				{
+					Name:    "แดน ผู้รับ",
+					Address: "dan.phurab@example.net",
+				},
+				{
+					Name:    "อีฟ ผู้รับ",
+					Address: "eve.phurab@example.net",
+				},
+			},
+			ResentBcc: []*mail.Address{
+				{
+					Name:    "แฟรงค์ ผู้รับ",
+					Address: "frank.phurab@example.net",
+				},
+				{
+					Name:    "เกรซ ผู้รับ",
+					Address: "grace.phurab@example.net",
+				},
+			},
+			ResentMessageID: "Message-Id-1@example.net",
+			ContentType: ContentTypeHeader{
+				ContentType: "multipart/related",
+				Params: map[string]string{
+					"boundary": "RelatedBoundaryString",
+					"charset":  "windows-874",
+				},
+			},
+			ExtraHeaders: map[string][]string{
+				"X-Clacks-Overhead": {"GNU Terry Pratchett"},
+			},
+		},
+		Text: `เป็นมนุษย์สุดประเสริฐเลิศคุณค่า กว่าบรรดาฝูงสัตว์เดรัจฉาน จงฝ่าฟันพัฒนาวิชาการ อย่าล้างผลาญฤๅเข่นฆ่าบีฑาใคร ไม่ถือโทษโกรธแช่งซัดฮึดฮัดด่า หัดอภัยเหมือนกีฬาอัชฌาสัย ปฏิบัติประพฤติกฎกำหนดใจ พูดจาให้จ๊ะๆ จ๋าๆ น่าฟังเอยฯ
+
+นายสังฆภัณฑ์ เฮงพิทักษ์ฝั่ง ผู้เฒ่าซึ่งมีอาชีพเป็นฅนขายฃวด ถูกตำรวจปฏิบัติการจับฟ้องศาล ฐานลักนาฬิกาคุณหญิงฉัตรชฎา ฌานสมาธิ`,
+		EnrichedText: `<bold>เป็นมนุษย์สุดประเสริฐเลิศคุณค่า</bold> <italic>กว่าบรรดาฝูงสัตว์เดรัจฉาน</italic> <fixed>จงฝ่าฟันพัฒนาวิชาการ</fixed> <underline>อย่าล้างผลาญฤๅเข่นฆ่าบีฑาใคร</underline> ไม่ถือโทษโกรธแช่งซัดฮึดฮัดด่า หัดอภัยเหมือนกีฬาอัชฌาสัย ปฏิบัติประพฤติกฎกำหนดใจ พูดจาให้จ๊ะๆ จ๋าๆ น่าฟังเอยฯ
+
+นายสังฆภัณฑ์ เฮงพิทักษ์ฝั่ง ผู้เฒ่าซึ่งมีอาชีพเป็นฅนขายฃวด ถูกตำรวจปฏิบัติการจับฟ้องศาล ฐานลักนาฬิกาคุณหญิงฉัตรชฎา ฌานสมาธิ`,
+		HTML: `<html>
+<div dir="ltr">
+<p>เป็นมนุษย์สุดประเสริฐเลิศคุณค่า กว่าบรรดาฝูงสัตว์เดรัจฉาน จงฝ่าฟันพัฒนาวิชาการ อย่าล้างผลาญฤๅเข่นฆ่าบีฑาใคร ไม่ถือโทษโกรธแช่งซัดฮึดฮัดด่า หัดอภัยเหมือนกีฬาอัชฌาสัย ปฏิบัติประพฤติกฎกำหนดใจ พูดจาให้จ๊ะๆ จ๋าๆ น่าฟังเอยฯ</p>
+
+<p>นายสังฆภัณฑ์ เฮงพิทักษ์ฝั่ง ผู้เฒ่าซึ่งมีอาชีพเป็นฅนขายฃวด ถูกตำรวจปฏิบัติการจับฟ้องศาล ฐานลักนาฬิกาคุณหญิงฉัตรชฎา ฌานสมาธิ</p>
+</div>
+</html>`,
+		InlineFiles: []InlineFile{
+			{
+				ContentID: "inline-jpg-image.jpg@example.com",
+				ContentType: ContentTypeHeader{
+					ContentType: "image/jpeg",
+					Params: map[string]string{
+						"name": "inline-jpg-image-name.jpg",
+					},
+				},
+				ContentDisposition: ContentDispositionHeader{
+					ContentDisposition: inline,
+					Params: map[string]string{
+						"filename": "inline-jpg-image-filename.jpg",
+					},
+				},
+				Data: []byte{255, 216, 255, 219, 0, 67, 0, 3, 2, 2, 2, 2, 2, 3, 2, 2, 2, 3, 3, 3, 3, 4,
+					6, 4, 4, 4, 4, 4, 8, 6, 6, 5, 6, 9, 8, 10, 10, 9, 8, 9, 9, 10, 12, 15, 12, 10, 11, 14, 11, 9, 9,
+					13, 17, 13, 14, 15, 16, 16, 17, 16, 10, 12, 18, 19, 18, 16, 19, 15, 16, 16, 16, 255, 201, 0, 11, 8,
+					0, 1, 0, 1, 1, 1, 17, 0, 255, 204, 0, 6, 0, 16, 16, 5, 255, 218, 0, 8, 1, 1, 0, 0, 63, 0, 210, 207,
+					32, 255, 217},
+			},
+		},
+	}
+
+	testEmailFromFile(t, fp, expectedEmail)
+}
+func TestParseEmailThaiMultipartRelatedWindows874OverQuotedprintable(t *testing.T) {
+	fp := "tests/test_thai_multipart_related_windows-874_over_quoted-printable.txt"
+	tz, _ := time.LoadLocation("Asia/Bangkok")
+	expectedDate, _ := time.Parse(
+		time.RFC1123Z+" (MST)",
+		time.Date(2019, time.April, 1, 7, 55, 0, 0, tz).Format(time.RFC1123Z+" (MST)"))
+	expectedEmail := Email{
+		Headers: Headers{
+			Date:    expectedDate,
+			Subject: "📧 Test แพนแกรมภาษาไทย",
+			ReplyTo: []*mail.Address{
+				{
+					Name:    "อลิซ ผู้ส่งจดหมาย",
+					Address: "alis.phusngcdhmay@example.net",
+				},
+			},
+			Sender: &mail.Address{
+				Name:    "อลิซ ผู้ส่งจดหมาย",
+				Address: "alis.phusngcdhmay@example.com",
+			},
+			From: []*mail.Address{
+				{
+					Name:    "อลิซ ผู้ส่งจดหมาย",
+					Address: "alis.phusngcdhmay@example.com",
+				},
+				{
+					Name:    "อลิซ ผู้ส่งจดหมาย",
+					Address: "alis.phusngcdhmay@example.net",
+				},
+			},
+			To: []*mail.Address{
+				{
+					Name:    "บ๊อบ ผู้รับ",
+					Address: "bob.phurab@example.com",
+				},
+				{
+					Name:    "คาโรล ผู้รับ",
+					Address: "carol.phurab@example.com",
+				},
+			},
+			Cc: []*mail.Address{
+				{
+					Name:    "แดน ผู้รับ",
+					Address: "dan.phurab@example.com",
+				},
+				{
+					Name:    "อีฟ ผู้รับ",
+					Address: "eve.phurab@example.com",
+				},
+			},
+			Bcc: []*mail.Address{
+				{
+					Name:    "แฟรงค์ ผู้รับ",
+					Address: "frank.phurab@example.com",
+				},
+				{
+					Name:    "เกรซ ผู้รับ",
+					Address: "grace.phurab@example.com",
+				},
+			},
+			MessageID:  "Message-Id-1@example.com",
+			InReplyTo:  []MessageId{"Message-Id-0@example.com"},
+			References: []MessageId{"Message-Id-0@example.com"},
+			Comments:   "Message Header Comment",
+			Keywords:   []string{"Keyword 1", "Keyword 2"},
+			ResentDate: expectedDate,
+			ResentFrom: []*mail.Address{
+				{
+					Name:    "อลิซ ผู้ส่งจดหมาย",
+					Address: "alis.phusngcdhmay@example.net",
+				},
+				{
+					Name:    "อลิซ ผู้ส่งจดหมาย",
+					Address: "alis.phusngcdhmay@example.com",
+				},
+			},
+			ResentSender: &mail.Address{
+				Name:    "อลิซ ผู้ส่งจดหมาย",
+				Address: "alis.phusngcdhmay@example.net",
+			},
+			ResentTo: []*mail.Address{
+				{
+					Name:    "บ๊อบ ผู้รับ",
+					Address: "bob.phurab@example.net",
+				},
+				{
+					Name:    "คาโรล ผู้รับ",
+					Address: "carol.phurab@example.net",
+				},
+			},
+			ResentCc: []*mail.Address{
+				{
+					Name:    "แดน ผู้รับ",
+					Address: "dan.phurab@example.net",
+				},
+				{
+					Name:    "อีฟ ผู้รับ",
+					Address: "eve.phurab@example.net",
+				},
+			},
+			ResentBcc: []*mail.Address{
+				{
+					Name:    "แฟรงค์ ผู้รับ",
+					Address: "frank.phurab@example.net",
+				},
+				{
+					Name:    "เกรซ ผู้รับ",
+					Address: "grace.phurab@example.net",
+				},
+			},
+			ResentMessageID: "Message-Id-1@example.net",
+			ContentType: ContentTypeHeader{
+				ContentType: "multipart/related",
+				Params: map[string]string{
+					"boundary": "RelatedBoundaryString",
+					"charset":  "windows-874",
+				},
+			},
+			ExtraHeaders: map[string][]string{
+				"X-Clacks-Overhead": {"GNU Terry Pratchett"},
+			},
+		},
+		Text: `เป็นมนุษย์สุดประเสริฐเลิศคุณค่า กว่าบรรดาฝูงสัตว์เดรัจฉาน จงฝ่าฟันพัฒนาวิชาการ อย่าล้างผลาญฤๅเข่นฆ่าบีฑาใคร ไม่ถือโทษโกรธแช่งซัดฮึดฮัดด่า หัดอภัยเหมือนกีฬาอัชฌาสัย ปฏิบัติประพฤติกฎกำหนดใจ พูดจาให้จ๊ะๆ จ๋าๆ น่าฟังเอยฯ
+
+นายสังฆภัณฑ์ เฮงพิทักษ์ฝั่ง ผู้เฒ่าซึ่งมีอาชีพเป็นฅนขายฃวด ถูกตำรวจปฏิบัติการจับฟ้องศาล ฐานลักนาฬิกาคุณหญิงฉัตรชฎา ฌานสมาธิ`,
+		EnrichedText: `<bold>เป็นมนุษย์สุดประเสริฐเลิศคุณค่า</bold> <italic>กว่าบรรดาฝูงสัตว์เดรัจฉาน</italic> <fixed>จงฝ่าฟันพัฒนาวิชาการ</fixed> <underline>อย่าล้างผลาญฤๅเข่นฆ่าบีฑาใคร</underline> ไม่ถือโทษโกรธแช่งซัดฮึดฮัดด่า หัดอภัยเหมือนกีฬาอัชฌาสัย ปฏิบัติประพฤติกฎกำหนดใจ พูดจาให้จ๊ะๆ จ๋าๆ น่าฟังเอยฯ
+
+นายสังฆภัณฑ์ เฮงพิทักษ์ฝั่ง ผู้เฒ่าซึ่งมีอาชีพเป็นฅนขายฃวด ถูกตำรวจปฏิบัติการจับฟ้องศาล ฐานลักนาฬิกาคุณหญิงฉัตรชฎา ฌานสมาธิ`,
+		HTML: `<html>
+<div dir="ltr">
+<p>เป็นมนุษย์สุดประเสริฐเลิศคุณค่า กว่าบรรดาฝูงสัตว์เดรัจฉาน จงฝ่าฟันพัฒนาวิชาการ อย่าล้างผลาญฤๅเข่นฆ่าบีฑาใคร ไม่ถือโทษโกรธแช่งซัดฮึดฮัดด่า หัดอภัยเหมือนกีฬาอัชฌาสัย ปฏิบัติประพฤติกฎกำหนดใจ พูดจาให้จ๊ะๆ จ๋าๆ น่าฟังเอยฯ</p>
+
+<p>นายสังฆภัณฑ์ เฮงพิทักษ์ฝั่ง ผู้เฒ่าซึ่งมีอาชีพเป็นฅนขายฃวด ถูกตำรวจปฏิบัติการจับฟ้องศาล ฐานลักนาฬิกาคุณหญิงฉัตรชฎา ฌานสมาธิ</p>
+</div>
+</html>`,
+		InlineFiles: []InlineFile{
+			{
+				ContentID: "inline-jpg-image.jpg@example.com",
+				ContentType: ContentTypeHeader{
+					ContentType: "image/jpeg",
+					Params: map[string]string{
+						"name": "inline-jpg-image-name.jpg",
+					},
+				},
+				ContentDisposition: ContentDispositionHeader{
+					ContentDisposition: inline,
+					Params: map[string]string{
+						"filename": "inline-jpg-image-filename.jpg",
+					},
+				},
+				Data: []byte{255, 216, 255, 219, 0, 67, 0, 3, 2, 2, 2, 2, 2, 3, 2, 2, 2, 3, 3, 3, 3, 4,
+					6, 4, 4, 4, 4, 4, 8, 6, 6, 5, 6, 9, 8, 10, 10, 9, 8, 9, 9, 10, 12, 15, 12, 10, 11, 14, 11, 9, 9,
+					13, 17, 13, 14, 15, 16, 16, 17, 16, 10, 12, 18, 19, 18, 16, 19, 15, 16, 16, 16, 255, 201, 0, 11, 8,
+					0, 1, 0, 1, 1, 1, 17, 0, 255, 204, 0, 6, 0, 16, 16, 5, 255, 218, 0, 8, 1, 1, 0, 0, 63, 0, 210, 207,
+					32, 255, 217},
+			},
+		},
+	}
+
+	testEmailFromFile(t, fp, expectedEmail)
+}
+func TestParseEmailThaiMultipartRelatedTis620OverBase64(t *testing.T) {
+	fp := "tests/test_thai_multipart_related_tis-620_over_base64.txt"
+	tz, _ := time.LoadLocation("Asia/Bangkok")
+	expectedDate, _ := time.Parse(
+		time.RFC1123Z+" (MST)",
+		time.Date(2019, time.April, 1, 7, 55, 0, 0, tz).Format(time.RFC1123Z+" (MST)"))
+	expectedEmail := Email{
+		Headers: Headers{
+			Date:    expectedDate,
+			Subject: "📧 Test แพนแกรมภาษาไทย",
+			ReplyTo: []*mail.Address{
+				{
+					Name:    "อลิซ ผู้ส่งจดหมาย",
+					Address: "alis.phusngcdhmay@example.net",
+				},
+			},
+			Sender: &mail.Address{
+				Name:    "อลิซ ผู้ส่งจดหมาย",
+				Address: "alis.phusngcdhmay@example.com",
+			},
+			From: []*mail.Address{
+				{
+					Name:    "อลิซ ผู้ส่งจดหมาย",
+					Address: "alis.phusngcdhmay@example.com",
+				},
+				{
+					Name:    "อลิซ ผู้ส่งจดหมาย",
+					Address: "alis.phusngcdhmay@example.net",
+				},
+			},
+			To: []*mail.Address{
+				{
+					Name:    "บ๊อบ ผู้รับ",
+					Address: "bob.phurab@example.com",
+				},
+				{
+					Name:    "คาโรล ผู้รับ",
+					Address: "carol.phurab@example.com",
+				},
+			},
+			Cc: []*mail.Address{
+				{
+					Name:    "แดน ผู้รับ",
+					Address: "dan.phurab@example.com",
+				},
+				{
+					Name:    "อีฟ ผู้รับ",
+					Address: "eve.phurab@example.com",
+				},
+			},
+			Bcc: []*mail.Address{
+				{
+					Name:    "แฟรงค์ ผู้รับ",
+					Address: "frank.phurab@example.com",
+				},
+				{
+					Name:    "เกรซ ผู้รับ",
+					Address: "grace.phurab@example.com",
+				},
+			},
+			MessageID:  "Message-Id-1@example.com",
+			InReplyTo:  []MessageId{"Message-Id-0@example.com"},
+			References: []MessageId{"Message-Id-0@example.com"},
+			Comments:   "Message Header Comment",
+			Keywords:   []string{"Keyword 1", "Keyword 2"},
+			ResentDate: expectedDate,
+			ResentFrom: []*mail.Address{
+				{
+					Name:    "อลิซ ผู้ส่งจดหมาย",
+					Address: "alis.phusngcdhmay@example.net",
+				},
+				{
+					Name:    "อลิซ ผู้ส่งจดหมาย",
+					Address: "alis.phusngcdhmay@example.com",
+				},
+			},
+			ResentSender: &mail.Address{
+				Name:    "อลิซ ผู้ส่งจดหมาย",
+				Address: "alis.phusngcdhmay@example.net",
+			},
+			ResentTo: []*mail.Address{
+				{
+					Name:    "บ๊อบ ผู้รับ",
+					Address: "bob.phurab@example.net",
+				},
+				{
+					Name:    "คาโรล ผู้รับ",
+					Address: "carol.phurab@example.net",
+				},
+			},
+			ResentCc: []*mail.Address{
+				{
+					Name:    "แดน ผู้รับ",
+					Address: "dan.phurab@example.net",
+				},
+				{
+					Name:    "อีฟ ผู้รับ",
+					Address: "eve.phurab@example.net",
+				},
+			},
+			ResentBcc: []*mail.Address{
+				{
+					Name:    "แฟรงค์ ผู้รับ",
+					Address: "frank.phurab@example.net",
+				},
+				{
+					Name:    "เกรซ ผู้รับ",
+					Address: "grace.phurab@example.net",
+				},
+			},
+			ResentMessageID: "Message-Id-1@example.net",
+			ContentType: ContentTypeHeader{
+				ContentType: "multipart/related",
+				Params: map[string]string{
+					"boundary": "RelatedBoundaryString",
+					"charset":  "tis-620",
+				},
+			},
+			ExtraHeaders: map[string][]string{
+				"X-Clacks-Overhead": {"GNU Terry Pratchett"},
+			},
+		},
+		Text: `เป็นมนุษย์สุดประเสริฐเลิศคุณค่า กว่าบรรดาฝูงสัตว์เดรัจฉาน จงฝ่าฟันพัฒนาวิชาการ อย่าล้างผลาญฤๅเข่นฆ่าบีฑาใคร ไม่ถือโทษโกรธแช่งซัดฮึดฮัดด่า หัดอภัยเหมือนกีฬาอัชฌาสัย ปฏิบัติประพฤติกฎกำหนดใจ พูดจาให้จ๊ะๆ จ๋าๆ น่าฟังเอยฯ
+
+นายสังฆภัณฑ์ เฮงพิทักษ์ฝั่ง ผู้เฒ่าซึ่งมีอาชีพเป็นฅนขายฃวด ถูกตำรวจปฏิบัติการจับฟ้องศาล ฐานลักนาฬิกาคุณหญิงฉัตรชฎา ฌานสมาธิ`,
+		EnrichedText: `<bold>เป็นมนุษย์สุดประเสริฐเลิศคุณค่า</bold> <italic>กว่าบรรดาฝูงสัตว์เดรัจฉาน</italic> <fixed>จงฝ่าฟันพัฒนาวิชาการ</fixed> <underline>อย่าล้างผลาญฤๅเข่นฆ่าบีฑาใคร</underline> ไม่ถือโทษโกรธแช่งซัดฮึดฮัดด่า หัดอภัยเหมือนกีฬาอัชฌาสัย ปฏิบัติประพฤติกฎกำหนดใจ พูดจาให้จ๊ะๆ จ๋าๆ น่าฟังเอยฯ
+
+นายสังฆภัณฑ์ เฮงพิทักษ์ฝั่ง ผู้เฒ่าซึ่งมีอาชีพเป็นฅนขายฃวด ถูกตำรวจปฏิบัติการจับฟ้องศาล ฐานลักนาฬิกาคุณหญิงฉัตรชฎา ฌานสมาธิ`,
+		HTML: `<html>
+<div dir="ltr">
+<p>เป็นมนุษย์สุดประเสริฐเลิศคุณค่า กว่าบรรดาฝูงสัตว์เดรัจฉาน จงฝ่าฟันพัฒนาวิชาการ อย่าล้างผลาญฤๅเข่นฆ่าบีฑาใคร ไม่ถือโทษโกรธแช่งซัดฮึดฮัดด่า หัดอภัยเหมือนกีฬาอัชฌาสัย ปฏิบัติประพฤติกฎกำหนดใจ พูดจาให้จ๊ะๆ จ๋าๆ น่าฟังเอยฯ</p>
+
+<p>นายสังฆภัณฑ์ เฮงพิทักษ์ฝั่ง ผู้เฒ่าซึ่งมีอาชีพเป็นฅนขายฃวด ถูกตำรวจปฏิบัติการจับฟ้องศาล ฐานลักนาฬิกาคุณหญิงฉัตรชฎา ฌานสมาธิ</p>
+</div>
+</html>`,
+		InlineFiles: []InlineFile{
+			{
+				ContentID: "inline-jpg-image.jpg@example.com",
+				ContentType: ContentTypeHeader{
+					ContentType: "image/jpeg",
+					Params: map[string]string{
+						"name": "inline-jpg-image-name.jpg",
+					},
+				},
+				ContentDisposition: ContentDispositionHeader{
+					ContentDisposition: inline,
+					Params: map[string]string{
+						"filename": "inline-jpg-image-filename.jpg",
+					},
+				},
+				Data: []byte{255, 216, 255, 219, 0, 67, 0, 3, 2, 2, 2, 2, 2, 3, 2, 2, 2, 3, 3, 3, 3, 4,
+					6, 4, 4, 4, 4, 4, 8, 6, 6, 5, 6, 9, 8, 10, 10, 9, 8, 9, 9, 10, 12, 15, 12, 10, 11, 14, 11, 9, 9,
+					13, 17, 13, 14, 15, 16, 16, 17, 16, 10, 12, 18, 19, 18, 16, 19, 15, 16, 16, 16, 255, 201, 0, 11, 8,
+					0, 1, 0, 1, 1, 1, 17, 0, 255, 204, 0, 6, 0, 16, 16, 5, 255, 218, 0, 8, 1, 1, 0, 0, 63, 0, 210, 207,
+					32, 255, 217},
+			},
+		},
+	}
+
+	testEmailFromFile(t, fp, expectedEmail)
+}
+func TestParseEmailThaiMultipartRelatedTis620OverQuotedprintable(t *testing.T) {
+	fp := "tests/test_thai_multipart_related_tis-620_over_quoted-printable.txt"
+	tz, _ := time.LoadLocation("Asia/Bangkok")
+	expectedDate, _ := time.Parse(
+		time.RFC1123Z+" (MST)",
+		time.Date(2019, time.April, 1, 7, 55, 0, 0, tz).Format(time.RFC1123Z+" (MST)"))
+	expectedEmail := Email{
+		Headers: Headers{
+			Date:    expectedDate,
+			Subject: "📧 Test แพนแกรมภาษาไทย",
+			ReplyTo: []*mail.Address{
+				{
+					Name:    "อลิซ ผู้ส่งจดหมาย",
+					Address: "alis.phusngcdhmay@example.net",
+				},
+			},
+			Sender: &mail.Address{
+				Name:    "อลิซ ผู้ส่งจดหมาย",
+				Address: "alis.phusngcdhmay@example.com",
+			},
+			From: []*mail.Address{
+				{
+					Name:    "อลิซ ผู้ส่งจดหมาย",
+					Address: "alis.phusngcdhmay@example.com",
+				},
+				{
+					Name:    "อลิซ ผู้ส่งจดหมาย",
+					Address: "alis.phusngcdhmay@example.net",
+				},
+			},
+			To: []*mail.Address{
+				{
+					Name:    "บ๊อบ ผู้รับ",
+					Address: "bob.phurab@example.com",
+				},
+				{
+					Name:    "คาโรล ผู้รับ",
+					Address: "carol.phurab@example.com",
+				},
+			},
+			Cc: []*mail.Address{
+				{
+					Name:    "แดน ผู้รับ",
+					Address: "dan.phurab@example.com",
+				},
+				{
+					Name:    "อีฟ ผู้รับ",
+					Address: "eve.phurab@example.com",
+				},
+			},
+			Bcc: []*mail.Address{
+				{
+					Name:    "แฟรงค์ ผู้รับ",
+					Address: "frank.phurab@example.com",
+				},
+				{
+					Name:    "เกรซ ผู้รับ",
+					Address: "grace.phurab@example.com",
+				},
+			},
+			MessageID:  "Message-Id-1@example.com",
+			InReplyTo:  []MessageId{"Message-Id-0@example.com"},
+			References: []MessageId{"Message-Id-0@example.com"},
+			Comments:   "Message Header Comment",
+			Keywords:   []string{"Keyword 1", "Keyword 2"},
+			ResentDate: expectedDate,
+			ResentFrom: []*mail.Address{
+				{
+					Name:    "อลิซ ผู้ส่งจดหมาย",
+					Address: "alis.phusngcdhmay@example.net",
+				},
+				{
+					Name:    "อลิซ ผู้ส่งจดหมาย",
+					Address: "alis.phusngcdhmay@example.com",
+				},
+			},
+			ResentSender: &mail.Address{
+				Name:    "อลิซ ผู้ส่งจดหมาย",
+				Address: "alis.phusngcdhmay@example.net",
+			},
+			ResentTo: []*mail.Address{
+				{
+					Name:    "บ๊อบ ผู้รับ",
+					Address: "bob.phurab@example.net",
+				},
+				{
+					Name:    "คาโรล ผู้รับ",
+					Address: "carol.phurab@example.net",
+				},
+			},
+			ResentCc: []*mail.Address{
+				{
+					Name:    "แดน ผู้รับ",
+					Address: "dan.phurab@example.net",
+				},
+				{
+					Name:    "อีฟ ผู้รับ",
+					Address: "eve.phurab@example.net",
+				},
+			},
+			ResentBcc: []*mail.Address{
+				{
+					Name:    "แฟรงค์ ผู้รับ",
+					Address: "frank.phurab@example.net",
+				},
+				{
+					Name:    "เกรซ ผู้รับ",
+					Address: "grace.phurab@example.net",
+				},
+			},
+			ResentMessageID: "Message-Id-1@example.net",
+			ContentType: ContentTypeHeader{
+				ContentType: "multipart/related",
+				Params: map[string]string{
+					"boundary": "RelatedBoundaryString",
+					"charset":  "tis-620",
+				},
+			},
+			ExtraHeaders: map[string][]string{
+				"X-Clacks-Overhead": {"GNU Terry Pratchett"},
+			},
+		},
+		Text: `เป็นมนุษย์สุดประเสริฐเลิศคุณค่า กว่าบรรดาฝูงสัตว์เดรัจฉาน จงฝ่าฟันพัฒนาวิชาการ อย่าล้างผลาญฤๅเข่นฆ่าบีฑาใคร ไม่ถือโทษโกรธแช่งซัดฮึดฮัดด่า หัดอภัยเหมือนกีฬาอัชฌาสัย ปฏิบัติประพฤติกฎกำหนดใจ พูดจาให้จ๊ะๆ จ๋าๆ น่าฟังเอยฯ
+
+นายสังฆภัณฑ์ เฮงพิทักษ์ฝั่ง ผู้เฒ่าซึ่งมีอาชีพเป็นฅนขายฃวด ถูกตำรวจปฏิบัติการจับฟ้องศาล ฐานลักนาฬิกาคุณหญิงฉัตรชฎา ฌานสมาธิ`,
+		EnrichedText: `<bold>เป็นมนุษย์สุดประเสริฐเลิศคุณค่า</bold> <italic>กว่าบรรดาฝูงสัตว์เดรัจฉาน</italic> <fixed>จงฝ่าฟันพัฒนาวิชาการ</fixed> <underline>อย่าล้างผลาญฤๅเข่นฆ่าบีฑาใคร</underline> ไม่ถือโทษโกรธแช่งซัดฮึดฮัดด่า หัดอภัยเหมือนกีฬาอัชฌาสัย ปฏิบัติประพฤติกฎกำหนดใจ พูดจาให้จ๊ะๆ จ๋าๆ น่าฟังเอยฯ
+
+นายสังฆภัณฑ์ เฮงพิทักษ์ฝั่ง ผู้เฒ่าซึ่งมีอาชีพเป็นฅนขายฃวด ถูกตำรวจปฏิบัติการจับฟ้องศาล ฐานลักนาฬิกาคุณหญิงฉัตรชฎา ฌานสมาธิ`,
+		HTML: `<html>
+<div dir="ltr">
+<p>เป็นมนุษย์สุดประเสริฐเลิศคุณค่า กว่าบรรดาฝูงสัตว์เดรัจฉาน จงฝ่าฟันพัฒนาวิชาการ อย่าล้างผลาญฤๅเข่นฆ่าบีฑาใคร ไม่ถือโทษโกรธแช่งซัดฮึดฮัดด่า หัดอภัยเหมือนกีฬาอัชฌาสัย ปฏิบัติประพฤติกฎกำหนดใจ พูดจาให้จ๊ะๆ จ๋าๆ น่าฟังเอยฯ</p>
+
+<p>นายสังฆภัณฑ์ เฮงพิทักษ์ฝั่ง ผู้เฒ่าซึ่งมีอาชีพเป็นฅนขายฃวด ถูกตำรวจปฏิบัติการจับฟ้องศาล ฐานลักนาฬิกาคุณหญิงฉัตรชฎา ฌานสมาธิ</p>
+</div>
+</html>`,
+		InlineFiles: []InlineFile{
+			{
+				ContentID: "inline-jpg-image.jpg@example.com",
+				ContentType: ContentTypeHeader{
+					ContentType: "image/jpeg",
+					Params: map[string]string{
+						"name": "inline-jpg-image-name.jpg",
+					},
+				},
+				ContentDisposition: ContentDispositionHeader{
+					ContentDisposition: inline,
+					Params: map[string]string{
+						"filename": "inline-jpg-image-filename.jpg",
+					},
+				},
+				Data: []byte{255, 216, 255, 219, 0, 67, 0, 3, 2, 2, 2, 2, 2, 3, 2, 2, 2, 3, 3, 3, 3, 4,
+					6, 4, 4, 4, 4, 4, 8, 6, 6, 5, 6, 9, 8, 10, 10, 9, 8, 9, 9, 10, 12, 15, 12, 10, 11, 14, 11, 9, 9,
+					13, 17, 13, 14, 15, 16, 16, 17, 16, 10, 12, 18, 19, 18, 16, 19, 15, 16, 16, 16, 255, 201, 0, 11, 8,
+					0, 1, 0, 1, 1, 1, 17, 0, 255, 204, 0, 6, 0, 16, 16, 5, 255, 218, 0, 8, 1, 1, 0, 0, 63, 0, 210, 207,
+					32, 255, 217},
+			},
+		},
+	}
+
+	testEmailFromFile(t, fp, expectedEmail)
+}
+func TestParseEmailThaiMultipartMixedIso885911OverBase64(t *testing.T) {
+	fp := "tests/test_thai_multipart_mixed_iso-8859-11_over_base64.txt"
+	tz, _ := time.LoadLocation("Asia/Bangkok")
+	expectedDate, _ := time.Parse(
+		time.RFC1123Z+" (MST)",
+		time.Date(2019, time.April, 1, 7, 55, 0, 0, tz).Format(time.RFC1123Z+" (MST)"))
+	expectedEmail := Email{
+		Headers: Headers{
+			Date:    expectedDate,
+			Subject: "📧 Test แพนแกรมภาษาไทย",
+			ReplyTo: []*mail.Address{
+				{
+					Name:    "อลิซ ผู้ส่งจดหมาย",
+					Address: "alis.phusngcdhmay@example.net",
+				},
+			},
+			Sender: &mail.Address{
+				Name:    "อลิซ ผู้ส่งจดหมาย",
+				Address: "alis.phusngcdhmay@example.com",
+			},
+			From: []*mail.Address{
+				{
+					Name:    "อลิซ ผู้ส่งจดหมาย",
+					Address: "alis.phusngcdhmay@example.com",
+				},
+				{
+					Name:    "อลิซ ผู้ส่งจดหมาย",
+					Address: "alis.phusngcdhmay@example.net",
+				},
+			},
+			To: []*mail.Address{
+				{
+					Name:    "บ๊อบ ผู้รับ",
+					Address: "bob.phurab@example.com",
+				},
+				{
+					Name:    "คาโรล ผู้รับ",
+					Address: "carol.phurab@example.com",
+				},
+			},
+			Cc: []*mail.Address{
+				{
+					Name:    "แดน ผู้รับ",
+					Address: "dan.phurab@example.com",
+				},
+				{
+					Name:    "อีฟ ผู้รับ",
+					Address: "eve.phurab@example.com",
+				},
+			},
+			Bcc: []*mail.Address{
+				{
+					Name:    "แฟรงค์ ผู้รับ",
+					Address: "frank.phurab@example.com",
+				},
+				{
+					Name:    "เกรซ ผู้รับ",
+					Address: "grace.phurab@example.com",
+				},
+			},
+			MessageID:  "Message-Id-1@example.com",
+			InReplyTo:  []MessageId{"Message-Id-0@example.com"},
+			References: []MessageId{"Message-Id-0@example.com"},
+			Comments:   "Message Header Comment",
+			Keywords:   []string{"Keyword 1", "Keyword 2"},
+			ResentDate: expectedDate,
+			ResentFrom: []*mail.Address{
+				{
+					Name:    "อลิซ ผู้ส่งจดหมาย",
+					Address: "alis.phusngcdhmay@example.net",
+				},
+				{
+					Name:    "อลิซ ผู้ส่งจดหมาย",
+					Address: "alis.phusngcdhmay@example.com",
+				},
+			},
+			ResentSender: &mail.Address{
+				Name:    "อลิซ ผู้ส่งจดหมาย",
+				Address: "alis.phusngcdhmay@example.net",
+			},
+			ResentTo: []*mail.Address{
+				{
+					Name:    "บ๊อบ ผู้รับ",
+					Address: "bob.phurab@example.net",
+				},
+				{
+					Name:    "คาโรล ผู้รับ",
+					Address: "carol.phurab@example.net",
+				},
+			},
+			ResentCc: []*mail.Address{
+				{
+					Name:    "แดน ผู้รับ",
+					Address: "dan.phurab@example.net",
+				},
+				{
+					Name:    "อีฟ ผู้รับ",
+					Address: "eve.phurab@example.net",
+				},
+			},
+			ResentBcc: []*mail.Address{
+				{
+					Name:    "แฟรงค์ ผู้รับ",
+					Address: "frank.phurab@example.net",
+				},
+				{
+					Name:    "เกรซ ผู้รับ",
+					Address: "grace.phurab@example.net",
+				},
+			},
+			ResentMessageID: "Message-Id-1@example.net",
+			ContentType: ContentTypeHeader{
+				ContentType: "multipart/mixed",
+				Params: map[string]string{
+					"boundary": "MixedBoundaryString",
+					"charset":  "iso-8859-11",
+				},
+			},
+			ExtraHeaders: map[string][]string{
+				"X-Clacks-Overhead": {"GNU Terry Pratchett"},
+			},
+		},
+		Text: `เป็นมนุษย์สุดประเสริฐเลิศคุณค่า กว่าบรรดาฝูงสัตว์เดรัจฉาน จงฝ่าฟันพัฒนาวิชาการ อย่าล้างผลาญฤๅเข่นฆ่าบีฑาใคร ไม่ถือโทษโกรธแช่งซัดฮึดฮัดด่า หัดอภัยเหมือนกีฬาอัชฌาสัย ปฏิบัติประพฤติกฎกำหนดใจ พูดจาให้จ๊ะๆ จ๋าๆ น่าฟังเอยฯ
+
+นายสังฆภัณฑ์ เฮงพิทักษ์ฝั่ง ผู้เฒ่าซึ่งมีอาชีพเป็นฅนขายฃวด ถูกตำรวจปฏิบัติการจับฟ้องศาล ฐานลักนาฬิกาคุณหญิงฉัตรชฎา ฌานสมาธิ`,
+		EnrichedText: `<bold>เป็นมนุษย์สุดประเสริฐเลิศคุณค่า</bold> <italic>กว่าบรรดาฝูงสัตว์เดรัจฉาน</italic> <fixed>จงฝ่าฟันพัฒนาวิชาการ</fixed> <underline>อย่าล้างผลาญฤๅเข่นฆ่าบีฑาใคร</underline> ไม่ถือโทษโกรธแช่งซัดฮึดฮัดด่า หัดอภัยเหมือนกีฬาอัชฌาสัย ปฏิบัติประพฤติกฎกำหนดใจ พูดจาให้จ๊ะๆ จ๋าๆ น่าฟังเอยฯ
+
+นายสังฆภัณฑ์ เฮงพิทักษ์ฝั่ง ผู้เฒ่าซึ่งมีอาชีพเป็นฅนขายฃวด ถูกตำรวจปฏิบัติการจับฟ้องศาล ฐานลักนาฬิกาคุณหญิงฉัตรชฎา ฌานสมาธิ`,
+		HTML: `<html>
+<div dir="ltr">
+<p>เป็นมนุษย์สุดประเสริฐเลิศคุณค่า กว่าบรรดาฝูงสัตว์เดรัจฉาน จงฝ่าฟันพัฒนาวิชาการ อย่าล้างผลาญฤๅเข่นฆ่าบีฑาใคร ไม่ถือโทษโกรธแช่งซัดฮึดฮัดด่า หัดอภัยเหมือนกีฬาอัชฌาสัย ปฏิบัติประพฤติกฎกำหนดใจ พูดจาให้จ๊ะๆ จ๋าๆ น่าฟังเอยฯ</p>
+
+<p>นายสังฆภัณฑ์ เฮงพิทักษ์ฝั่ง ผู้เฒ่าซึ่งมีอาชีพเป็นฅนขายฃวด ถูกตำรวจปฏิบัติการจับฟ้องศาล ฐานลักนาฬิกาคุณหญิงฉัตรชฎา ฌานสมาธิ</p>
+</div>
+</html>`,
+		InlineFiles: []InlineFile{
+			{
+				ContentType: ContentTypeHeader{
+					ContentType: "image/jpeg",
+					Params: map[string]string{
+						"name": "inline-jpg-image-without-disposition.jpg",
+					},
+				},
+				ContentDisposition: ContentDispositionHeader{
+					ContentDisposition: "",
+					Params:             map[string]string(nil),
+				},
+				Data: []byte{255, 216, 255, 219, 0, 67, 0, 3, 2, 2, 2, 2, 2, 3, 2, 2, 2, 3, 3, 3, 3, 4,
+					6, 4, 4, 4, 4, 4, 8, 6, 6, 5, 6, 9, 8, 10, 10, 9, 8, 9, 9, 10, 12, 15, 12, 10, 11, 14, 11, 9, 9,
+					13, 17, 13, 14, 15, 16, 16, 17, 16, 10, 12, 18, 19, 18, 16, 19, 15, 16, 16, 16, 255, 201, 0, 11, 8,
+					0, 1, 0, 1, 1, 1, 17, 0, 255, 204, 0, 6, 0, 16, 16, 5, 255, 218, 0, 8, 1, 1, 0, 0, 63, 0, 210, 207,
+					32, 255, 217},
+			},
+			{
+				ContentID: "inline-jpg-image.jpg@example.com",
+				ContentType: ContentTypeHeader{
+					ContentType: "image/jpeg",
+					Params: map[string]string{
+						"name": "inline-jpg-image-name.jpg",
+					},
+				},
+				ContentDisposition: ContentDispositionHeader{
+					ContentDisposition: inline,
+					Params: map[string]string{
+						"filename": "inline-jpg-image-filename.jpg",
+					},
+				},
+				Data: []byte{255, 216, 255, 219, 0, 67, 0, 3, 2, 2, 2, 2, 2, 3, 2, 2, 2, 3, 3, 3, 3, 4,
+					6, 4, 4, 4, 4, 4, 8, 6, 6, 5, 6, 9, 8, 10, 10, 9, 8, 9, 9, 10, 12, 15, 12, 10, 11, 14, 11, 9, 9,
+					13, 17, 13, 14, 15, 16, 16, 17, 16, 10, 12, 18, 19, 18, 16, 19, 15, 16, 16, 16, 255, 201, 0, 11, 8,
+					0, 1, 0, 1, 1, 1, 17, 0, 255, 204, 0, 6, 0, 16, 16, 5, 255, 218, 0, 8, 1, 1, 0, 0, 63, 0, 210, 207,
+					32, 255, 217},
+			},
+		},
+		AttachedFiles: []AttachedFile{
+			{
+				ContentType: ContentTypeHeader{
+					ContentType: "application/pdf",
+					Params: map[string]string{
+						"name": "attached-pdf-name.pdf",
+					},
+				},
+				ContentDisposition: ContentDispositionHeader{
+					ContentDisposition: attachment,
+					Params: map[string]string{
+						"filename": "attached-pdf-filename.pdf",
+					},
+				},
+				Data: []byte{37, 80, 68, 70, 45, 49, 46, 13, 116, 114, 97, 105, 108, 101, 114, 60, 60,
+					47, 82, 111, 111, 116, 60, 60, 47, 80, 97, 103, 101, 115, 60, 60, 47, 75, 105, 100, 115, 91, 60,
+					60, 47, 77, 101, 100, 105, 97, 66, 111, 120, 91, 48, 32, 48, 32, 51, 32, 51, 93, 62, 62, 93, 62,
+					62, 62, 62, 62, 62},
+			},
+			{
+				ContentType: ContentTypeHeader{
+					ContentType: "application/pdf",
+					Params: map[string]string{
+						"name": "attached-pdf-without-disposition.pdf",
+					},
+				},
+				ContentDisposition: ContentDispositionHeader{
+					ContentDisposition: "",
+					Params:             map[string]string(nil),
+				},
+				Data: []byte{37, 80, 68, 70, 45, 49, 46, 13, 116, 114, 97, 105, 108, 101, 114, 60, 60,
+					47, 82, 111, 111, 116, 60, 60, 47, 80, 97, 103, 101, 115, 60, 60, 47, 75, 105, 100, 115, 91, 60,
+					60, 47, 77, 101, 100, 105, 97, 66, 111, 120, 91, 48, 32, 48, 32, 51, 32, 51, 93, 62, 62, 93, 62,
+					62, 62, 62, 62, 62},
+			},
+			{
+				ContentType: ContentTypeHeader{
+					ContentType: "application/json",
+					Params: map[string]string{
+						"name": "attached-json-name.json",
+					},
+				},
+				ContentDisposition: ContentDispositionHeader{
+					ContentDisposition: attachment,
+					Params: map[string]string{
+						"filename": "attached-json-filename.json",
+					},
+				},
+				Data: []byte{123, 34, 102, 111, 111, 34, 58, 34, 98, 97, 114, 34, 125},
+			},
+			{
+				ContentType: ContentTypeHeader{
+					ContentType: "text/plain",
+					Params: map[string]string{
+						"name": "attached-text-plain-name.txt",
+					},
+				},
+				ContentDisposition: ContentDispositionHeader{
+					ContentDisposition: attachment,
+					Params: map[string]string{
+						"filename": "attached-text-plain-filename.txt",
+					},
+				},
+				Data: []byte{84, 101, 120, 116, 47, 112, 108, 97, 105, 110, 32, 99, 111, 110, 116, 101, 110, 116, 32,
+					97, 115, 32, 97, 110, 32, 97, 116, 116, 97, 99, 104, 101, 100, 32, 46, 116, 120, 116, 32, 102, 105,
+					108, 101, 46},
+			},
+			{
+				ContentType: ContentTypeHeader{
+					ContentType: "text/html",
+					Params: map[string]string{
+						"name": "attached-text-html-name.html",
+					},
+				},
+				ContentDisposition: ContentDispositionHeader{
+					ContentDisposition: attachment,
+					Params: map[string]string{
+						"filename": "attached-text-html-filename.html",
+					},
+				},
+				Data: []byte{84, 101, 120, 116, 47, 104, 116, 109, 108, 32, 99, 111, 110, 116, 101, 110, 116, 32, 97,
+					115, 32, 97, 110, 32, 97, 116, 116, 97, 99, 104, 101, 100, 32, 46, 104, 116, 109, 108, 32, 102,
+					105, 108, 101, 46},
+			},
+		},
+	}
+
+	testEmailFromFile(t, fp, expectedEmail)
+}
+func TestParseEmailThaiMultipartMixedIso885911OverQuotedprintable(t *testing.T) {
+	fp := "tests/test_thai_multipart_mixed_iso-8859-11_over_quoted-printable.txt"
+	tz, _ := time.LoadLocation("Asia/Bangkok")
+	expectedDate, _ := time.Parse(
+		time.RFC1123Z+" (MST)",
+		time.Date(2019, time.April, 1, 7, 55, 0, 0, tz).Format(time.RFC1123Z+" (MST)"))
+	expectedEmail := Email{
+		Headers: Headers{
+			Date:    expectedDate,
+			Subject: "📧 Test แพนแกรมภาษาไทย",
+			ReplyTo: []*mail.Address{
+				{
+					Name:    "อลิซ ผู้ส่งจดหมาย",
+					Address: "alis.phusngcdhmay@example.net",
+				},
+			},
+			Sender: &mail.Address{
+				Name:    "อลิซ ผู้ส่งจดหมาย",
+				Address: "alis.phusngcdhmay@example.com",
+			},
+			From: []*mail.Address{
+				{
+					Name:    "อลิซ ผู้ส่งจดหมาย",
+					Address: "alis.phusngcdhmay@example.com",
+				},
+				{
+					Name:    "อลิซ ผู้ส่งจดหมาย",
+					Address: "alis.phusngcdhmay@example.net",
+				},
+			},
+			To: []*mail.Address{
+				{
+					Name:    "บ๊อบ ผู้รับ",
+					Address: "bob.phurab@example.com",
+				},
+				{
+					Name:    "คาโรล ผู้รับ",
+					Address: "carol.phurab@example.com",
+				},
+			},
+			Cc: []*mail.Address{
+				{
+					Name:    "แดน ผู้รับ",
+					Address: "dan.phurab@example.com",
+				},
+				{
+					Name:    "อีฟ ผู้รับ",
+					Address: "eve.phurab@example.com",
+				},
+			},
+			Bcc: []*mail.Address{
+				{
+					Name:    "แฟรงค์ ผู้รับ",
+					Address: "frank.phurab@example.com",
+				},
+				{
+					Name:    "เกรซ ผู้รับ",
+					Address: "grace.phurab@example.com",
+				},
+			},
+			MessageID:  "Message-Id-1@example.com",
+			InReplyTo:  []MessageId{"Message-Id-0@example.com"},
+			References: []MessageId{"Message-Id-0@example.com"},
+			Comments:   "Message Header Comment",
+			Keywords:   []string{"Keyword 1", "Keyword 2"},
+			ResentDate: expectedDate,
+			ResentFrom: []*mail.Address{
+				{
+					Name:    "อลิซ ผู้ส่งจดหมาย",
+					Address: "alis.phusngcdhmay@example.net",
+				},
+				{
+					Name:    "อลิซ ผู้ส่งจดหมาย",
+					Address: "alis.phusngcdhmay@example.com",
+				},
+			},
+			ResentSender: &mail.Address{
+				Name:    "อลิซ ผู้ส่งจดหมาย",
+				Address: "alis.phusngcdhmay@example.net",
+			},
+			ResentTo: []*mail.Address{
+				{
+					Name:    "บ๊อบ ผู้รับ",
+					Address: "bob.phurab@example.net",
+				},
+				{
+					Name:    "คาโรล ผู้รับ",
+					Address: "carol.phurab@example.net",
+				},
+			},
+			ResentCc: []*mail.Address{
+				{
+					Name:    "แดน ผู้รับ",
+					Address: "dan.phurab@example.net",
+				},
+				{
+					Name:    "อีฟ ผู้รับ",
+					Address: "eve.phurab@example.net",
+				},
+			},
+			ResentBcc: []*mail.Address{
+				{
+					Name:    "แฟรงค์ ผู้รับ",
+					Address: "frank.phurab@example.net",
+				},
+				{
+					Name:    "เกรซ ผู้รับ",
+					Address: "grace.phurab@example.net",
+				},
+			},
+			ResentMessageID: "Message-Id-1@example.net",
+			ContentType: ContentTypeHeader{
+				ContentType: "multipart/mixed",
+				Params: map[string]string{
+					"boundary": "MixedBoundaryString",
+					"charset":  "iso-8859-11",
+				},
+			},
+			ExtraHeaders: map[string][]string{
+				"X-Clacks-Overhead": {"GNU Terry Pratchett"},
+			},
+		},
+		Text: `เป็นมนุษย์สุดประเสริฐเลิศคุณค่า กว่าบรรดาฝูงสัตว์เดรัจฉาน จงฝ่าฟันพัฒนาวิชาการ อย่าล้างผลาญฤๅเข่นฆ่าบีฑาใคร ไม่ถือโทษโกรธแช่งซัดฮึดฮัดด่า หัดอภัยเหมือนกีฬาอัชฌาสัย ปฏิบัติประพฤติกฎกำหนดใจ พูดจาให้จ๊ะๆ จ๋าๆ น่าฟังเอยฯ
+
+นายสังฆภัณฑ์ เฮงพิทักษ์ฝั่ง ผู้เฒ่าซึ่งมีอาชีพเป็นฅนขายฃวด ถูกตำรวจปฏิบัติการจับฟ้องศาล ฐานลักนาฬิกาคุณหญิงฉัตรชฎา ฌานสมาธิ`,
+		EnrichedText: `<bold>เป็นมนุษย์สุดประเสริฐเลิศคุณค่า</bold> <italic>กว่าบรรดาฝูงสัตว์เดรัจฉาน</italic> <fixed>จงฝ่าฟันพัฒนาวิชาการ</fixed> <underline>อย่าล้างผลาญฤๅเข่นฆ่าบีฑาใคร</underline> ไม่ถือโทษโกรธแช่งซัดฮึดฮัดด่า หัดอภัยเหมือนกีฬาอัชฌาสัย ปฏิบัติประพฤติกฎกำหนดใจ พูดจาให้จ๊ะๆ จ๋าๆ น่าฟังเอยฯ
+
+นายสังฆภัณฑ์ เฮงพิทักษ์ฝั่ง ผู้เฒ่าซึ่งมีอาชีพเป็นฅนขายฃวด ถูกตำรวจปฏิบัติการจับฟ้องศาล ฐานลักนาฬิกาคุณหญิงฉัตรชฎา ฌานสมาธิ`,
+		HTML: `<html>
+<div dir="ltr">
+<p>เป็นมนุษย์สุดประเสริฐเลิศคุณค่า กว่าบรรดาฝูงสัตว์เดรัจฉาน จงฝ่าฟันพัฒนาวิชาการ อย่าล้างผลาญฤๅเข่นฆ่าบีฑาใคร ไม่ถือโทษโกรธแช่งซัดฮึดฮัดด่า หัดอภัยเหมือนกีฬาอัชฌาสัย ปฏิบัติประพฤติกฎกำหนดใจ พูดจาให้จ๊ะๆ จ๋าๆ น่าฟังเอยฯ</p>
+
+<p>นายสังฆภัณฑ์ เฮงพิทักษ์ฝั่ง ผู้เฒ่าซึ่งมีอาชีพเป็นฅนขายฃวด ถูกตำรวจปฏิบัติการจับฟ้องศาล ฐานลักนาฬิกาคุณหญิงฉัตรชฎา ฌานสมาธิ</p>
+</div>
+</html>`,
+		InlineFiles: []InlineFile{
+			{
+				ContentType: ContentTypeHeader{
+					ContentType: "image/jpeg",
+					Params: map[string]string{
+						"name": "inline-jpg-image-without-disposition.jpg",
+					},
+				},
+				ContentDisposition: ContentDispositionHeader{
+					ContentDisposition: "",
+					Params:             map[string]string(nil),
+				},
+				Data: []byte{255, 216, 255, 219, 0, 67, 0, 3, 2, 2, 2, 2, 2, 3, 2, 2, 2, 3, 3, 3, 3, 4,
+					6, 4, 4, 4, 4, 4, 8, 6, 6, 5, 6, 9, 8, 10, 10, 9, 8, 9, 9, 10, 12, 15, 12, 10, 11, 14, 11, 9, 9,
+					13, 17, 13, 14, 15, 16, 16, 17, 16, 10, 12, 18, 19, 18, 16, 19, 15, 16, 16, 16, 255, 201, 0, 11, 8,
+					0, 1, 0, 1, 1, 1, 17, 0, 255, 204, 0, 6, 0, 16, 16, 5, 255, 218, 0, 8, 1, 1, 0, 0, 63, 0, 210, 207,
+					32, 255, 217},
+			},
+			{
+				ContentID: "inline-jpg-image.jpg@example.com",
+				ContentType: ContentTypeHeader{
+					ContentType: "image/jpeg",
+					Params: map[string]string{
+						"name": "inline-jpg-image-name.jpg",
+					},
+				},
+				ContentDisposition: ContentDispositionHeader{
+					ContentDisposition: inline,
+					Params: map[string]string{
+						"filename": "inline-jpg-image-filename.jpg",
+					},
+				},
+				Data: []byte{255, 216, 255, 219, 0, 67, 0, 3, 2, 2, 2, 2, 2, 3, 2, 2, 2, 3, 3, 3, 3, 4,
+					6, 4, 4, 4, 4, 4, 8, 6, 6, 5, 6, 9, 8, 10, 10, 9, 8, 9, 9, 10, 12, 15, 12, 10, 11, 14, 11, 9, 9,
+					13, 17, 13, 14, 15, 16, 16, 17, 16, 10, 12, 18, 19, 18, 16, 19, 15, 16, 16, 16, 255, 201, 0, 11, 8,
+					0, 1, 0, 1, 1, 1, 17, 0, 255, 204, 0, 6, 0, 16, 16, 5, 255, 218, 0, 8, 1, 1, 0, 0, 63, 0, 210, 207,
+					32, 255, 217},
+			},
+		},
+		AttachedFiles: []AttachedFile{
+			{
+				ContentType: ContentTypeHeader{
+					ContentType: "application/pdf",
+					Params: map[string]string{
+						"name": "attached-pdf-name.pdf",
+					},
+				},
+				ContentDisposition: ContentDispositionHeader{
+					ContentDisposition: attachment,
+					Params: map[string]string{
+						"filename": "attached-pdf-filename.pdf",
+					},
+				},
+				Data: []byte{37, 80, 68, 70, 45, 49, 46, 13, 116, 114, 97, 105, 108, 101, 114, 60, 60,
+					47, 82, 111, 111, 116, 60, 60, 47, 80, 97, 103, 101, 115, 60, 60, 47, 75, 105, 100, 115, 91, 60,
+					60, 47, 77, 101, 100, 105, 97, 66, 111, 120, 91, 48, 32, 48, 32, 51, 32, 51, 93, 62, 62, 93, 62,
+					62, 62, 62, 62, 62},
+			},
+			{
+				ContentType: ContentTypeHeader{
+					ContentType: "application/pdf",
+					Params: map[string]string{
+						"name": "attached-pdf-without-disposition.pdf",
+					},
+				},
+				ContentDisposition: ContentDispositionHeader{
+					ContentDisposition: "",
+					Params:             map[string]string(nil),
+				},
+				Data: []byte{37, 80, 68, 70, 45, 49, 46, 13, 116, 114, 97, 105, 108, 101, 114, 60, 60,
+					47, 82, 111, 111, 116, 60, 60, 47, 80, 97, 103, 101, 115, 60, 60, 47, 75, 105, 100, 115, 91, 60,
+					60, 47, 77, 101, 100, 105, 97, 66, 111, 120, 91, 48, 32, 48, 32, 51, 32, 51, 93, 62, 62, 93, 62,
+					62, 62, 62, 62, 62},
+			},
+			{
+				ContentType: ContentTypeHeader{
+					ContentType: "application/json",
+					Params: map[string]string{
+						"name": "attached-json-name.json",
+					},
+				},
+				ContentDisposition: ContentDispositionHeader{
+					ContentDisposition: attachment,
+					Params: map[string]string{
+						"filename": "attached-json-filename.json",
+					},
+				},
+				Data: []byte{123, 34, 102, 111, 111, 34, 58, 34, 98, 97, 114, 34, 125},
+			},
+			{
+				ContentType: ContentTypeHeader{
+					ContentType: "text/plain",
+					Params: map[string]string{
+						"name": "attached-text-plain-name.txt",
+					},
+				},
+				ContentDisposition: ContentDispositionHeader{
+					ContentDisposition: attachment,
+					Params: map[string]string{
+						"filename": "attached-text-plain-filename.txt",
+					},
+				},
+				Data: []byte{84, 101, 120, 116, 47, 112, 108, 97, 105, 110, 32, 99, 111, 110, 116, 101, 110, 116, 32,
+					97, 115, 32, 97, 110, 32, 97, 116, 116, 97, 99, 104, 101, 100, 32, 46, 116, 120, 116, 32, 102, 105,
+					108, 101, 46},
+			},
+			{
+				ContentType: ContentTypeHeader{
+					ContentType: "text/html",
+					Params: map[string]string{
+						"name": "attached-text-html-name.html",
+					},
+				},
+				ContentDisposition: ContentDispositionHeader{
+					ContentDisposition: attachment,
+					Params: map[string]string{
+						"filename": "attached-text-html-filename.html",
+					},
+				},
+				Data: []byte{84, 101, 120, 116, 47, 104, 116, 109, 108, 32, 99, 111, 110, 116, 101, 110, 116, 32, 97,
+					115, 32, 97, 110, 32, 97, 116, 116, 97, 99, 104, 101, 100, 32, 46, 104, 116, 109, 108, 32, 102,
+					105, 108, 101, 46},
+			},
+		},
+	}
+
+	testEmailFromFile(t, fp, expectedEmail)
+}
+func TestParseEmailThaiMultipartMixedWindows874OverBase64(t *testing.T) {
+	fp := "tests/test_thai_multipart_mixed_windows-874_over_base64.txt"
+	tz, _ := time.LoadLocation("Asia/Bangkok")
+	expectedDate, _ := time.Parse(
+		time.RFC1123Z+" (MST)",
+		time.Date(2019, time.April, 1, 7, 55, 0, 0, tz).Format(time.RFC1123Z+" (MST)"))
+	expectedEmail := Email{
+		Headers: Headers{
+			Date:    expectedDate,
+			Subject: "📧 Test แพนแกรมภาษาไทย",
+			ReplyTo: []*mail.Address{
+				{
+					Name:    "อลิซ ผู้ส่งจดหมาย",
+					Address: "alis.phusngcdhmay@example.net",
+				},
+			},
+			Sender: &mail.Address{
+				Name:    "อลิซ ผู้ส่งจดหมาย",
+				Address: "alis.phusngcdhmay@example.com",
+			},
+			From: []*mail.Address{
+				{
+					Name:    "อลิซ ผู้ส่งจดหมาย",
+					Address: "alis.phusngcdhmay@example.com",
+				},
+				{
+					Name:    "อลิซ ผู้ส่งจดหมาย",
+					Address: "alis.phusngcdhmay@example.net",
+				},
+			},
+			To: []*mail.Address{
+				{
+					Name:    "บ๊อบ ผู้รับ",
+					Address: "bob.phurab@example.com",
+				},
+				{
+					Name:    "คาโรล ผู้รับ",
+					Address: "carol.phurab@example.com",
+				},
+			},
+			Cc: []*mail.Address{
+				{
+					Name:    "แดน ผู้รับ",
+					Address: "dan.phurab@example.com",
+				},
+				{
+					Name:    "อีฟ ผู้รับ",
+					Address: "eve.phurab@example.com",
+				},
+			},
+			Bcc: []*mail.Address{
+				{
+					Name:    "แฟรงค์ ผู้รับ",
+					Address: "frank.phurab@example.com",
+				},
+				{
+					Name:    "เกรซ ผู้รับ",
+					Address: "grace.phurab@example.com",
+				},
+			},
+			MessageID:  "Message-Id-1@example.com",
+			InReplyTo:  []MessageId{"Message-Id-0@example.com"},
+			References: []MessageId{"Message-Id-0@example.com"},
+			Comments:   "Message Header Comment",
+			Keywords:   []string{"Keyword 1", "Keyword 2"},
+			ResentDate: expectedDate,
+			ResentFrom: []*mail.Address{
+				{
+					Name:    "อลิซ ผู้ส่งจดหมาย",
+					Address: "alis.phusngcdhmay@example.net",
+				},
+				{
+					Name:    "อลิซ ผู้ส่งจดหมาย",
+					Address: "alis.phusngcdhmay@example.com",
+				},
+			},
+			ResentSender: &mail.Address{
+				Name:    "อลิซ ผู้ส่งจดหมาย",
+				Address: "alis.phusngcdhmay@example.net",
+			},
+			ResentTo: []*mail.Address{
+				{
+					Name:    "บ๊อบ ผู้รับ",
+					Address: "bob.phurab@example.net",
+				},
+				{
+					Name:    "คาโรล ผู้รับ",
+					Address: "carol.phurab@example.net",
+				},
+			},
+			ResentCc: []*mail.Address{
+				{
+					Name:    "แดน ผู้รับ",
+					Address: "dan.phurab@example.net",
+				},
+				{
+					Name:    "อีฟ ผู้รับ",
+					Address: "eve.phurab@example.net",
+				},
+			},
+			ResentBcc: []*mail.Address{
+				{
+					Name:    "แฟรงค์ ผู้รับ",
+					Address: "frank.phurab@example.net",
+				},
+				{
+					Name:    "เกรซ ผู้รับ",
+					Address: "grace.phurab@example.net",
+				},
+			},
+			ResentMessageID: "Message-Id-1@example.net",
+			ContentType: ContentTypeHeader{
+				ContentType: "multipart/mixed",
+				Params: map[string]string{
+					"boundary": "MixedBoundaryString",
+					"charset":  "windows-874",
+				},
+			},
+			ExtraHeaders: map[string][]string{
+				"X-Clacks-Overhead": {"GNU Terry Pratchett"},
+			},
+		},
+		Text: `เป็นมนุษย์สุดประเสริฐเลิศคุณค่า กว่าบรรดาฝูงสัตว์เดรัจฉาน จงฝ่าฟันพัฒนาวิชาการ อย่าล้างผลาญฤๅเข่นฆ่าบีฑาใคร ไม่ถือโทษโกรธแช่งซัดฮึดฮัดด่า หัดอภัยเหมือนกีฬาอัชฌาสัย ปฏิบัติประพฤติกฎกำหนดใจ พูดจาให้จ๊ะๆ จ๋าๆ น่าฟังเอยฯ
+
+นายสังฆภัณฑ์ เฮงพิทักษ์ฝั่ง ผู้เฒ่าซึ่งมีอาชีพเป็นฅนขายฃวด ถูกตำรวจปฏิบัติการจับฟ้องศาล ฐานลักนาฬิกาคุณหญิงฉัตรชฎา ฌานสมาธิ`,
+		EnrichedText: `<bold>เป็นมนุษย์สุดประเสริฐเลิศคุณค่า</bold> <italic>กว่าบรรดาฝูงสัตว์เดรัจฉาน</italic> <fixed>จงฝ่าฟันพัฒนาวิชาการ</fixed> <underline>อย่าล้างผลาญฤๅเข่นฆ่าบีฑาใคร</underline> ไม่ถือโทษโกรธแช่งซัดฮึดฮัดด่า หัดอภัยเหมือนกีฬาอัชฌาสัย ปฏิบัติประพฤติกฎกำหนดใจ พูดจาให้จ๊ะๆ จ๋าๆ น่าฟังเอยฯ
+
+นายสังฆภัณฑ์ เฮงพิทักษ์ฝั่ง ผู้เฒ่าซึ่งมีอาชีพเป็นฅนขายฃวด ถูกตำรวจปฏิบัติการจับฟ้องศาล ฐานลักนาฬิกาคุณหญิงฉัตรชฎา ฌานสมาธิ`,
+		HTML: `<html>
+<div dir="ltr">
+<p>เป็นมนุษย์สุดประเสริฐเลิศคุณค่า กว่าบรรดาฝูงสัตว์เดรัจฉาน จงฝ่าฟันพัฒนาวิชาการ อย่าล้างผลาญฤๅเข่นฆ่าบีฑาใคร ไม่ถือโทษโกรธแช่งซัดฮึดฮัดด่า หัดอภัยเหมือนกีฬาอัชฌาสัย ปฏิบัติประพฤติกฎกำหนดใจ พูดจาให้จ๊ะๆ จ๋าๆ น่าฟังเอยฯ</p>
+
+<p>นายสังฆภัณฑ์ เฮงพิทักษ์ฝั่ง ผู้เฒ่าซึ่งมีอาชีพเป็นฅนขายฃวด ถูกตำรวจปฏิบัติการจับฟ้องศาล ฐานลักนาฬิกาคุณหญิงฉัตรชฎา ฌานสมาธิ</p>
+</div>
+</html>`,
+		InlineFiles: []InlineFile{
+			{
+				ContentType: ContentTypeHeader{
+					ContentType: "image/jpeg",
+					Params: map[string]string{
+						"name": "inline-jpg-image-without-disposition.jpg",
+					},
+				},
+				ContentDisposition: ContentDispositionHeader{
+					ContentDisposition: "",
+					Params:             map[string]string(nil),
+				},
+				Data: []byte{255, 216, 255, 219, 0, 67, 0, 3, 2, 2, 2, 2, 2, 3, 2, 2, 2, 3, 3, 3, 3, 4,
+					6, 4, 4, 4, 4, 4, 8, 6, 6, 5, 6, 9, 8, 10, 10, 9, 8, 9, 9, 10, 12, 15, 12, 10, 11, 14, 11, 9, 9,
+					13, 17, 13, 14, 15, 16, 16, 17, 16, 10, 12, 18, 19, 18, 16, 19, 15, 16, 16, 16, 255, 201, 0, 11, 8,
+					0, 1, 0, 1, 1, 1, 17, 0, 255, 204, 0, 6, 0, 16, 16, 5, 255, 218, 0, 8, 1, 1, 0, 0, 63, 0, 210, 207,
+					32, 255, 217},
+			},
+			{
+				ContentID: "inline-jpg-image.jpg@example.com",
+				ContentType: ContentTypeHeader{
+					ContentType: "image/jpeg",
+					Params: map[string]string{
+						"name": "inline-jpg-image-name.jpg",
+					},
+				},
+				ContentDisposition: ContentDispositionHeader{
+					ContentDisposition: inline,
+					Params: map[string]string{
+						"filename": "inline-jpg-image-filename.jpg",
+					},
+				},
+				Data: []byte{255, 216, 255, 219, 0, 67, 0, 3, 2, 2, 2, 2, 2, 3, 2, 2, 2, 3, 3, 3, 3, 4,
+					6, 4, 4, 4, 4, 4, 8, 6, 6, 5, 6, 9, 8, 10, 10, 9, 8, 9, 9, 10, 12, 15, 12, 10, 11, 14, 11, 9, 9,
+					13, 17, 13, 14, 15, 16, 16, 17, 16, 10, 12, 18, 19, 18, 16, 19, 15, 16, 16, 16, 255, 201, 0, 11, 8,
+					0, 1, 0, 1, 1, 1, 17, 0, 255, 204, 0, 6, 0, 16, 16, 5, 255, 218, 0, 8, 1, 1, 0, 0, 63, 0, 210, 207,
+					32, 255, 217},
+			},
+		},
+		AttachedFiles: []AttachedFile{
+			{
+				ContentType: ContentTypeHeader{
+					ContentType: "application/pdf",
+					Params: map[string]string{
+						"name": "attached-pdf-name.pdf",
+					},
+				},
+				ContentDisposition: ContentDispositionHeader{
+					ContentDisposition: attachment,
+					Params: map[string]string{
+						"filename": "attached-pdf-filename.pdf",
+					},
+				},
+				Data: []byte{37, 80, 68, 70, 45, 49, 46, 13, 116, 114, 97, 105, 108, 101, 114, 60, 60,
+					47, 82, 111, 111, 116, 60, 60, 47, 80, 97, 103, 101, 115, 60, 60, 47, 75, 105, 100, 115, 91, 60,
+					60, 47, 77, 101, 100, 105, 97, 66, 111, 120, 91, 48, 32, 48, 32, 51, 32, 51, 93, 62, 62, 93, 62,
+					62, 62, 62, 62, 62},
+			},
+			{
+				ContentType: ContentTypeHeader{
+					ContentType: "application/pdf",
+					Params: map[string]string{
+						"name": "attached-pdf-without-disposition.pdf",
+					},
+				},
+				ContentDisposition: ContentDispositionHeader{
+					ContentDisposition: "",
+					Params:             map[string]string(nil),
+				},
+				Data: []byte{37, 80, 68, 70, 45, 49, 46, 13, 116, 114, 97, 105, 108, 101, 114, 60, 60,
+					47, 82, 111, 111, 116, 60, 60, 47, 80, 97, 103, 101, 115, 60, 60, 47, 75, 105, 100, 115, 91, 60,
+					60, 47, 77, 101, 100, 105, 97, 66, 111, 120, 91, 48, 32, 48, 32, 51, 32, 51, 93, 62, 62, 93, 62,
+					62, 62, 62, 62, 62},
+			},
+			{
+				ContentType: ContentTypeHeader{
+					ContentType: "application/json",
+					Params: map[string]string{
+						"name": "attached-json-name.json",
+					},
+				},
+				ContentDisposition: ContentDispositionHeader{
+					ContentDisposition: attachment,
+					Params: map[string]string{
+						"filename": "attached-json-filename.json",
+					},
+				},
+				Data: []byte{123, 34, 102, 111, 111, 34, 58, 34, 98, 97, 114, 34, 125},
+			},
+			{
+				ContentType: ContentTypeHeader{
+					ContentType: "text/plain",
+					Params: map[string]string{
+						"name": "attached-text-plain-name.txt",
+					},
+				},
+				ContentDisposition: ContentDispositionHeader{
+					ContentDisposition: attachment,
+					Params: map[string]string{
+						"filename": "attached-text-plain-filename.txt",
+					},
+				},
+				Data: []byte{84, 101, 120, 116, 47, 112, 108, 97, 105, 110, 32, 99, 111, 110, 116, 101, 110, 116, 32,
+					97, 115, 32, 97, 110, 32, 97, 116, 116, 97, 99, 104, 101, 100, 32, 46, 116, 120, 116, 32, 102, 105,
+					108, 101, 46},
+			},
+			{
+				ContentType: ContentTypeHeader{
+					ContentType: "text/html",
+					Params: map[string]string{
+						"name": "attached-text-html-name.html",
+					},
+				},
+				ContentDisposition: ContentDispositionHeader{
+					ContentDisposition: attachment,
+					Params: map[string]string{
+						"filename": "attached-text-html-filename.html",
+					},
+				},
+				Data: []byte{84, 101, 120, 116, 47, 104, 116, 109, 108, 32, 99, 111, 110, 116, 101, 110, 116, 32, 97,
+					115, 32, 97, 110, 32, 97, 116, 116, 97, 99, 104, 101, 100, 32, 46, 104, 116, 109, 108, 32, 102,
+					105, 108, 101, 46},
+			},
+		},
+	}
+
+	testEmailFromFile(t, fp, expectedEmail)
+}
+func TestParseEmailThaiMultipartMixedWindows874OverQuotedprintable(t *testing.T) {
+	fp := "tests/test_thai_multipart_mixed_windows-874_over_quoted-printable.txt"
+	tz, _ := time.LoadLocation("Asia/Bangkok")
+	expectedDate, _ := time.Parse(
+		time.RFC1123Z+" (MST)",
+		time.Date(2019, time.April, 1, 7, 55, 0, 0, tz).Format(time.RFC1123Z+" (MST)"))
+	expectedEmail := Email{
+		Headers: Headers{
+			Date:    expectedDate,
+			Subject: "📧 Test แพนแกรมภาษาไทย",
+			ReplyTo: []*mail.Address{
+				{
+					Name:    "อลิซ ผู้ส่งจดหมาย",
+					Address: "alis.phusngcdhmay@example.net",
+				},
+			},
+			Sender: &mail.Address{
+				Name:    "อลิซ ผู้ส่งจดหมาย",
+				Address: "alis.phusngcdhmay@example.com",
+			},
+			From: []*mail.Address{
+				{
+					Name:    "อลิซ ผู้ส่งจดหมาย",
+					Address: "alis.phusngcdhmay@example.com",
+				},
+				{
+					Name:    "อลิซ ผู้ส่งจดหมาย",
+					Address: "alis.phusngcdhmay@example.net",
+				},
+			},
+			To: []*mail.Address{
+				{
+					Name:    "บ๊อบ ผู้รับ",
+					Address: "bob.phurab@example.com",
+				},
+				{
+					Name:    "คาโรล ผู้รับ",
+					Address: "carol.phurab@example.com",
+				},
+			},
+			Cc: []*mail.Address{
+				{
+					Name:    "แดน ผู้รับ",
+					Address: "dan.phurab@example.com",
+				},
+				{
+					Name:    "อีฟ ผู้รับ",
+					Address: "eve.phurab@example.com",
+				},
+			},
+			Bcc: []*mail.Address{
+				{
+					Name:    "แฟรงค์ ผู้รับ",
+					Address: "frank.phurab@example.com",
+				},
+				{
+					Name:    "เกรซ ผู้รับ",
+					Address: "grace.phurab@example.com",
+				},
+			},
+			MessageID:  "Message-Id-1@example.com",
+			InReplyTo:  []MessageId{"Message-Id-0@example.com"},
+			References: []MessageId{"Message-Id-0@example.com"},
+			Comments:   "Message Header Comment",
+			Keywords:   []string{"Keyword 1", "Keyword 2"},
+			ResentDate: expectedDate,
+			ResentFrom: []*mail.Address{
+				{
+					Name:    "อลิซ ผู้ส่งจดหมาย",
+					Address: "alis.phusngcdhmay@example.net",
+				},
+				{
+					Name:    "อลิซ ผู้ส่งจดหมาย",
+					Address: "alis.phusngcdhmay@example.com",
+				},
+			},
+			ResentSender: &mail.Address{
+				Name:    "อลิซ ผู้ส่งจดหมาย",
+				Address: "alis.phusngcdhmay@example.net",
+			},
+			ResentTo: []*mail.Address{
+				{
+					Name:    "บ๊อบ ผู้รับ",
+					Address: "bob.phurab@example.net",
+				},
+				{
+					Name:    "คาโรล ผู้รับ",
+					Address: "carol.phurab@example.net",
+				},
+			},
+			ResentCc: []*mail.Address{
+				{
+					Name:    "แดน ผู้รับ",
+					Address: "dan.phurab@example.net",
+				},
+				{
+					Name:    "อีฟ ผู้รับ",
+					Address: "eve.phurab@example.net",
+				},
+			},
+			ResentBcc: []*mail.Address{
+				{
+					Name:    "แฟรงค์ ผู้รับ",
+					Address: "frank.phurab@example.net",
+				},
+				{
+					Name:    "เกรซ ผู้รับ",
+					Address: "grace.phurab@example.net",
+				},
+			},
+			ResentMessageID: "Message-Id-1@example.net",
+			ContentType: ContentTypeHeader{
+				ContentType: "multipart/mixed",
+				Params: map[string]string{
+					"boundary": "MixedBoundaryString",
+					"charset":  "windows-874",
+				},
+			},
+			ExtraHeaders: map[string][]string{
+				"X-Clacks-Overhead": {"GNU Terry Pratchett"},
+			},
+		},
+		Text: `เป็นมนุษย์สุดประเสริฐเลิศคุณค่า กว่าบรรดาฝูงสัตว์เดรัจฉาน จงฝ่าฟันพัฒนาวิชาการ อย่าล้างผลาญฤๅเข่นฆ่าบีฑาใคร ไม่ถือโทษโกรธแช่งซัดฮึดฮัดด่า หัดอภัยเหมือนกีฬาอัชฌาสัย ปฏิบัติประพฤติกฎกำหนดใจ พูดจาให้จ๊ะๆ จ๋าๆ น่าฟังเอยฯ
+
+นายสังฆภัณฑ์ เฮงพิทักษ์ฝั่ง ผู้เฒ่าซึ่งมีอาชีพเป็นฅนขายฃวด ถูกตำรวจปฏิบัติการจับฟ้องศาล ฐานลักนาฬิกาคุณหญิงฉัตรชฎา ฌานสมาธิ`,
+		EnrichedText: `<bold>เป็นมนุษย์สุดประเสริฐเลิศคุณค่า</bold> <italic>กว่าบรรดาฝูงสัตว์เดรัจฉาน</italic> <fixed>จงฝ่าฟันพัฒนาวิชาการ</fixed> <underline>อย่าล้างผลาญฤๅเข่นฆ่าบีฑาใคร</underline> ไม่ถือโทษโกรธแช่งซัดฮึดฮัดด่า หัดอภัยเหมือนกีฬาอัชฌาสัย ปฏิบัติประพฤติกฎกำหนดใจ พูดจาให้จ๊ะๆ จ๋าๆ น่าฟังเอยฯ
+
+นายสังฆภัณฑ์ เฮงพิทักษ์ฝั่ง ผู้เฒ่าซึ่งมีอาชีพเป็นฅนขายฃวด ถูกตำรวจปฏิบัติการจับฟ้องศาล ฐานลักนาฬิกาคุณหญิงฉัตรชฎา ฌานสมาธิ`,
+		HTML: `<html>
+<div dir="ltr">
+<p>เป็นมนุษย์สุดประเสริฐเลิศคุณค่า กว่าบรรดาฝูงสัตว์เดรัจฉาน จงฝ่าฟันพัฒนาวิชาการ อย่าล้างผลาญฤๅเข่นฆ่าบีฑาใคร ไม่ถือโทษโกรธแช่งซัดฮึดฮัดด่า หัดอภัยเหมือนกีฬาอัชฌาสัย ปฏิบัติประพฤติกฎกำหนดใจ พูดจาให้จ๊ะๆ จ๋าๆ น่าฟังเอยฯ</p>
+
+<p>นายสังฆภัณฑ์ เฮงพิทักษ์ฝั่ง ผู้เฒ่าซึ่งมีอาชีพเป็นฅนขายฃวด ถูกตำรวจปฏิบัติการจับฟ้องศาล ฐานลักนาฬิกาคุณหญิงฉัตรชฎา ฌานสมาธิ</p>
+</div>
+</html>`,
+		InlineFiles: []InlineFile{
+			{
+				ContentType: ContentTypeHeader{
+					ContentType: "image/jpeg",
+					Params: map[string]string{
+						"name": "inline-jpg-image-without-disposition.jpg",
+					},
+				},
+				ContentDisposition: ContentDispositionHeader{
+					ContentDisposition: "",
+					Params:             map[string]string(nil),
+				},
+				Data: []byte{255, 216, 255, 219, 0, 67, 0, 3, 2, 2, 2, 2, 2, 3, 2, 2, 2, 3, 3, 3, 3, 4,
+					6, 4, 4, 4, 4, 4, 8, 6, 6, 5, 6, 9, 8, 10, 10, 9, 8, 9, 9, 10, 12, 15, 12, 10, 11, 14, 11, 9, 9,
+					13, 17, 13, 14, 15, 16, 16, 17, 16, 10, 12, 18, 19, 18, 16, 19, 15, 16, 16, 16, 255, 201, 0, 11, 8,
+					0, 1, 0, 1, 1, 1, 17, 0, 255, 204, 0, 6, 0, 16, 16, 5, 255, 218, 0, 8, 1, 1, 0, 0, 63, 0, 210, 207,
+					32, 255, 217},
+			},
+			{
+				ContentID: "inline-jpg-image.jpg@example.com",
+				ContentType: ContentTypeHeader{
+					ContentType: "image/jpeg",
+					Params: map[string]string{
+						"name": "inline-jpg-image-name.jpg",
+					},
+				},
+				ContentDisposition: ContentDispositionHeader{
+					ContentDisposition: inline,
+					Params: map[string]string{
+						"filename": "inline-jpg-image-filename.jpg",
+					},
+				},
+				Data: []byte{255, 216, 255, 219, 0, 67, 0, 3, 2, 2, 2, 2, 2, 3, 2, 2, 2, 3, 3, 3, 3, 4,
+					6, 4, 4, 4, 4, 4, 8, 6, 6, 5, 6, 9, 8, 10, 10, 9, 8, 9, 9, 10, 12, 15, 12, 10, 11, 14, 11, 9, 9,
+					13, 17, 13, 14, 15, 16, 16, 17, 16, 10, 12, 18, 19, 18, 16, 19, 15, 16, 16, 16, 255, 201, 0, 11, 8,
+					0, 1, 0, 1, 1, 1, 17, 0, 255, 204, 0, 6, 0, 16, 16, 5, 255, 218, 0, 8, 1, 1, 0, 0, 63, 0, 210, 207,
+					32, 255, 217},
+			},
+		},
+		AttachedFiles: []AttachedFile{
+			{
+				ContentType: ContentTypeHeader{
+					ContentType: "application/pdf",
+					Params: map[string]string{
+						"name": "attached-pdf-name.pdf",
+					},
+				},
+				ContentDisposition: ContentDispositionHeader{
+					ContentDisposition: attachment,
+					Params: map[string]string{
+						"filename": "attached-pdf-filename.pdf",
+					},
+				},
+				Data: []byte{37, 80, 68, 70, 45, 49, 46, 13, 116, 114, 97, 105, 108, 101, 114, 60, 60,
+					47, 82, 111, 111, 116, 60, 60, 47, 80, 97, 103, 101, 115, 60, 60, 47, 75, 105, 100, 115, 91, 60,
+					60, 47, 77, 101, 100, 105, 97, 66, 111, 120, 91, 48, 32, 48, 32, 51, 32, 51, 93, 62, 62, 93, 62,
+					62, 62, 62, 62, 62},
+			},
+			{
+				ContentType: ContentTypeHeader{
+					ContentType: "application/pdf",
+					Params: map[string]string{
+						"name": "attached-pdf-without-disposition.pdf",
+					},
+				},
+				ContentDisposition: ContentDispositionHeader{
+					ContentDisposition: "",
+					Params:             map[string]string(nil),
+				},
+				Data: []byte{37, 80, 68, 70, 45, 49, 46, 13, 116, 114, 97, 105, 108, 101, 114, 60, 60,
+					47, 82, 111, 111, 116, 60, 60, 47, 80, 97, 103, 101, 115, 60, 60, 47, 75, 105, 100, 115, 91, 60,
+					60, 47, 77, 101, 100, 105, 97, 66, 111, 120, 91, 48, 32, 48, 32, 51, 32, 51, 93, 62, 62, 93, 62,
+					62, 62, 62, 62, 62},
+			},
+			{
+				ContentType: ContentTypeHeader{
+					ContentType: "application/json",
+					Params: map[string]string{
+						"name": "attached-json-name.json",
+					},
+				},
+				ContentDisposition: ContentDispositionHeader{
+					ContentDisposition: attachment,
+					Params: map[string]string{
+						"filename": "attached-json-filename.json",
+					},
+				},
+				Data: []byte{123, 34, 102, 111, 111, 34, 58, 34, 98, 97, 114, 34, 125},
+			},
+			{
+				ContentType: ContentTypeHeader{
+					ContentType: "text/plain",
+					Params: map[string]string{
+						"name": "attached-text-plain-name.txt",
+					},
+				},
+				ContentDisposition: ContentDispositionHeader{
+					ContentDisposition: attachment,
+					Params: map[string]string{
+						"filename": "attached-text-plain-filename.txt",
+					},
+				},
+				Data: []byte{84, 101, 120, 116, 47, 112, 108, 97, 105, 110, 32, 99, 111, 110, 116, 101, 110, 116, 32,
+					97, 115, 32, 97, 110, 32, 97, 116, 116, 97, 99, 104, 101, 100, 32, 46, 116, 120, 116, 32, 102, 105,
+					108, 101, 46},
+			},
+			{
+				ContentType: ContentTypeHeader{
+					ContentType: "text/html",
+					Params: map[string]string{
+						"name": "attached-text-html-name.html",
+					},
+				},
+				ContentDisposition: ContentDispositionHeader{
+					ContentDisposition: attachment,
+					Params: map[string]string{
+						"filename": "attached-text-html-filename.html",
+					},
+				},
+				Data: []byte{84, 101, 120, 116, 47, 104, 116, 109, 108, 32, 99, 111, 110, 116, 101, 110, 116, 32, 97,
+					115, 32, 97, 110, 32, 97, 116, 116, 97, 99, 104, 101, 100, 32, 46, 104, 116, 109, 108, 32, 102,
+					105, 108, 101, 46},
+			},
+		},
+	}
+
+	testEmailFromFile(t, fp, expectedEmail)
+}
+func TestParseEmailThaiMultipartMixedTis620OverBase64(t *testing.T) {
+	fp := "tests/test_thai_multipart_mixed_tis-620_over_base64.txt"
+	tz, _ := time.LoadLocation("Asia/Bangkok")
+	expectedDate, _ := time.Parse(
+		time.RFC1123Z+" (MST)",
+		time.Date(2019, time.April, 1, 7, 55, 0, 0, tz).Format(time.RFC1123Z+" (MST)"))
+	expectedEmail := Email{
+		Headers: Headers{
+			Date:    expectedDate,
+			Subject: "📧 Test แพนแกรมภาษาไทย",
+			ReplyTo: []*mail.Address{
+				{
+					Name:    "อลิซ ผู้ส่งจดหมาย",
+					Address: "alis.phusngcdhmay@example.net",
+				},
+			},
+			Sender: &mail.Address{
+				Name:    "อลิซ ผู้ส่งจดหมาย",
+				Address: "alis.phusngcdhmay@example.com",
+			},
+			From: []*mail.Address{
+				{
+					Name:    "อลิซ ผู้ส่งจดหมาย",
+					Address: "alis.phusngcdhmay@example.com",
+				},
+				{
+					Name:    "อลิซ ผู้ส่งจดหมาย",
+					Address: "alis.phusngcdhmay@example.net",
+				},
+			},
+			To: []*mail.Address{
+				{
+					Name:    "บ๊อบ ผู้รับ",
+					Address: "bob.phurab@example.com",
+				},
+				{
+					Name:    "คาโรล ผู้รับ",
+					Address: "carol.phurab@example.com",
+				},
+			},
+			Cc: []*mail.Address{
+				{
+					Name:    "แดน ผู้รับ",
+					Address: "dan.phurab@example.com",
+				},
+				{
+					Name:    "อีฟ ผู้รับ",
+					Address: "eve.phurab@example.com",
+				},
+			},
+			Bcc: []*mail.Address{
+				{
+					Name:    "แฟรงค์ ผู้รับ",
+					Address: "frank.phurab@example.com",
+				},
+				{
+					Name:    "เกรซ ผู้รับ",
+					Address: "grace.phurab@example.com",
+				},
+			},
+			MessageID:  "Message-Id-1@example.com",
+			InReplyTo:  []MessageId{"Message-Id-0@example.com"},
+			References: []MessageId{"Message-Id-0@example.com"},
+			Comments:   "Message Header Comment",
+			Keywords:   []string{"Keyword 1", "Keyword 2"},
+			ResentDate: expectedDate,
+			ResentFrom: []*mail.Address{
+				{
+					Name:    "อลิซ ผู้ส่งจดหมาย",
+					Address: "alis.phusngcdhmay@example.net",
+				},
+				{
+					Name:    "อลิซ ผู้ส่งจดหมาย",
+					Address: "alis.phusngcdhmay@example.com",
+				},
+			},
+			ResentSender: &mail.Address{
+				Name:    "อลิซ ผู้ส่งจดหมาย",
+				Address: "alis.phusngcdhmay@example.net",
+			},
+			ResentTo: []*mail.Address{
+				{
+					Name:    "บ๊อบ ผู้รับ",
+					Address: "bob.phurab@example.net",
+				},
+				{
+					Name:    "คาโรล ผู้รับ",
+					Address: "carol.phurab@example.net",
+				},
+			},
+			ResentCc: []*mail.Address{
+				{
+					Name:    "แดน ผู้รับ",
+					Address: "dan.phurab@example.net",
+				},
+				{
+					Name:    "อีฟ ผู้รับ",
+					Address: "eve.phurab@example.net",
+				},
+			},
+			ResentBcc: []*mail.Address{
+				{
+					Name:    "แฟรงค์ ผู้รับ",
+					Address: "frank.phurab@example.net",
+				},
+				{
+					Name:    "เกรซ ผู้รับ",
+					Address: "grace.phurab@example.net",
+				},
+			},
+			ResentMessageID: "Message-Id-1@example.net",
+			ContentType: ContentTypeHeader{
+				ContentType: "multipart/mixed",
+				Params: map[string]string{
+					"boundary": "MixedBoundaryString",
+					"charset":  "tis-620",
+				},
+			},
+			ExtraHeaders: map[string][]string{
+				"X-Clacks-Overhead": {"GNU Terry Pratchett"},
+			},
+		},
+		Text: `เป็นมนุษย์สุดประเสริฐเลิศคุณค่า กว่าบรรดาฝูงสัตว์เดรัจฉาน จงฝ่าฟันพัฒนาวิชาการ อย่าล้างผลาญฤๅเข่นฆ่าบีฑาใคร ไม่ถือโทษโกรธแช่งซัดฮึดฮัดด่า หัดอภัยเหมือนกีฬาอัชฌาสัย ปฏิบัติประพฤติกฎกำหนดใจ พูดจาให้จ๊ะๆ จ๋าๆ น่าฟังเอยฯ
+
+นายสังฆภัณฑ์ เฮงพิทักษ์ฝั่ง ผู้เฒ่าซึ่งมีอาชีพเป็นฅนขายฃวด ถูกตำรวจปฏิบัติการจับฟ้องศาล ฐานลักนาฬิกาคุณหญิงฉัตรชฎา ฌานสมาธิ`,
+		EnrichedText: `<bold>เป็นมนุษย์สุดประเสริฐเลิศคุณค่า</bold> <italic>กว่าบรรดาฝูงสัตว์เดรัจฉาน</italic> <fixed>จงฝ่าฟันพัฒนาวิชาการ</fixed> <underline>อย่าล้างผลาญฤๅเข่นฆ่าบีฑาใคร</underline> ไม่ถือโทษโกรธแช่งซัดฮึดฮัดด่า หัดอภัยเหมือนกีฬาอัชฌาสัย ปฏิบัติประพฤติกฎกำหนดใจ พูดจาให้จ๊ะๆ จ๋าๆ น่าฟังเอยฯ
+
+นายสังฆภัณฑ์ เฮงพิทักษ์ฝั่ง ผู้เฒ่าซึ่งมีอาชีพเป็นฅนขายฃวด ถูกตำรวจปฏิบัติการจับฟ้องศาล ฐานลักนาฬิกาคุณหญิงฉัตรชฎา ฌานสมาธิ`,
+		HTML: `<html>
+<div dir="ltr">
+<p>เป็นมนุษย์สุดประเสริฐเลิศคุณค่า กว่าบรรดาฝูงสัตว์เดรัจฉาน จงฝ่าฟันพัฒนาวิชาการ อย่าล้างผลาญฤๅเข่นฆ่าบีฑาใคร ไม่ถือโทษโกรธแช่งซัดฮึดฮัดด่า หัดอภัยเหมือนกีฬาอัชฌาสัย ปฏิบัติประพฤติกฎกำหนดใจ พูดจาให้จ๊ะๆ จ๋าๆ น่าฟังเอยฯ</p>
+
+<p>นายสังฆภัณฑ์ เฮงพิทักษ์ฝั่ง ผู้เฒ่าซึ่งมีอาชีพเป็นฅนขายฃวด ถูกตำรวจปฏิบัติการจับฟ้องศาล ฐานลักนาฬิกาคุณหญิงฉัตรชฎา ฌานสมาธิ</p>
+</div>
+</html>`,
+		InlineFiles: []InlineFile{
+			{
+				ContentType: ContentTypeHeader{
+					ContentType: "image/jpeg",
+					Params: map[string]string{
+						"name": "inline-jpg-image-without-disposition.jpg",
+					},
+				},
+				ContentDisposition: ContentDispositionHeader{
+					ContentDisposition: "",
+					Params:             map[string]string(nil),
+				},
+				Data: []byte{255, 216, 255, 219, 0, 67, 0, 3, 2, 2, 2, 2, 2, 3, 2, 2, 2, 3, 3, 3, 3, 4,
+					6, 4, 4, 4, 4, 4, 8, 6, 6, 5, 6, 9, 8, 10, 10, 9, 8, 9, 9, 10, 12, 15, 12, 10, 11, 14, 11, 9, 9,
+					13, 17, 13, 14, 15, 16, 16, 17, 16, 10, 12, 18, 19, 18, 16, 19, 15, 16, 16, 16, 255, 201, 0, 11, 8,
+					0, 1, 0, 1, 1, 1, 17, 0, 255, 204, 0, 6, 0, 16, 16, 5, 255, 218, 0, 8, 1, 1, 0, 0, 63, 0, 210, 207,
+					32, 255, 217},
+			},
+			{
+				ContentID: "inline-jpg-image.jpg@example.com",
+				ContentType: ContentTypeHeader{
+					ContentType: "image/jpeg",
+					Params: map[string]string{
+						"name": "inline-jpg-image-name.jpg",
+					},
+				},
+				ContentDisposition: ContentDispositionHeader{
+					ContentDisposition: inline,
+					Params: map[string]string{
+						"filename": "inline-jpg-image-filename.jpg",
+					},
+				},
+				Data: []byte{255, 216, 255, 219, 0, 67, 0, 3, 2, 2, 2, 2, 2, 3, 2, 2, 2, 3, 3, 3, 3, 4,
+					6, 4, 4, 4, 4, 4, 8, 6, 6, 5, 6, 9, 8, 10, 10, 9, 8, 9, 9, 10, 12, 15, 12, 10, 11, 14, 11, 9, 9,
+					13, 17, 13, 14, 15, 16, 16, 17, 16, 10, 12, 18, 19, 18, 16, 19, 15, 16, 16, 16, 255, 201, 0, 11, 8,
+					0, 1, 0, 1, 1, 1, 17, 0, 255, 204, 0, 6, 0, 16, 16, 5, 255, 218, 0, 8, 1, 1, 0, 0, 63, 0, 210, 207,
+					32, 255, 217},
+			},
+		},
+		AttachedFiles: []AttachedFile{
+			{
+				ContentType: ContentTypeHeader{
+					ContentType: "application/pdf",
+					Params: map[string]string{
+						"name": "attached-pdf-name.pdf",
+					},
+				},
+				ContentDisposition: ContentDispositionHeader{
+					ContentDisposition: attachment,
+					Params: map[string]string{
+						"filename": "attached-pdf-filename.pdf",
+					},
+				},
+				Data: []byte{37, 80, 68, 70, 45, 49, 46, 13, 116, 114, 97, 105, 108, 101, 114, 60, 60,
+					47, 82, 111, 111, 116, 60, 60, 47, 80, 97, 103, 101, 115, 60, 60, 47, 75, 105, 100, 115, 91, 60,
+					60, 47, 77, 101, 100, 105, 97, 66, 111, 120, 91, 48, 32, 48, 32, 51, 32, 51, 93, 62, 62, 93, 62,
+					62, 62, 62, 62, 62},
+			},
+			{
+				ContentType: ContentTypeHeader{
+					ContentType: "application/pdf",
+					Params: map[string]string{
+						"name": "attached-pdf-without-disposition.pdf",
+					},
+				},
+				ContentDisposition: ContentDispositionHeader{
+					ContentDisposition: "",
+					Params:             map[string]string(nil),
+				},
+				Data: []byte{37, 80, 68, 70, 45, 49, 46, 13, 116, 114, 97, 105, 108, 101, 114, 60, 60,
+					47, 82, 111, 111, 116, 60, 60, 47, 80, 97, 103, 101, 115, 60, 60, 47, 75, 105, 100, 115, 91, 60,
+					60, 47, 77, 101, 100, 105, 97, 66, 111, 120, 91, 48, 32, 48, 32, 51, 32, 51, 93, 62, 62, 93, 62,
+					62, 62, 62, 62, 62},
+			},
+			{
+				ContentType: ContentTypeHeader{
+					ContentType: "application/json",
+					Params: map[string]string{
+						"name": "attached-json-name.json",
+					},
+				},
+				ContentDisposition: ContentDispositionHeader{
+					ContentDisposition: attachment,
+					Params: map[string]string{
+						"filename": "attached-json-filename.json",
+					},
+				},
+				Data: []byte{123, 34, 102, 111, 111, 34, 58, 34, 98, 97, 114, 34, 125},
+			},
+			{
+				ContentType: ContentTypeHeader{
+					ContentType: "text/plain",
+					Params: map[string]string{
+						"name": "attached-text-plain-name.txt",
+					},
+				},
+				ContentDisposition: ContentDispositionHeader{
+					ContentDisposition: attachment,
+					Params: map[string]string{
+						"filename": "attached-text-plain-filename.txt",
+					},
+				},
+				Data: []byte{84, 101, 120, 116, 47, 112, 108, 97, 105, 110, 32, 99, 111, 110, 116, 101, 110, 116, 32,
+					97, 115, 32, 97, 110, 32, 97, 116, 116, 97, 99, 104, 101, 100, 32, 46, 116, 120, 116, 32, 102, 105,
+					108, 101, 46},
+			},
+			{
+				ContentType: ContentTypeHeader{
+					ContentType: "text/html",
+					Params: map[string]string{
+						"name": "attached-text-html-name.html",
+					},
+				},
+				ContentDisposition: ContentDispositionHeader{
+					ContentDisposition: attachment,
+					Params: map[string]string{
+						"filename": "attached-text-html-filename.html",
+					},
+				},
+				Data: []byte{84, 101, 120, 116, 47, 104, 116, 109, 108, 32, 99, 111, 110, 116, 101, 110, 116, 32, 97,
+					115, 32, 97, 110, 32, 97, 116, 116, 97, 99, 104, 101, 100, 32, 46, 104, 116, 109, 108, 32, 102,
+					105, 108, 101, 46},
+			},
+		},
+	}
+
+	testEmailFromFile(t, fp, expectedEmail)
+}
+func TestParseEmailThaiMultipartMixedTis620OverQuotedprintable(t *testing.T) {
+	fp := "tests/test_thai_multipart_mixed_tis-620_over_quoted-printable.txt"
+	tz, _ := time.LoadLocation("Asia/Bangkok")
+	expectedDate, _ := time.Parse(
+		time.RFC1123Z+" (MST)",
+		time.Date(2019, time.April, 1, 7, 55, 0, 0, tz).Format(time.RFC1123Z+" (MST)"))
+	expectedEmail := Email{
+		Headers: Headers{
+			Date:    expectedDate,
+			Subject: "📧 Test แพนแกรมภาษาไทย",
+			ReplyTo: []*mail.Address{
+				{
+					Name:    "อลิซ ผู้ส่งจดหมาย",
+					Address: "alis.phusngcdhmay@example.net",
+				},
+			},
+			Sender: &mail.Address{
+				Name:    "อลิซ ผู้ส่งจดหมาย",
+				Address: "alis.phusngcdhmay@example.com",
+			},
+			From: []*mail.Address{
+				{
+					Name:    "อลิซ ผู้ส่งจดหมาย",
+					Address: "alis.phusngcdhmay@example.com",
+				},
+				{
+					Name:    "อลิซ ผู้ส่งจดหมาย",
+					Address: "alis.phusngcdhmay@example.net",
+				},
+			},
+			To: []*mail.Address{
+				{
+					Name:    "บ๊อบ ผู้รับ",
+					Address: "bob.phurab@example.com",
+				},
+				{
+					Name:    "คาโรล ผู้รับ",
+					Address: "carol.phurab@example.com",
+				},
+			},
+			Cc: []*mail.Address{
+				{
+					Name:    "แดน ผู้รับ",
+					Address: "dan.phurab@example.com",
+				},
+				{
+					Name:    "อีฟ ผู้รับ",
+					Address: "eve.phurab@example.com",
+				},
+			},
+			Bcc: []*mail.Address{
+				{
+					Name:    "แฟรงค์ ผู้รับ",
+					Address: "frank.phurab@example.com",
+				},
+				{
+					Name:    "เกรซ ผู้รับ",
+					Address: "grace.phurab@example.com",
+				},
+			},
+			MessageID:  "Message-Id-1@example.com",
+			InReplyTo:  []MessageId{"Message-Id-0@example.com"},
+			References: []MessageId{"Message-Id-0@example.com"},
+			Comments:   "Message Header Comment",
+			Keywords:   []string{"Keyword 1", "Keyword 2"},
+			ResentDate: expectedDate,
+			ResentFrom: []*mail.Address{
+				{
+					Name:    "อลิซ ผู้ส่งจดหมาย",
+					Address: "alis.phusngcdhmay@example.net",
+				},
+				{
+					Name:    "อลิซ ผู้ส่งจดหมาย",
+					Address: "alis.phusngcdhmay@example.com",
+				},
+			},
+			ResentSender: &mail.Address{
+				Name:    "อลิซ ผู้ส่งจดหมาย",
+				Address: "alis.phusngcdhmay@example.net",
+			},
+			ResentTo: []*mail.Address{
+				{
+					Name:    "บ๊อบ ผู้รับ",
+					Address: "bob.phurab@example.net",
+				},
+				{
+					Name:    "คาโรล ผู้รับ",
+					Address: "carol.phurab@example.net",
+				},
+			},
+			ResentCc: []*mail.Address{
+				{
+					Name:    "แดน ผู้รับ",
+					Address: "dan.phurab@example.net",
+				},
+				{
+					Name:    "อีฟ ผู้รับ",
+					Address: "eve.phurab@example.net",
+				},
+			},
+			ResentBcc: []*mail.Address{
+				{
+					Name:    "แฟรงค์ ผู้รับ",
+					Address: "frank.phurab@example.net",
+				},
+				{
+					Name:    "เกรซ ผู้รับ",
+					Address: "grace.phurab@example.net",
+				},
+			},
+			ResentMessageID: "Message-Id-1@example.net",
+			ContentType: ContentTypeHeader{
+				ContentType: "multipart/mixed",
+				Params: map[string]string{
+					"boundary": "MixedBoundaryString",
+					"charset":  "tis-620",
+				},
+			},
+			ExtraHeaders: map[string][]string{
+				"X-Clacks-Overhead": {"GNU Terry Pratchett"},
+			},
+		},
+		Text: `เป็นมนุษย์สุดประเสริฐเลิศคุณค่า กว่าบรรดาฝูงสัตว์เดรัจฉาน จงฝ่าฟันพัฒนาวิชาการ อย่าล้างผลาญฤๅเข่นฆ่าบีฑาใคร ไม่ถือโทษโกรธแช่งซัดฮึดฮัดด่า หัดอภัยเหมือนกีฬาอัชฌาสัย ปฏิบัติประพฤติกฎกำหนดใจ พูดจาให้จ๊ะๆ จ๋าๆ น่าฟังเอยฯ
+
+นายสังฆภัณฑ์ เฮงพิทักษ์ฝั่ง ผู้เฒ่าซึ่งมีอาชีพเป็นฅนขายฃวด ถูกตำรวจปฏิบัติการจับฟ้องศาล ฐานลักนาฬิกาคุณหญิงฉัตรชฎา ฌานสมาธิ`,
+		EnrichedText: `<bold>เป็นมนุษย์สุดประเสริฐเลิศคุณค่า</bold> <italic>กว่าบรรดาฝูงสัตว์เดรัจฉาน</italic> <fixed>จงฝ่าฟันพัฒนาวิชาการ</fixed> <underline>อย่าล้างผลาญฤๅเข่นฆ่าบีฑาใคร</underline> ไม่ถือโทษโกรธแช่งซัดฮึดฮัดด่า หัดอภัยเหมือนกีฬาอัชฌาสัย ปฏิบัติประพฤติกฎกำหนดใจ พูดจาให้จ๊ะๆ จ๋าๆ น่าฟังเอยฯ
+
+นายสังฆภัณฑ์ เฮงพิทักษ์ฝั่ง ผู้เฒ่าซึ่งมีอาชีพเป็นฅนขายฃวด ถูกตำรวจปฏิบัติการจับฟ้องศาล ฐานลักนาฬิกาคุณหญิงฉัตรชฎา ฌานสมาธิ`,
+		HTML: `<html>
+<div dir="ltr">
+<p>เป็นมนุษย์สุดประเสริฐเลิศคุณค่า กว่าบรรดาฝูงสัตว์เดรัจฉาน จงฝ่าฟันพัฒนาวิชาการ อย่าล้างผลาญฤๅเข่นฆ่าบีฑาใคร ไม่ถือโทษโกรธแช่งซัดฮึดฮัดด่า หัดอภัยเหมือนกีฬาอัชฌาสัย ปฏิบัติประพฤติกฎกำหนดใจ พูดจาให้จ๊ะๆ จ๋าๆ น่าฟังเอยฯ</p>
+
+<p>นายสังฆภัณฑ์ เฮงพิทักษ์ฝั่ง ผู้เฒ่าซึ่งมีอาชีพเป็นฅนขายฃวด ถูกตำรวจปฏิบัติการจับฟ้องศาล ฐานลักนาฬิกาคุณหญิงฉัตรชฎา ฌานสมาธิ</p>
+</div>
+</html>`,
+		InlineFiles: []InlineFile{
+			{
+				ContentType: ContentTypeHeader{
+					ContentType: "image/jpeg",
+					Params: map[string]string{
+						"name": "inline-jpg-image-without-disposition.jpg",
+					},
+				},
+				ContentDisposition: ContentDispositionHeader{
+					ContentDisposition: "",
+					Params:             map[string]string(nil),
+				},
+				Data: []byte{255, 216, 255, 219, 0, 67, 0, 3, 2, 2, 2, 2, 2, 3, 2, 2, 2, 3, 3, 3, 3, 4,
+					6, 4, 4, 4, 4, 4, 8, 6, 6, 5, 6, 9, 8, 10, 10, 9, 8, 9, 9, 10, 12, 15, 12, 10, 11, 14, 11, 9, 9,
+					13, 17, 13, 14, 15, 16, 16, 17, 16, 10, 12, 18, 19, 18, 16, 19, 15, 16, 16, 16, 255, 201, 0, 11, 8,
+					0, 1, 0, 1, 1, 1, 17, 0, 255, 204, 0, 6, 0, 16, 16, 5, 255, 218, 0, 8, 1, 1, 0, 0, 63, 0, 210, 207,
+					32, 255, 217},
+			},
+			{
+				ContentID: "inline-jpg-image.jpg@example.com",
+				ContentType: ContentTypeHeader{
+					ContentType: "image/jpeg",
+					Params: map[string]string{
+						"name": "inline-jpg-image-name.jpg",
+					},
+				},
+				ContentDisposition: ContentDispositionHeader{
+					ContentDisposition: inline,
+					Params: map[string]string{
+						"filename": "inline-jpg-image-filename.jpg",
+					},
+				},
+				Data: []byte{255, 216, 255, 219, 0, 67, 0, 3, 2, 2, 2, 2, 2, 3, 2, 2, 2, 3, 3, 3, 3, 4,
+					6, 4, 4, 4, 4, 4, 8, 6, 6, 5, 6, 9, 8, 10, 10, 9, 8, 9, 9, 10, 12, 15, 12, 10, 11, 14, 11, 9, 9,
+					13, 17, 13, 14, 15, 16, 16, 17, 16, 10, 12, 18, 19, 18, 16, 19, 15, 16, 16, 16, 255, 201, 0, 11, 8,
+					0, 1, 0, 1, 1, 1, 17, 0, 255, 204, 0, 6, 0, 16, 16, 5, 255, 218, 0, 8, 1, 1, 0, 0, 63, 0, 210, 207,
+					32, 255, 217},
+			},
+		},
+		AttachedFiles: []AttachedFile{
+			{
+				ContentType: ContentTypeHeader{
+					ContentType: "application/pdf",
+					Params: map[string]string{
+						"name": "attached-pdf-name.pdf",
+					},
+				},
+				ContentDisposition: ContentDispositionHeader{
+					ContentDisposition: attachment,
+					Params: map[string]string{
+						"filename": "attached-pdf-filename.pdf",
+					},
+				},
+				Data: []byte{37, 80, 68, 70, 45, 49, 46, 13, 116, 114, 97, 105, 108, 101, 114, 60, 60,
+					47, 82, 111, 111, 116, 60, 60, 47, 80, 97, 103, 101, 115, 60, 60, 47, 75, 105, 100, 115, 91, 60,
+					60, 47, 77, 101, 100, 105, 97, 66, 111, 120, 91, 48, 32, 48, 32, 51, 32, 51, 93, 62, 62, 93, 62,
+					62, 62, 62, 62, 62},
+			},
+			{
+				ContentType: ContentTypeHeader{
+					ContentType: "application/pdf",
+					Params: map[string]string{
+						"name": "attached-pdf-without-disposition.pdf",
+					},
+				},
+				ContentDisposition: ContentDispositionHeader{
+					ContentDisposition: "",
+					Params:             map[string]string(nil),
+				},
+				Data: []byte{37, 80, 68, 70, 45, 49, 46, 13, 116, 114, 97, 105, 108, 101, 114, 60, 60,
+					47, 82, 111, 111, 116, 60, 60, 47, 80, 97, 103, 101, 115, 60, 60, 47, 75, 105, 100, 115, 91, 60,
+					60, 47, 77, 101, 100, 105, 97, 66, 111, 120, 91, 48, 32, 48, 32, 51, 32, 51, 93, 62, 62, 93, 62,
+					62, 62, 62, 62, 62},
+			},
+			{
+				ContentType: ContentTypeHeader{
+					ContentType: "application/json",
+					Params: map[string]string{
+						"name": "attached-json-name.json",
+					},
+				},
+				ContentDisposition: ContentDispositionHeader{
+					ContentDisposition: attachment,
+					Params: map[string]string{
+						"filename": "attached-json-filename.json",
+					},
+				},
+				Data: []byte{123, 34, 102, 111, 111, 34, 58, 34, 98, 97, 114, 34, 125},
+			},
+			{
+				ContentType: ContentTypeHeader{
+					ContentType: "text/plain",
+					Params: map[string]string{
+						"name": "attached-text-plain-name.txt",
+					},
+				},
+				ContentDisposition: ContentDispositionHeader{
+					ContentDisposition: attachment,
+					Params: map[string]string{
+						"filename": "attached-text-plain-filename.txt",
+					},
+				},
+				Data: []byte{84, 101, 120, 116, 47, 112, 108, 97, 105, 110, 32, 99, 111, 110, 116, 101, 110, 116, 32,
+					97, 115, 32, 97, 110, 32, 97, 116, 116, 97, 99, 104, 101, 100, 32, 46, 116, 120, 116, 32, 102, 105,
+					108, 101, 46},
+			},
+			{
+				ContentType: ContentTypeHeader{
+					ContentType: "text/html",
+					Params: map[string]string{
+						"name": "attached-text-html-name.html",
+					},
+				},
+				ContentDisposition: ContentDispositionHeader{
+					ContentDisposition: attachment,
+					Params: map[string]string{
+						"filename": "attached-text-html-filename.html",
+					},
+				},
+				Data: []byte{84, 101, 120, 116, 47, 104, 116, 109, 108, 32, 99, 111, 110, 116, 101, 110, 116, 32, 97,
+					115, 32, 97, 110, 32, 97, 116, 116, 97, 99, 104, 101, 100, 32, 46, 104, 116, 109, 108, 32, 102,
+					105, 108, 101, 46},
+			},
+		},
+	}
+
+	testEmailFromFile(t, fp, expectedEmail)
+}
+func TestParseEmailThaiMultipartSignedIso885911OverBase64(t *testing.T) {
+	fp := "tests/test_thai_multipart_signed_iso-8859-11_over_base64.txt"
+	tz, _ := time.LoadLocation("Asia/Bangkok")
+	expectedDate, _ := time.Parse(
+		time.RFC1123Z+" (MST)",
+		time.Date(2019, time.April, 1, 7, 55, 0, 0, tz).Format(time.RFC1123Z+" (MST)"))
+	expectedEmail := Email{
+		Headers: Headers{
+			Date:    expectedDate,
+			Subject: "📧 Signed Test แพนแกรมภาษาไทย",
+			ReplyTo: []*mail.Address{
+				{
+					Name:    "อลิซ ผู้ส่งจดหมาย",
+					Address: "alis.phusngcdhmay@example.net",
+				},
+			},
+			Sender: &mail.Address{
+				Name:    "อลิซ ผู้ส่งจดหมาย",
+				Address: "alis.phusngcdhmay@example.com",
+			},
+			From: []*mail.Address{
+				{
+					Name:    "อลิซ ผู้ส่งจดหมาย",
+					Address: "alis.phusngcdhmay@example.com",
+				},
+				{
+					Name:    "อลิซ ผู้ส่งจดหมาย",
+					Address: "alis.phusngcdhmay@example.net",
+				},
+			},
+			To: []*mail.Address{
+				{
+					Name:    "บ๊อบ ผู้รับ",
+					Address: "bob.phurab@example.com",
+				},
+				{
+					Name:    "คาโรล ผู้รับ",
+					Address: "carol.phurab@example.com",
+				},
+			},
+			Cc: []*mail.Address{
+				{
+					Name:    "แดน ผู้รับ",
+					Address: "dan.phurab@example.com",
+				},
+				{
+					Name:    "อีฟ ผู้รับ",
+					Address: "eve.phurab@example.com",
+				},
+			},
+			Bcc: []*mail.Address{
+				{
+					Name:    "แฟรงค์ ผู้รับ",
+					Address: "frank.phurab@example.com",
+				},
+				{
+					Name:    "เกรซ ผู้รับ",
+					Address: "grace.phurab@example.com",
+				},
+			},
+			MessageID:  "Message-Id-1@example.com",
+			InReplyTo:  []MessageId{"Message-Id-0@example.com"},
+			References: []MessageId{"Message-Id-0@example.com"},
+			Comments:   "Message Header Comment",
+			Keywords:   []string{"Keyword 1", "Keyword 2"},
+			ResentDate: expectedDate,
+			ResentFrom: []*mail.Address{
+				{
+					Name:    "อลิซ ผู้ส่งจดหมาย",
+					Address: "alis.phusngcdhmay@example.net",
+				},
+				{
+					Name:    "อลิซ ผู้ส่งจดหมาย",
+					Address: "alis.phusngcdhmay@example.com",
+				},
+			},
+			ResentSender: &mail.Address{
+				Name:    "อลิซ ผู้ส่งจดหมาย",
+				Address: "alis.phusngcdhmay@example.net",
+			},
+			ResentTo: []*mail.Address{
+				{
+					Name:    "บ๊อบ ผู้รับ",
+					Address: "bob.phurab@example.net",
+				},
+				{
+					Name:    "คาโรล ผู้รับ",
+					Address: "carol.phurab@example.net",
+				},
+			},
+			ResentCc: []*mail.Address{
+				{
+					Name:    "แดน ผู้รับ",
+					Address: "dan.phurab@example.net",
+				},
+				{
+					Name:    "อีฟ ผู้รับ",
+					Address: "eve.phurab@example.net",
+				},
+			},
+			ResentBcc: []*mail.Address{
+				{
+					Name:    "แฟรงค์ ผู้รับ",
+					Address: "frank.phurab@example.net",
+				},
+				{
+					Name:    "เกรซ ผู้รับ",
+					Address: "grace.phurab@example.net",
+				},
+			},
+			ResentMessageID: "Message-Id-1@example.net",
+			ContentType: ContentTypeHeader{
+				ContentType: "multipart/signed",
+				Params: map[string]string{
+					"boundary": "SignedBoundaryString",
+					"charset":  "iso-8859-11",
+					"micalg":   "sha1",
+					"protocol": "application/pkcs7-signature",
+				},
+			},
+			ExtraHeaders: map[string][]string{
+				"X-Clacks-Overhead": {"GNU Terry Pratchett"},
+			},
+		},
+		Text: `เป็นมนุษย์สุดประเสริฐเลิศคุณค่า กว่าบรรดาฝูงสัตว์เดรัจฉาน จงฝ่าฟันพัฒนาวิชาการ อย่าล้างผลาญฤๅเข่นฆ่าบีฑาใคร ไม่ถือโทษโกรธแช่งซัดฮึดฮัดด่า หัดอภัยเหมือนกีฬาอัชฌาสัย ปฏิบัติประพฤติกฎกำหนดใจ พูดจาให้จ๊ะๆ จ๋าๆ น่าฟังเอยฯ
+
+นายสังฆภัณฑ์ เฮงพิทักษ์ฝั่ง ผู้เฒ่าซึ่งมีอาชีพเป็นฅนขายฃวด ถูกตำรวจปฏิบัติการจับฟ้องศาล ฐานลักนาฬิกาคุณหญิงฉัตรชฎา ฌานสมาธิ`,
+		AttachedFiles: []AttachedFile{
+			{
+				ContentType: ContentTypeHeader{
+					ContentType: "application/pkcs7-signature",
+					Params: map[string]string{
+						"name": "smime.p7s",
+					},
+				},
+				ContentDisposition: ContentDispositionHeader{
+					ContentDisposition: attachment,
+					Params: map[string]string{
+						"filename": "smime.p7s",
+					},
+				},
+				Data: []byte{130, 28, 135, 132, 117, 46, 142, 18, 97, 140, 126, 251, 159, 193, 199, 25, 58, 223, 189, 185, 227, 239, 158, 173, 108, 31, 71, 27, 133, 80, 165, 252, 133, 227, 174, 198, 132, 129, 159, 29, 246, 19, 235, 133, 80, 165, 252, 133, 227, 174, 198, 132, 129, 159, 29, 246, 19, 234, 49, 251, 238, 127, 7, 28, 104, 33, 200, 120, 71, 82, 232, 225, 38, 30, 249, 234, 214, 193, 244, 113, 147, 173, 251, 219, 158, 57, 252, 28, 113, 147, 173, 251, 225, 38, 24, 199, 239, 190, 173, 108, 31, 71, 27, 133, 80, 110, 120, 251, 231, 174, 198, 132, 129, 159, 29, 246, 19, 234, 8, 114, 30, 17, 212, 186, 58, 95, 200, 94, 59, 26, 18, 6, 124, 119, 216, 79, 174, 21, 65, 185, 227, 239, 158},
+			},
+		},
+	}
+
+	testEmailFromFile(t, fp, expectedEmail)
+}
+
+func TestParseEmailThaiMultipartSignedIso885911OverQuotedprintable(t *testing.T) {
+	fp := "tests/test_thai_multipart_signed_iso-8859-11_over_quoted-printable.txt"
+	tz, _ := time.LoadLocation("Asia/Bangkok")
+	expectedDate, _ := time.Parse(
+		time.RFC1123Z+" (MST)",
+		time.Date(2019, time.April, 1, 7, 55, 0, 0, tz).Format(time.RFC1123Z+" (MST)"))
+	expectedEmail := Email{
+		Headers: Headers{
+			Date:    expectedDate,
+			Subject: "📧 Signed Test แพนแกรมภาษาไทย",
+			ReplyTo: []*mail.Address{
+				{
+					Name:    "อลิซ ผู้ส่งจดหมาย",
+					Address: "alis.phusngcdhmay@example.net",
+				},
+			},
+			Sender: &mail.Address{
+				Name:    "อลิซ ผู้ส่งจดหมาย",
+				Address: "alis.phusngcdhmay@example.com",
+			},
+			From: []*mail.Address{
+				{
+					Name:    "อลิซ ผู้ส่งจดหมาย",
+					Address: "alis.phusngcdhmay@example.com",
+				},
+				{
+					Name:    "อลิซ ผู้ส่งจดหมาย",
+					Address: "alis.phusngcdhmay@example.net",
+				},
+			},
+			To: []*mail.Address{
+				{
+					Name:    "บ๊อบ ผู้รับ",
+					Address: "bob.phurab@example.com",
+				},
+				{
+					Name:    "คาโรล ผู้รับ",
+					Address: "carol.phurab@example.com",
+				},
+			},
+			Cc: []*mail.Address{
+				{
+					Name:    "แดน ผู้รับ",
+					Address: "dan.phurab@example.com",
+				},
+				{
+					Name:    "อีฟ ผู้รับ",
+					Address: "eve.phurab@example.com",
+				},
+			},
+			Bcc: []*mail.Address{
+				{
+					Name:    "แฟรงค์ ผู้รับ",
+					Address: "frank.phurab@example.com",
+				},
+				{
+					Name:    "เกรซ ผู้รับ",
+					Address: "grace.phurab@example.com",
+				},
+			},
+			MessageID:  "Message-Id-1@example.com",
+			InReplyTo:  []MessageId{"Message-Id-0@example.com"},
+			References: []MessageId{"Message-Id-0@example.com"},
+			Comments:   "Message Header Comment",
+			Keywords:   []string{"Keyword 1", "Keyword 2"},
+			ResentDate: expectedDate,
+			ResentFrom: []*mail.Address{
+				{
+					Name:    "อลิซ ผู้ส่งจดหมาย",
+					Address: "alis.phusngcdhmay@example.net",
+				},
+				{
+					Name:    "อลิซ ผู้ส่งจดหมาย",
+					Address: "alis.phusngcdhmay@example.com",
+				},
+			},
+			ResentSender: &mail.Address{
+				Name:    "อลิซ ผู้ส่งจดหมาย",
+				Address: "alis.phusngcdhmay@example.net",
+			},
+			ResentTo: []*mail.Address{
+				{
+					Name:    "บ๊อบ ผู้รับ",
+					Address: "bob.phurab@example.net",
+				},
+				{
+					Name:    "คาโรล ผู้รับ",
+					Address: "carol.phurab@example.net",
+				},
+			},
+			ResentCc: []*mail.Address{
+				{
+					Name:    "แดน ผู้รับ",
+					Address: "dan.phurab@example.net",
+				},
+				{
+					Name:    "อีฟ ผู้รับ",
+					Address: "eve.phurab@example.net",
+				},
+			},
+			ResentBcc: []*mail.Address{
+				{
+					Name:    "แฟรงค์ ผู้รับ",
+					Address: "frank.phurab@example.net",
+				},
+				{
+					Name:    "เกรซ ผู้รับ",
+					Address: "grace.phurab@example.net",
+				},
+			},
+			ResentMessageID: "Message-Id-1@example.net",
+			ContentType: ContentTypeHeader{
+				ContentType: "multipart/signed",
+				Params: map[string]string{
+					"boundary": "SignedBoundaryString",
+					"charset":  "iso-8859-11",
+					"micalg":   "sha1",
+					"protocol": "application/pkcs7-signature",
+				},
+			},
+			ExtraHeaders: map[string][]string{
+				"X-Clacks-Overhead": {"GNU Terry Pratchett"},
+			},
+		},
+		Text: `เป็นมนุษย์สุดประเสริฐเลิศคุณค่า กว่าบรรดาฝูงสัตว์เดรัจฉาน จงฝ่าฟันพัฒนาวิชาการ อย่าล้างผลาญฤๅเข่นฆ่าบีฑาใคร ไม่ถือโทษโกรธแช่งซัดฮึดฮัดด่า หัดอภัยเหมือนกีฬาอัชฌาสัย ปฏิบัติประพฤติกฎกำหนดใจ พูดจาให้จ๊ะๆ จ๋าๆ น่าฟังเอยฯ
+
+นายสังฆภัณฑ์ เฮงพิทักษ์ฝั่ง ผู้เฒ่าซึ่งมีอาชีพเป็นฅนขายฃวด ถูกตำรวจปฏิบัติการจับฟ้องศาล ฐานลักนาฬิกาคุณหญิงฉัตรชฎา ฌานสมาธิ`,
+		AttachedFiles: []AttachedFile{
+			{
+				ContentType: ContentTypeHeader{
+					ContentType: "application/pkcs7-signature",
+					Params: map[string]string{
+						"name": "smime.p7s",
+					},
+				},
+				ContentDisposition: ContentDispositionHeader{
+					ContentDisposition: attachment,
+					Params: map[string]string{
+						"filename": "smime.p7s",
+					},
+				},
+				Data: []byte{130, 28, 135, 132, 117, 46, 142, 18, 97, 140, 126, 251, 159, 193, 199, 25, 58, 223, 189, 185, 227, 239, 158, 173, 108, 31, 71, 27, 133, 80, 165, 252, 133, 227, 174, 198, 132, 129, 159, 29, 246, 19, 235, 133, 80, 165, 252, 133, 227, 174, 198, 132, 129, 159, 29, 246, 19, 234, 49, 251, 238, 127, 7, 28, 104, 33, 200, 120, 71, 82, 232, 225, 38, 30, 249, 234, 214, 193, 244, 113, 147, 173, 251, 219, 158, 57, 252, 28, 113, 147, 173, 251, 225, 38, 24, 199, 239, 190, 173, 108, 31, 71, 27, 133, 80, 110, 120, 251, 231, 174, 198, 132, 129, 159, 29, 246, 19, 234, 8, 114, 30, 17, 212, 186, 58, 95, 200, 94, 59, 26, 18, 6, 124, 119, 216, 79, 174, 21, 65, 185, 227, 239, 158},
+			},
+		},
+	}
+
+	testEmailFromFile(t, fp, expectedEmail)
+}
+
+func TestParseEmailThaiMultipartSignedWindows874OverBase64(t *testing.T) {
+	fp := "tests/test_thai_multipart_signed_windows-874_over_base64.txt"
+	tz, _ := time.LoadLocation("Asia/Bangkok")
+	expectedDate, _ := time.Parse(
+		time.RFC1123Z+" (MST)",
+		time.Date(2019, time.April, 1, 7, 55, 0, 0, tz).Format(time.RFC1123Z+" (MST)"))
+	expectedEmail := Email{
+		Headers: Headers{
+			Date:    expectedDate,
+			Subject: "📧 Signed Test แพนแกรมภาษาไทย",
+			ReplyTo: []*mail.Address{
+				{
+					Name:    "อลิซ ผู้ส่งจดหมาย",
+					Address: "alis.phusngcdhmay@example.net",
+				},
+			},
+			Sender: &mail.Address{
+				Name:    "อลิซ ผู้ส่งจดหมาย",
+				Address: "alis.phusngcdhmay@example.com",
+			},
+			From: []*mail.Address{
+				{
+					Name:    "อลิซ ผู้ส่งจดหมาย",
+					Address: "alis.phusngcdhmay@example.com",
+				},
+				{
+					Name:    "อลิซ ผู้ส่งจดหมาย",
+					Address: "alis.phusngcdhmay@example.net",
+				},
+			},
+			To: []*mail.Address{
+				{
+					Name:    "บ๊อบ ผู้รับ",
+					Address: "bob.phurab@example.com",
+				},
+				{
+					Name:    "คาโรล ผู้รับ",
+					Address: "carol.phurab@example.com",
+				},
+			},
+			Cc: []*mail.Address{
+				{
+					Name:    "แดน ผู้รับ",
+					Address: "dan.phurab@example.com",
+				},
+				{
+					Name:    "อีฟ ผู้รับ",
+					Address: "eve.phurab@example.com",
+				},
+			},
+			Bcc: []*mail.Address{
+				{
+					Name:    "แฟรงค์ ผู้รับ",
+					Address: "frank.phurab@example.com",
+				},
+				{
+					Name:    "เกรซ ผู้รับ",
+					Address: "grace.phurab@example.com",
+				},
+			},
+			MessageID:  "Message-Id-1@example.com",
+			InReplyTo:  []MessageId{"Message-Id-0@example.com"},
+			References: []MessageId{"Message-Id-0@example.com"},
+			Comments:   "Message Header Comment",
+			Keywords:   []string{"Keyword 1", "Keyword 2"},
+			ResentDate: expectedDate,
+			ResentFrom: []*mail.Address{
+				{
+					Name:    "อลิซ ผู้ส่งจดหมาย",
+					Address: "alis.phusngcdhmay@example.net",
+				},
+				{
+					Name:    "อลิซ ผู้ส่งจดหมาย",
+					Address: "alis.phusngcdhmay@example.com",
+				},
+			},
+			ResentSender: &mail.Address{
+				Name:    "อลิซ ผู้ส่งจดหมาย",
+				Address: "alis.phusngcdhmay@example.net",
+			},
+			ResentTo: []*mail.Address{
+				{
+					Name:    "บ๊อบ ผู้รับ",
+					Address: "bob.phurab@example.net",
+				},
+				{
+					Name:    "คาโรล ผู้รับ",
+					Address: "carol.phurab@example.net",
+				},
+			},
+			ResentCc: []*mail.Address{
+				{
+					Name:    "แดน ผู้รับ",
+					Address: "dan.phurab@example.net",
+				},
+				{
+					Name:    "อีฟ ผู้รับ",
+					Address: "eve.phurab@example.net",
+				},
+			},
+			ResentBcc: []*mail.Address{
+				{
+					Name:    "แฟรงค์ ผู้รับ",
+					Address: "frank.phurab@example.net",
+				},
+				{
+					Name:    "เกรซ ผู้รับ",
+					Address: "grace.phurab@example.net",
+				},
+			},
+			ResentMessageID: "Message-Id-1@example.net",
+			ContentType: ContentTypeHeader{
+				ContentType: "multipart/signed",
+				Params: map[string]string{
+					"boundary": "SignedBoundaryString",
+					"charset":  "windows-874",
+					"micalg":   "sha1",
+					"protocol": "application/pkcs7-signature",
+				},
+			},
+			ExtraHeaders: map[string][]string{
+				"X-Clacks-Overhead": {"GNU Terry Pratchett"},
+			},
+		},
+		Text: `เป็นมนุษย์สุดประเสริฐเลิศคุณค่า กว่าบรรดาฝูงสัตว์เดรัจฉาน จงฝ่าฟันพัฒนาวิชาการ อย่าล้างผลาญฤๅเข่นฆ่าบีฑาใคร ไม่ถือโทษโกรธแช่งซัดฮึดฮัดด่า หัดอภัยเหมือนกีฬาอัชฌาสัย ปฏิบัติประพฤติกฎกำหนดใจ พูดจาให้จ๊ะๆ จ๋าๆ น่าฟังเอยฯ
+
+นายสังฆภัณฑ์ เฮงพิทักษ์ฝั่ง ผู้เฒ่าซึ่งมีอาชีพเป็นฅนขายฃวด ถูกตำรวจปฏิบัติการจับฟ้องศาล ฐานลักนาฬิกาคุณหญิงฉัตรชฎา ฌานสมาธิ`,
+		AttachedFiles: []AttachedFile{
+			{
+				ContentType: ContentTypeHeader{
+					ContentType: "application/pkcs7-signature",
+					Params: map[string]string{
+						"name": "smime.p7s",
+					},
+				},
+				ContentDisposition: ContentDispositionHeader{
+					ContentDisposition: attachment,
+					Params: map[string]string{
+						"filename": "smime.p7s",
+					},
+				},
+				Data: []byte{130, 28, 135, 132, 117, 46, 142, 18, 97, 140, 126, 251, 159, 193, 199, 25, 58, 223, 189, 185, 227, 239, 158, 173, 108, 31, 71, 27, 133, 80, 165, 252, 133, 227, 174, 198, 132, 129, 159, 29, 246, 19, 235, 133, 80, 165, 252, 133, 227, 174, 198, 132, 129, 159, 29, 246, 19, 234, 49, 251, 238, 127, 7, 28, 104, 33, 200, 120, 71, 82, 232, 225, 38, 30, 249, 234, 214, 193, 244, 113, 147, 173, 251, 219, 158, 57, 252, 28, 113, 147, 173, 251, 225, 38, 24, 199, 239, 190, 173, 108, 31, 71, 27, 133, 80, 110, 120, 251, 231, 174, 198, 132, 129, 159, 29, 246, 19, 234, 8, 114, 30, 17, 212, 186, 58, 95, 200, 94, 59, 26, 18, 6, 124, 119, 216, 79, 174, 21, 65, 185, 227, 239, 158},
+			},
+		},
+	}
+
+	testEmailFromFile(t, fp, expectedEmail)
+}
+
+func TestParseEmailThaiMultipartSignedWindows874OverQuotedprintable(t *testing.T) {
+	fp := "tests/test_thai_multipart_signed_windows-874_over_quoted-printable.txt"
+	tz, _ := time.LoadLocation("Asia/Bangkok")
+	expectedDate, _ := time.Parse(
+		time.RFC1123Z+" (MST)",
+		time.Date(2019, time.April, 1, 7, 55, 0, 0, tz).Format(time.RFC1123Z+" (MST)"))
+	expectedEmail := Email{
+		Headers: Headers{
+			Date:    expectedDate,
+			Subject: "📧 Signed Test แพนแกรมภาษาไทย",
+			ReplyTo: []*mail.Address{
+				{
+					Name:    "อลิซ ผู้ส่งจดหมาย",
+					Address: "alis.phusngcdhmay@example.net",
+				},
+			},
+			Sender: &mail.Address{
+				Name:    "อลิซ ผู้ส่งจดหมาย",
+				Address: "alis.phusngcdhmay@example.com",
+			},
+			From: []*mail.Address{
+				{
+					Name:    "อลิซ ผู้ส่งจดหมาย",
+					Address: "alis.phusngcdhmay@example.com",
+				},
+				{
+					Name:    "อลิซ ผู้ส่งจดหมาย",
+					Address: "alis.phusngcdhmay@example.net",
+				},
+			},
+			To: []*mail.Address{
+				{
+					Name:    "บ๊อบ ผู้รับ",
+					Address: "bob.phurab@example.com",
+				},
+				{
+					Name:    "คาโรล ผู้รับ",
+					Address: "carol.phurab@example.com",
+				},
+			},
+			Cc: []*mail.Address{
+				{
+					Name:    "แดน ผู้รับ",
+					Address: "dan.phurab@example.com",
+				},
+				{
+					Name:    "อีฟ ผู้รับ",
+					Address: "eve.phurab@example.com",
+				},
+			},
+			Bcc: []*mail.Address{
+				{
+					Name:    "แฟรงค์ ผู้รับ",
+					Address: "frank.phurab@example.com",
+				},
+				{
+					Name:    "เกรซ ผู้รับ",
+					Address: "grace.phurab@example.com",
+				},
+			},
+			MessageID:  "Message-Id-1@example.com",
+			InReplyTo:  []MessageId{"Message-Id-0@example.com"},
+			References: []MessageId{"Message-Id-0@example.com"},
+			Comments:   "Message Header Comment",
+			Keywords:   []string{"Keyword 1", "Keyword 2"},
+			ResentDate: expectedDate,
+			ResentFrom: []*mail.Address{
+				{
+					Name:    "อลิซ ผู้ส่งจดหมาย",
+					Address: "alis.phusngcdhmay@example.net",
+				},
+				{
+					Name:    "อลิซ ผู้ส่งจดหมาย",
+					Address: "alis.phusngcdhmay@example.com",
+				},
+			},
+			ResentSender: &mail.Address{
+				Name:    "อลิซ ผู้ส่งจดหมาย",
+				Address: "alis.phusngcdhmay@example.net",
+			},
+			ResentTo: []*mail.Address{
+				{
+					Name:    "บ๊อบ ผู้รับ",
+					Address: "bob.phurab@example.net",
+				},
+				{
+					Name:    "คาโรล ผู้รับ",
+					Address: "carol.phurab@example.net",
+				},
+			},
+			ResentCc: []*mail.Address{
+				{
+					Name:    "แดน ผู้รับ",
+					Address: "dan.phurab@example.net",
+				},
+				{
+					Name:    "อีฟ ผู้รับ",
+					Address: "eve.phurab@example.net",
+				},
+			},
+			ResentBcc: []*mail.Address{
+				{
+					Name:    "แฟรงค์ ผู้รับ",
+					Address: "frank.phurab@example.net",
+				},
+				{
+					Name:    "เกรซ ผู้รับ",
+					Address: "grace.phurab@example.net",
+				},
+			},
+			ResentMessageID: "Message-Id-1@example.net",
+			ContentType: ContentTypeHeader{
+				ContentType: "multipart/signed",
+				Params: map[string]string{
+					"boundary": "SignedBoundaryString",
+					"charset":  "windows-874",
+					"micalg":   "sha1",
+					"protocol": "application/pkcs7-signature",
+				},
+			},
+			ExtraHeaders: map[string][]string{
+				"X-Clacks-Overhead": {"GNU Terry Pratchett"},
+			},
+		},
+		Text: `เป็นมนุษย์สุดประเสริฐเลิศคุณค่า กว่าบรรดาฝูงสัตว์เดรัจฉาน จงฝ่าฟันพัฒนาวิชาการ อย่าล้างผลาญฤๅเข่นฆ่าบีฑาใคร ไม่ถือโทษโกรธแช่งซัดฮึดฮัดด่า หัดอภัยเหมือนกีฬาอัชฌาสัย ปฏิบัติประพฤติกฎกำหนดใจ พูดจาให้จ๊ะๆ จ๋าๆ น่าฟังเอยฯ
+
+นายสังฆภัณฑ์ เฮงพิทักษ์ฝั่ง ผู้เฒ่าซึ่งมีอาชีพเป็นฅนขายฃวด ถูกตำรวจปฏิบัติการจับฟ้องศาล ฐานลักนาฬิกาคุณหญิงฉัตรชฎา ฌานสมาธิ`,
+		AttachedFiles: []AttachedFile{
+			{
+				ContentType: ContentTypeHeader{
+					ContentType: "application/pkcs7-signature",
+					Params: map[string]string{
+						"name": "smime.p7s",
+					},
+				},
+				ContentDisposition: ContentDispositionHeader{
+					ContentDisposition: attachment,
+					Params: map[string]string{
+						"filename": "smime.p7s",
+					},
+				},
+				Data: []byte{130, 28, 135, 132, 117, 46, 142, 18, 97, 140, 126, 251, 159, 193, 199, 25, 58, 223, 189, 185, 227, 239, 158, 173, 108, 31, 71, 27, 133, 80, 165, 252, 133, 227, 174, 198, 132, 129, 159, 29, 246, 19, 235, 133, 80, 165, 252, 133, 227, 174, 198, 132, 129, 159, 29, 246, 19, 234, 49, 251, 238, 127, 7, 28, 104, 33, 200, 120, 71, 82, 232, 225, 38, 30, 249, 234, 214, 193, 244, 113, 147, 173, 251, 219, 158, 57, 252, 28, 113, 147, 173, 251, 225, 38, 24, 199, 239, 190, 173, 108, 31, 71, 27, 133, 80, 110, 120, 251, 231, 174, 198, 132, 129, 159, 29, 246, 19, 234, 8, 114, 30, 17, 212, 186, 58, 95, 200, 94, 59, 26, 18, 6, 124, 119, 216, 79, 174, 21, 65, 185, 227, 239, 158},
+			},
+		},
+	}
+
+	testEmailFromFile(t, fp, expectedEmail)
+}
+
+func TestParseEmailThaiMultipartSignedTis620OverBase64(t *testing.T) {
+	fp := "tests/test_thai_multipart_signed_tis-620_over_base64.txt"
+	tz, _ := time.LoadLocation("Asia/Bangkok")
+	expectedDate, _ := time.Parse(
+		time.RFC1123Z+" (MST)",
+		time.Date(2019, time.April, 1, 7, 55, 0, 0, tz).Format(time.RFC1123Z+" (MST)"))
+	expectedEmail := Email{
+		Headers: Headers{
+			Date:    expectedDate,
+			Subject: "📧 Signed Test แพนแกรมภาษาไทย",
+			ReplyTo: []*mail.Address{
+				{
+					Name:    "อลิซ ผู้ส่งจดหมาย",
+					Address: "alis.phusngcdhmay@example.net",
+				},
+			},
+			Sender: &mail.Address{
+				Name:    "อลิซ ผู้ส่งจดหมาย",
+				Address: "alis.phusngcdhmay@example.com",
+			},
+			From: []*mail.Address{
+				{
+					Name:    "อลิซ ผู้ส่งจดหมาย",
+					Address: "alis.phusngcdhmay@example.com",
+				},
+				{
+					Name:    "อลิซ ผู้ส่งจดหมาย",
+					Address: "alis.phusngcdhmay@example.net",
+				},
+			},
+			To: []*mail.Address{
+				{
+					Name:    "บ๊อบ ผู้รับ",
+					Address: "bob.phurab@example.com",
+				},
+				{
+					Name:    "คาโรล ผู้รับ",
+					Address: "carol.phurab@example.com",
+				},
+			},
+			Cc: []*mail.Address{
+				{
+					Name:    "แดน ผู้รับ",
+					Address: "dan.phurab@example.com",
+				},
+				{
+					Name:    "อีฟ ผู้รับ",
+					Address: "eve.phurab@example.com",
+				},
+			},
+			Bcc: []*mail.Address{
+				{
+					Name:    "แฟรงค์ ผู้รับ",
+					Address: "frank.phurab@example.com",
+				},
+				{
+					Name:    "เกรซ ผู้รับ",
+					Address: "grace.phurab@example.com",
+				},
+			},
+			MessageID:  "Message-Id-1@example.com",
+			InReplyTo:  []MessageId{"Message-Id-0@example.com"},
+			References: []MessageId{"Message-Id-0@example.com"},
+			Comments:   "Message Header Comment",
+			Keywords:   []string{"Keyword 1", "Keyword 2"},
+			ResentDate: expectedDate,
+			ResentFrom: []*mail.Address{
+				{
+					Name:    "อลิซ ผู้ส่งจดหมาย",
+					Address: "alis.phusngcdhmay@example.net",
+				},
+				{
+					Name:    "อลิซ ผู้ส่งจดหมาย",
+					Address: "alis.phusngcdhmay@example.com",
+				},
+			},
+			ResentSender: &mail.Address{
+				Name:    "อลิซ ผู้ส่งจดหมาย",
+				Address: "alis.phusngcdhmay@example.net",
+			},
+			ResentTo: []*mail.Address{
+				{
+					Name:    "บ๊อบ ผู้รับ",
+					Address: "bob.phurab@example.net",
+				},
+				{
+					Name:    "คาโรล ผู้รับ",
+					Address: "carol.phurab@example.net",
+				},
+			},
+			ResentCc: []*mail.Address{
+				{
+					Name:    "แดน ผู้รับ",
+					Address: "dan.phurab@example.net",
+				},
+				{
+					Name:    "อีฟ ผู้รับ",
+					Address: "eve.phurab@example.net",
+				},
+			},
+			ResentBcc: []*mail.Address{
+				{
+					Name:    "แฟรงค์ ผู้รับ",
+					Address: "frank.phurab@example.net",
+				},
+				{
+					Name:    "เกรซ ผู้รับ",
+					Address: "grace.phurab@example.net",
+				},
+			},
+			ResentMessageID: "Message-Id-1@example.net",
+			ContentType: ContentTypeHeader{
+				ContentType: "multipart/signed",
+				Params: map[string]string{
+					"boundary": "SignedBoundaryString",
+					"charset":  "tis-620",
+					"micalg":   "sha1",
+					"protocol": "application/pkcs7-signature",
+				},
+			},
+			ExtraHeaders: map[string][]string{
+				"X-Clacks-Overhead": {"GNU Terry Pratchett"},
+			},
+		},
+		Text: `เป็นมนุษย์สุดประเสริฐเลิศคุณค่า กว่าบรรดาฝูงสัตว์เดรัจฉาน จงฝ่าฟันพัฒนาวิชาการ อย่าล้างผลาญฤๅเข่นฆ่าบีฑาใคร ไม่ถือโทษโกรธแช่งซัดฮึดฮัดด่า หัดอภัยเหมือนกีฬาอัชฌาสัย ปฏิบัติประพฤติกฎกำหนดใจ พูดจาให้จ๊ะๆ จ๋าๆ น่าฟังเอยฯ
+
+นายสังฆภัณฑ์ เฮงพิทักษ์ฝั่ง ผู้เฒ่าซึ่งมีอาชีพเป็นฅนขายฃวด ถูกตำรวจปฏิบัติการจับฟ้องศาล ฐานลักนาฬิกาคุณหญิงฉัตรชฎา ฌานสมาธิ`,
+		AttachedFiles: []AttachedFile{
+			{
+				ContentType: ContentTypeHeader{
+					ContentType: "application/pkcs7-signature",
+					Params: map[string]string{
+						"name": "smime.p7s",
+					},
+				},
+				ContentDisposition: ContentDispositionHeader{
+					ContentDisposition: attachment,
+					Params: map[string]string{
+						"filename": "smime.p7s",
+					},
+				},
+				Data: []byte{130, 28, 135, 132, 117, 46, 142, 18, 97, 140, 126, 251, 159, 193, 199, 25, 58, 223, 189, 185, 227, 239, 158, 173, 108, 31, 71, 27, 133, 80, 165, 252, 133, 227, 174, 198, 132, 129, 159, 29, 246, 19, 235, 133, 80, 165, 252, 133, 227, 174, 198, 132, 129, 159, 29, 246, 19, 234, 49, 251, 238, 127, 7, 28, 104, 33, 200, 120, 71, 82, 232, 225, 38, 30, 249, 234, 214, 193, 244, 113, 147, 173, 251, 219, 158, 57, 252, 28, 113, 147, 173, 251, 225, 38, 24, 199, 239, 190, 173, 108, 31, 71, 27, 133, 80, 110, 120, 251, 231, 174, 198, 132, 129, 159, 29, 246, 19, 234, 8, 114, 30, 17, 212, 186, 58, 95, 200, 94, 59, 26, 18, 6, 124, 119, 216, 79, 174, 21, 65, 185, 227, 239, 158},
+			},
+		},
+	}
+
+	testEmailFromFile(t, fp, expectedEmail)
+}
+
+func TestParseEmailThaiMultipartSignedTis620OverQuotedprintable(t *testing.T) {
+	fp := "tests/test_thai_multipart_signed_tis-620_over_quoted-printable.txt"
+	tz, _ := time.LoadLocation("Asia/Bangkok")
+	expectedDate, _ := time.Parse(
+		time.RFC1123Z+" (MST)",
+		time.Date(2019, time.April, 1, 7, 55, 0, 0, tz).Format(time.RFC1123Z+" (MST)"))
+	expectedEmail := Email{
+		Headers: Headers{
+			Date:    expectedDate,
+			Subject: "📧 Signed Test แพนแกรมภาษาไทย",
+			ReplyTo: []*mail.Address{
+				{
+					Name:    "อลิซ ผู้ส่งจดหมาย",
+					Address: "alis.phusngcdhmay@example.net",
+				},
+			},
+			Sender: &mail.Address{
+				Name:    "อลิซ ผู้ส่งจดหมาย",
+				Address: "alis.phusngcdhmay@example.com",
+			},
+			From: []*mail.Address{
+				{
+					Name:    "อลิซ ผู้ส่งจดหมาย",
+					Address: "alis.phusngcdhmay@example.com",
+				},
+				{
+					Name:    "อลิซ ผู้ส่งจดหมาย",
+					Address: "alis.phusngcdhmay@example.net",
+				},
+			},
+			To: []*mail.Address{
+				{
+					Name:    "บ๊อบ ผู้รับ",
+					Address: "bob.phurab@example.com",
+				},
+				{
+					Name:    "คาโรล ผู้รับ",
+					Address: "carol.phurab@example.com",
+				},
+			},
+			Cc: []*mail.Address{
+				{
+					Name:    "แดน ผู้รับ",
+					Address: "dan.phurab@example.com",
+				},
+				{
+					Name:    "อีฟ ผู้รับ",
+					Address: "eve.phurab@example.com",
+				},
+			},
+			Bcc: []*mail.Address{
+				{
+					Name:    "แฟรงค์ ผู้รับ",
+					Address: "frank.phurab@example.com",
+				},
+				{
+					Name:    "เกรซ ผู้รับ",
+					Address: "grace.phurab@example.com",
+				},
+			},
+			MessageID:  "Message-Id-1@example.com",
+			InReplyTo:  []MessageId{"Message-Id-0@example.com"},
+			References: []MessageId{"Message-Id-0@example.com"},
+			Comments:   "Message Header Comment",
+			Keywords:   []string{"Keyword 1", "Keyword 2"},
+			ResentDate: expectedDate,
+			ResentFrom: []*mail.Address{
+				{
+					Name:    "อลิซ ผู้ส่งจดหมาย",
+					Address: "alis.phusngcdhmay@example.net",
+				},
+				{
+					Name:    "อลิซ ผู้ส่งจดหมาย",
+					Address: "alis.phusngcdhmay@example.com",
+				},
+			},
+			ResentSender: &mail.Address{
+				Name:    "อลิซ ผู้ส่งจดหมาย",
+				Address: "alis.phusngcdhmay@example.net",
+			},
+			ResentTo: []*mail.Address{
+				{
+					Name:    "บ๊อบ ผู้รับ",
+					Address: "bob.phurab@example.net",
+				},
+				{
+					Name:    "คาโรล ผู้รับ",
+					Address: "carol.phurab@example.net",
+				},
+			},
+			ResentCc: []*mail.Address{
+				{
+					Name:    "แดน ผู้รับ",
+					Address: "dan.phurab@example.net",
+				},
+				{
+					Name:    "อีฟ ผู้รับ",
+					Address: "eve.phurab@example.net",
+				},
+			},
+			ResentBcc: []*mail.Address{
+				{
+					Name:    "แฟรงค์ ผู้รับ",
+					Address: "frank.phurab@example.net",
+				},
+				{
+					Name:    "เกรซ ผู้รับ",
+					Address: "grace.phurab@example.net",
+				},
+			},
+			ResentMessageID: "Message-Id-1@example.net",
+			ContentType: ContentTypeHeader{
+				ContentType: "multipart/signed",
+				Params: map[string]string{
+					"boundary": "SignedBoundaryString",
+					"charset":  "tis-620",
+					"micalg":   "sha1",
+					"protocol": "application/pkcs7-signature",
+				},
+			},
+			ExtraHeaders: map[string][]string{
+				"X-Clacks-Overhead": {"GNU Terry Pratchett"},
+			},
+		},
+		Text: `เป็นมนุษย์สุดประเสริฐเลิศคุณค่า กว่าบรรดาฝูงสัตว์เดรัจฉาน จงฝ่าฟันพัฒนาวิชาการ อย่าล้างผลาญฤๅเข่นฆ่าบีฑาใคร ไม่ถือโทษโกรธแช่งซัดฮึดฮัดด่า หัดอภัยเหมือนกีฬาอัชฌาสัย ปฏิบัติประพฤติกฎกำหนดใจ พูดจาให้จ๊ะๆ จ๋าๆ น่าฟังเอยฯ
+
+นายสังฆภัณฑ์ เฮงพิทักษ์ฝั่ง ผู้เฒ่าซึ่งมีอาชีพเป็นฅนขายฃวด ถูกตำรวจปฏิบัติการจับฟ้องศาล ฐานลักนาฬิกาคุณหญิงฉัตรชฎา ฌานสมาธิ`,
+		AttachedFiles: []AttachedFile{
+			{
+				ContentType: ContentTypeHeader{
+					ContentType: "application/pkcs7-signature",
+					Params: map[string]string{
+						"name": "smime.p7s",
+					},
+				},
+				ContentDisposition: ContentDispositionHeader{
+					ContentDisposition: attachment,
+					Params: map[string]string{
+						"filename": "smime.p7s",
+					},
+				},
+				Data: []byte{130, 28, 135, 132, 117, 46, 142, 18, 97, 140, 126, 251, 159, 193, 199, 25, 58, 223, 189, 185, 227, 239, 158, 173, 108, 31, 71, 27, 133, 80, 165, 252, 133, 227, 174, 198, 132, 129, 159, 29, 246, 19, 235, 133, 80, 165, 252, 133, 227, 174, 198, 132, 129, 159, 29, 246, 19, 234, 49, 251, 238, 127, 7, 28, 104, 33, 200, 120, 71, 82, 232, 225, 38, 30, 249, 234, 214, 193, 244, 113, 147, 173, 251, 219, 158, 57, 252, 28, 113, 147, 173, 251, 225, 38, 24, 199, 239, 190, 173, 108, 31, 71, 27, 133, 80, 110, 120, 251, 231, 174, 198, 132, 129, 159, 29, 246, 19, 234, 8, 114, 30, 17, 212, 186, 58, 95, 200, 94, 59, 26, 18, 6, 124, 119, 216, 79, 174, 21, 65, 185, 227, 239, 158},
+			},
+		},
+	}
+
+	testEmailFromFile(t, fp, expectedEmail)
+}

--- a/tests/test_thai_multipart_mixed_iso-8859-11_over_base64.txt
+++ b/tests/test_thai_multipart_mixed_iso-8859-11_over_base64.txt
@@ -1,0 +1,130 @@
+Date: Mon, 01 Apr 2019 07:55:00 +0700 (+07)
+From: =?IsO-8859-11?b?zcXUqyC82enK6KeotMvB0sI=?= <alis.phusngcdhmay@example.com>,
+ =?IsO-8859-11?b?zcXUqyC82enK6KeotMvB0sI=?= <alis.phusngcdhmay@example.net>
+Sender: =?IsO-8859-11?b?zcXUqyC82enK6KeotMvB0sI=?= <alis.phusngcdhmay@example.com>
+Reply-To: =?IsO-8859-11?b?zcXUqyC82enK6KeotMvB0sI=?= <alis.phusngcdhmay@example.net>
+To: =?Iso-8859-11?b?uurNuiC82enD0bo=?= <bob.phurab@example.com>,
+ =?iso-8859-11?B?pNLiw8UgvNnpw9G6?= <carol.phurab@example.com>
+Cc: =?isO-8859-11?b?4bS5ILzZ6cPRug==?= <dan.phurab@example.com>,
+ =?iSO-8859-11?b?zdW/ILzZ6cPRug==?= <eve.phurab@example.com>
+Bcc: =?iSo-8859-11?b?4b/Dp6TsILzZ6cPRug==?= <frank.phurab@example.com>,
+ =?iSO-8859-11?B?4KHDqyC82enD0bo=?= <grace.phurab@example.com>
+Subject: =?UTF-8?B?8J+Tpw==?= Test
+ =?iSo-8859-11?b?4b654aHDwcDSydLkt8I=?=
+In-Reply-To: <Message-Id-0@example.com>
+References: <Message-Id-0@example.com>
+Message-ID: <Message-Id-1@example.com>
+Comments: Message Header Comment
+Keywords: Keyword 1, Keyword 2
+Resent-Date: Mon, 01 Apr 2019 07:55:00 +0700 (+07)
+Resent-From: =?IsO-8859-11?b?zcXUqyC82enK6KeotMvB0sI=?= <alis.phusngcdhmay@example.net>,
+ =?IsO-8859-11?b?zcXUqyC82enK6KeotMvB0sI=?= <alis.phusngcdhmay@example.com>
+Resent-Sender: =?IsO-8859-11?b?zcXUqyC82enK6KeotMvB0sI=?= <alis.phusngcdhmay@example.net>
+Resent-To: =?Iso-8859-11?b?uurNuiC82enD0bo=?= <bob.phurab@example.net>,
+ =?iso-8859-11?B?pNLiw8UgvNnpw9G6?= <carol.phurab@example.net>
+Resent-Cc: =?isO-8859-11?b?4bS5ILzZ6cPRug==?= <dan.phurab@example.net>,
+ =?iSO-8859-11?b?zdW/ILzZ6cPRug==?= <eve.phurab@example.net>
+Resent-Bcc: =?iSo-8859-11?b?4b/Dp6TsILzZ6cPRug==?= <frank.phurab@example.net>,
+ =?iSO-8859-11?B?4KHDqyC82enD0bo=?= <grace.phurab@example.net>
+Resent-Message-ID: <Message-Id-1@example.net>
+Content-Type: MuLTipART/MIXed; cHarSEt="iso-8859-11"; BOUnDArY="MixedBoundaryString"
+Content-Transfer-Encoding: BaSe64
+X-Clacks-Overhead: GNU Terry Pratchett
+
+
+--MixedBoundaryString
+Content-Type: mULtiPART/rElAted; BOuNdARy="RelatedBoundaryString"
+
+--RelatedBoundaryString
+Content-Type: multIPart/ALterNAtIVe; BouNDaRy="AlternativeBoundaryString"
+
+--AlternativeBoundaryString
+Content-Type: TEXt/pLaiN; cHaRSeT="Iso-8859-11"
+Content-Transfer-Encoding: BaSe64
+
+4LvnucG52MnC7MrYtLvD0ODKw9Sw4MXUyKTYs6To0iChx+jSusPDtNK92afK0bXH7OC0w9GoqdK5
+IKinvejSv9G5vtGyudLH1KrSodLDIM3C6NLF6dKnvMXSrcTl4KLouabo0rrVsdLjpMMg5MHottfN
+4rfJ4qHDuOGq6Ker0bTO1rTO0bS06NIgy9G0zcDRwuDLwdfNuaHVzNLN0aqs0srRwiC7r9S60bXU
+u8PQvsS11KGuodPLubTjqCC+2bSo0uPL6ajq0OYgqOvS5iC56NK/0afgzcLPCgq50sLK0aemwNGz
+sewg4M6nvtS30aHJ7L3R6KcgvNnp4LLo0qvW6KfB1c3SqtW+4LvnuaW5otLCo8e0ILbZobXTw8eo
+u6/UutG11KHSw6jRur/pzafI0sUgsNK5xdGhudLM1KHSpNizy63Up6nRtcOqrtIgrNK5ysHSuNQ
+
+--AlternativeBoundaryString
+Content-Type: TexT/eNrichED; cHaRSET="isO-8859-11"
+Content-Transfer-Encoding: baSE64
+
+PGJvbGQ+4LvnucG52MnC7MrYtLvD0ODKw9Sw4MXUyKTYs6To0jwvYm9sZD4gPGl0YWxpYz6hx+jS
+usPDtNK92afK0bXH7OC0w9GoqdK5PC9pdGFsaWM+IDxmaXhlZD6op73o0r/Rub7RsrnSx9Sq0qHS
+wzwvZml4ZWQ+IDx1bmRlcmxpbmU+zcLo0sXp0qe8xdKtxOXgoui5pujSutWx0uOkwzwvdW5kZXJs
+aW5lPiDkwei2183it8niocO44arop6vRtM7WtM7RtLTo0iDL0bTNwNHC4MvB1825odXM0s3RqqzS
+ytHCILuv1LrRtdS7w9C+xLXUoa6h08u5tOOoIL7ZtKjS48vpqOrQ5iCo69LmILno0r/Rp+DNws8K
+CrnSwsrRp6bA0bOx7CDgzqe+1LfRocnsvdHopyC82engsujSq9bop8HVzdKq1b7gu+e5pbmi0sKj
+x7QgttmhtdPDx6i7r9S60bXUodLDqNG6v+nNp8jSxSCw0rnF0aG50szUodKk2LPLrdSnqdG1w6qu
+0iCs0rnKwdK41A
+
+--AlternativeBoundaryString
+Content-Type: tExt/HtmL; cHarsET="iso-8859-11"
+Content-Transfer-Encoding: BAse64
+
+PGh0bWw+CjxkaXYgZGlyPSJsdHIiPgo8cD7gu+e5wbnYycLsyti0u8PQ4MrD1LDgxdTIpNizpOjS
+IKHH6NK6w8O00r3Zp8rRtcfs4LTD0aip0rkgqKe96NK/0bm+0bK50sfUqtKh0sMgzcLo0sXp0qe8
+xdKtxOXgoui5pujSutWx0uOkwyDkwei2183it8niocO44arop6vRtM7WtM7RtLTo0iDL0bTNwNHC
+4MvB1825odXM0s3RqqzSytHCILuv1LrRtdS7w9C+xLXUoa6h08u5tOOoIL7ZtKjS48vpqOrQ5iCo
+69LmILno0r/Rp+DNws88L3A+Cgo8cD650sLK0aemwNGzsewg4M6nvtS30aHJ7L3R6KcgvNnp4LLo
+0qvW6KfB1c3SqtW+4LvnuaW5otLCo8e0ILbZobXTw8eou6/UutG11KHSw6jRur/pzafI0sUgsNK5
+xdGhudLM1KHSpNizy63Up6nRtcOqrtIgrNK5ysHSuNQ8L3A+CjwvZGl2Pgo8L2h0bWw+
+
+--AlternativeBoundaryString--
+
+--RelatedBoundaryString
+Content-Type: image/jpeg; nAme="inline-jpg-image-without-disposition.jpg"
+Content-Transfer-Encoding: Base64
+
+/9j/2wBDAAMCAgICAgMCAgIDAwMDBAYEBAQEBAgGBgUGCQgKCgkICQkKDA8MCgsOCwkJDRENDg8Q
+EBEQCgwSExIQEw8QEBD/yQALCAABAAEBAREA/8wABgAQEAX/2gAIAQEAAD8A0s8g/9k=
+
+--RelatedBoundaryString
+Content-Type: image/jpeg; NaMe="inline-jpg-image-name.jpg"
+Content-Transfer-Encoding: bAsE64
+Content-Disposition: inLinE; fIleNaMe="inline-jpg-image-filename.jpg"
+Content-ID: <inline-jpg-image.jpg@example.com>
+
+/9j/2wBDAAMCAgICAgMCAgIDAwMDBAYEBAQEBAgGBgUGCQgKCgkICQkKDA8MCgsOCwkJDRENDg8Q
+EBEQCgwSExIQEw8QEBD/yQALCAABAAEBAREA/8wABgAQEAX/2gAIAQEAAD8A0s8g/9k=
+
+--RelatedBoundaryString--
+
+--MixedBoundaryString
+Content-Type: APplIcaTiON/Pdf; NAMe="attached-pdf-name.pdf"
+Content-Transfer-Encoding: base64
+Content-Disposition: ATTacHMENt; FILEName="attached-pdf-filename.pdf"
+
+JVBERi0xLg10cmFpbGVyPDwvUm9vdDw8L1BhZ2VzPDwvS2lkc1s8PC9NZWRpYUJveFswIDAgMyAz
+XT4+XT4+Pj4+Pg==
+
+--MixedBoundaryString
+Content-Type: APplIcATion/Pdf; nAME="attached-pdf-without-disposition.pdf"
+Content-Transfer-Encoding: BasE64
+
+JVBERi0xLg10cmFpbGVyPDwvUm9vdDw8L1BhZ2VzPDwvS2lkc1s8PC9NZWRpYUJveFswIDAgMyAz
+XT4+XT4+Pj4+Pg==
+
+--MixedBoundaryString
+Content-Type: apPLiCaTiOn/json; nAmE="attached-json-name.json"
+Content-Disposition: AtTAChmeNt; FilENAme="attached-json-filename.json"
+
+{"foo":"bar"}
+--MixedBoundaryString
+Content-Type: teXT/pLain; NAme="attached-text-plain-name.txt"
+Content-Disposition: atTAcHmEnt; fIleNAMe="attached-text-plain-filename.txt"
+Content-Transfer-Encoding: basE64
+
+VGV4dC9wbGFpbiBjb250ZW50IGFzIGFuIGF0dGFjaGVkIC50eHQgZmlsZS4=
+
+--MixedBoundaryString
+Content-Type: TExT/htML; nAMe="attached-text-html-name.html"
+Content-Disposition: AtTacHmENt; FilEnamE="attached-text-html-filename.html"
+Content-Transfer-Encoding: BAsE64
+
+VGV4dC9odG1sIGNvbnRlbnQgYXMgYW4gYXR0YWNoZWQgLmh0bWwgZmlsZS4=
+--MixedBoundaryString--

--- a/tests/test_thai_multipart_mixed_iso-8859-11_over_quoted-printable.txt
+++ b/tests/test_thai_multipart_mixed_iso-8859-11_over_quoted-printable.txt
@@ -1,0 +1,159 @@
+Date: Mon, 01 Apr 2019 07:55:00 +0700 (+07)
+From: =?Iso-8859-11?Q?=CD=C5=D4=AB_=BC=D9=E9=CA=E8=A7=A8=B4=CB=C1=D2=C2?= <alis.phusngcdhmay@example.com>,
+ =?Iso-8859-11?Q?=CD=C5=D4=AB_=BC=D9=E9=CA=E8=A7=A8=B4=CB=C1=D2=C2?= <alis.phusngcdhmay@example.net>
+Sender: =?Iso-8859-11?Q?=CD=C5=D4=AB_=BC=D9=E9=CA=E8=A7=A8=B4=CB=C1=D2=C2?= <alis.phusngcdhmay@example.com>
+Reply-To: =?Iso-8859-11?Q?=CD=C5=D4=AB_=BC=D9=E9=CA=E8=A7=A8=B4=CB=C1=D2=C2?= <alis.phusngcdhmay@example.net>
+To: =?iSo-8859-11?q?=BA=EA=CD=BA_=BC=D9=E9=C3=D1=BA?= <bob.phurab@example.com>,
+ =?ISO-8859-11?Q?=A4=D2=E2=C3=C5_=BC=D9=E9=C3=D1=BA?= <carol.phurab@example.com>
+Cc: =?ISo-8859-11?Q?=E1=B4=B9_=BC=D9=E9=C3=D1=BA?= <dan.phurab@example.com>,
+ =?IsO-8859-11?Q?=CD=D5=BF_=BC=D9=E9=C3=D1=BA?= <eve.phurab@example.com>
+Bcc: =?IsO-8859-11?q?=E1=BF=C3=A7=A4=EC_=BC=D9=E9=C3=D1=BA?= <frank.phurab@example.com>,
+ =?iSO-8859-11?q?=E0=A1=C3=AB_=BC=D9=E9=C3=D1=BA?= <grace.phurab@example.com>
+Subject: =?UTF-8?B?8J+Tpw==?= Test
+ =?Iso-8859-11?Q?=E1=BE=B9=E1=A1=C3=C1=C0=D2=C9=D2=E4=B7=C2?=
+In-Reply-To: <Message-Id-0@example.com>
+References: <Message-Id-0@example.com>
+Message-ID: <Message-Id-1@example.com>
+Comments: Message Header Comment
+Keywords: Keyword 1, Keyword 2
+Resent-Date: Mon, 01 Apr 2019 07:55:00 +0700 (+07)
+Resent-From: =?Iso-8859-11?Q?=CD=C5=D4=AB_=BC=D9=E9=CA=E8=A7=A8=B4=CB=C1=D2=C2?= <alis.phusngcdhmay@example.net>,
+ =?Iso-8859-11?Q?=CD=C5=D4=AB_=BC=D9=E9=CA=E8=A7=A8=B4=CB=C1=D2=C2?= <alis.phusngcdhmay@example.com>
+Resent-Sender: =?Iso-8859-11?Q?=CD=C5=D4=AB_=BC=D9=E9=CA=E8=A7=A8=B4=CB=C1=D2=C2?= <alis.phusngcdhmay@example.net>
+Resent-To: =?iSo-8859-11?q?=BA=EA=CD=BA_=BC=D9=E9=C3=D1=BA?= <bob.phurab@example.net>,
+ =?ISO-8859-11?Q?=A4=D2=E2=C3=C5_=BC=D9=E9=C3=D1=BA?= <carol.phurab@example.net>
+Resent-Cc: =?ISo-8859-11?Q?=E1=B4=B9_=BC=D9=E9=C3=D1=BA?= <dan.phurab@example.net>,
+ =?IsO-8859-11?Q?=CD=D5=BF_=BC=D9=E9=C3=D1=BA?= <eve.phurab@example.net>
+Resent-Bcc: =?IsO-8859-11?q?=E1=BF=C3=A7=A4=EC_=BC=D9=E9=C3=D1=BA?= <frank.phurab@example.net>,
+ =?iSO-8859-11?q?=E0=A1=C3=AB_=BC=D9=E9=C3=D1=BA?= <grace.phurab@example.net>
+Resent-Message-ID: <Message-Id-1@example.net>
+Content-Type: MUlTiPArt/mIxeD; chArSET="iSO-8859-11"; BounDary="MixedBoundaryString"
+Content-Transfer-Encoding: Quoted-PRIntAbLe
+X-Clacks-Overhead: GNU Terry Pratchett
+
+
+--MixedBoundaryString
+Content-Type: MUlTiPaRT/RELated; BOUNDARY="RelatedBoundaryString"
+
+--RelatedBoundaryString
+Content-Type: MULTiPaRT/alTernATive; BOunDarY="AlternativeBoundaryString"
+
+--AlternativeBoundaryString
+Content-Type: texT/pLaIN; cHarSEt="ISo-8859-11"
+Content-Transfer-Encoding: quoTed-PRinTaBLe
+
+=E0=BB=E7=B9=C1=B9=D8=C9=C2=EC=CA=D8=B4=BB=C3=D0=E0=CA=C3=D4=B0=E0=C5=D4=C8=
+=A4=D8=B3=A4=E8=D2 =A1=C7=E8=D2=BA=C3=C3=B4=D2=BD=D9=A7=CA=D1=B5=C7=EC=E0=
+=B4=C3=D1=A8=A9=D2=B9 =A8=A7=BD=E8=D2=BF=D1=B9=BE=D1=B2=B9=D2=C7=D4=AA=D2=
+=A1=D2=C3 =CD=C2=E8=D2=C5=E9=D2=A7=BC=C5=D2=AD=C4=E5=E0=A2=E8=B9=A6=E8=D2=
+=BA=D5=B1=D2=E3=A4=C3 =E4=C1=E8=B6=D7=CD=E2=B7=C9=E2=A1=C3=B8=E1=AA=E8=A7=
+=AB=D1=B4=CE=D6=B4=CE=D1=B4=B4=E8=D2 =CB=D1=B4=CD=C0=D1=C2=E0=CB=C1=D7=CD=
+=B9=A1=D5=CC=D2=CD=D1=AA=AC=D2=CA=D1=C2 =BB=AF=D4=BA=D1=B5=D4=BB=C3=D0=BE=
+=C4=B5=D4=A1=AE=A1=D3=CB=B9=B4=E3=A8 =BE=D9=B4=A8=D2=E3=CB=E9=A8=EA=D0=E6 =
+=A8=EB=D2=E6 =B9=E8=D2=BF=D1=A7=E0=CD=C2=CF
+
+=B9=D2=C2=CA=D1=A7=A6=C0=D1=B3=B1=EC =E0=CE=A7=BE=D4=B7=D1=A1=C9=EC=BD=D1=
+=E8=A7 =BC=D9=E9=E0=B2=E8=D2=AB=D6=E8=A7=C1=D5=CD=D2=AA=D5=BE=E0=BB=E7=B9=
+=A5=B9=A2=D2=C2=A3=C7=B4 =B6=D9=A1=B5=D3=C3=C7=A8=BB=AF=D4=BA=D1=B5=D4=A1=
+=D2=C3=A8=D1=BA=BF=E9=CD=A7=C8=D2=C5 =B0=D2=B9=C5=D1=A1=B9=D2=CC=D4=A1=D2=
+=A4=D8=B3=CB=AD=D4=A7=A9=D1=B5=C3=AA=AE=D2 =AC=D2=B9=CA=C1=D2=B8=D4
+
+--AlternativeBoundaryString
+Content-Type: tExt/enRIcHEd; chArSeT="IsO-8859-11"
+Content-Transfer-Encoding: qUOTEd-PrintABLE
+
+<bold>=E0=BB=E7=B9=C1=B9=D8=C9=C2=EC=CA=D8=B4=BB=C3=D0=E0=CA=C3=D4=B0=E0=C5=
+=D4=C8=A4=D8=B3=A4=E8=D2</bold> <italic>=A1=C7=E8=D2=BA=C3=C3=B4=D2=BD=D9=
+=A7=CA=D1=B5=C7=EC=E0=B4=C3=D1=A8=A9=D2=B9</italic> <fixed>=A8=A7=BD=E8=D2=
+=BF=D1=B9=BE=D1=B2=B9=D2=C7=D4=AA=D2=A1=D2=C3</fixed> <underline>=CD=C2=E8=
+=D2=C5=E9=D2=A7=BC=C5=D2=AD=C4=E5=E0=A2=E8=B9=A6=E8=D2=BA=D5=B1=D2=E3=A4=C3=
+</underline> =E4=C1=E8=B6=D7=CD=E2=B7=C9=E2=A1=C3=B8=E1=AA=E8=A7=AB=D1=B4=
+=CE=D6=B4=CE=D1=B4=B4=E8=D2 =CB=D1=B4=CD=C0=D1=C2=E0=CB=C1=D7=CD=B9=A1=D5=
+=CC=D2=CD=D1=AA=AC=D2=CA=D1=C2 =BB=AF=D4=BA=D1=B5=D4=BB=C3=D0=BE=C4=B5=D4=
+=A1=AE=A1=D3=CB=B9=B4=E3=A8 =BE=D9=B4=A8=D2=E3=CB=E9=A8=EA=D0=E6 =A8=EB=D2=
+=E6 =B9=E8=D2=BF=D1=A7=E0=CD=C2=CF
+
+=B9=D2=C2=CA=D1=A7=A6=C0=D1=B3=B1=EC =E0=CE=A7=BE=D4=B7=D1=A1=C9=EC=BD=D1=
+=E8=A7 =BC=D9=E9=E0=B2=E8=D2=AB=D6=E8=A7=C1=D5=CD=D2=AA=D5=BE=E0=BB=E7=B9=
+=A5=B9=A2=D2=C2=A3=C7=B4 =B6=D9=A1=B5=D3=C3=C7=A8=BB=AF=D4=BA=D1=B5=D4=A1=
+=D2=C3=A8=D1=BA=BF=E9=CD=A7=C8=D2=C5 =B0=D2=B9=C5=D1=A1=B9=D2=CC=D4=A1=D2=
+=A4=D8=B3=CB=AD=D4=A7=A9=D1=B5=C3=AA=AE=D2 =AC=D2=B9=CA=C1=D2=B8=D4
+
+--AlternativeBoundaryString
+Content-Type: texT/htML; cHARSEt="IsO-8859-11"
+Content-Transfer-Encoding: qUoTeD-PrINtaBle
+
+<html>
+<div dir=3D"ltr">
+<p>=E0=BB=E7=B9=C1=B9=D8=C9=C2=EC=CA=D8=B4=BB=C3=D0=E0=CA=C3=D4=B0=E0=C5=D4=
+=C8=A4=D8=B3=A4=E8=D2 =A1=C7=E8=D2=BA=C3=C3=B4=D2=BD=D9=A7=CA=D1=B5=C7=EC=
+=E0=B4=C3=D1=A8=A9=D2=B9 =A8=A7=BD=E8=D2=BF=D1=B9=BE=D1=B2=B9=D2=C7=D4=AA=
+=D2=A1=D2=C3 =CD=C2=E8=D2=C5=E9=D2=A7=BC=C5=D2=AD=C4=E5=E0=A2=E8=B9=A6=E8=
+=D2=BA=D5=B1=D2=E3=A4=C3 =E4=C1=E8=B6=D7=CD=E2=B7=C9=E2=A1=C3=B8=E1=AA=E8=
+=A7=AB=D1=B4=CE=D6=B4=CE=D1=B4=B4=E8=D2 =CB=D1=B4=CD=C0=D1=C2=E0=CB=C1=D7=
+=CD=B9=A1=D5=CC=D2=CD=D1=AA=AC=D2=CA=D1=C2 =BB=AF=D4=BA=D1=B5=D4=BB=C3=D0=
+=BE=C4=B5=D4=A1=AE=A1=D3=CB=B9=B4=E3=A8 =BE=D9=B4=A8=D2=E3=CB=E9=A8=EA=D0=
+=E6 =A8=EB=D2=E6 =B9=E8=D2=BF=D1=A7=E0=CD=C2=CF</p>
+
+<p>=B9=D2=C2=CA=D1=A7=A6=C0=D1=B3=B1=EC =E0=CE=A7=BE=D4=B7=D1=A1=C9=EC=BD=
+=D1=E8=A7 =BC=D9=E9=E0=B2=E8=D2=AB=D6=E8=A7=C1=D5=CD=D2=AA=D5=BE=E0=BB=E7=
+=B9=A5=B9=A2=D2=C2=A3=C7=B4 =B6=D9=A1=B5=D3=C3=C7=A8=BB=AF=D4=BA=D1=B5=D4=
+=A1=D2=C3=A8=D1=BA=BF=E9=CD=A7=C8=D2=C5 =B0=D2=B9=C5=D1=A1=B9=D2=CC=D4=A1=
+=D2=A4=D8=B3=CB=AD=D4=A7=A9=D1=B5=C3=AA=AE=D2 =AC=D2=B9=CA=C1=D2=B8=D4</p>
+</div>
+</html>
+
+--AlternativeBoundaryString--
+
+--RelatedBoundaryString
+Content-Type: image/jpeg; naMe="inline-jpg-image-without-disposition.jpg"
+Content-Transfer-Encoding: baSE64
+
+/9j/2wBDAAMCAgICAgMCAgIDAwMDBAYEBAQEBAgGBgUGCQgKCgkICQkKDA8MCgsOCwkJDRENDg8Q
+EBEQCgwSExIQEw8QEBD/yQALCAABAAEBAREA/8wABgAQEAX/2gAIAQEAAD8A0s8g/9k=
+
+--RelatedBoundaryString
+Content-Type: image/jpeg; NAme="inline-jpg-image-name.jpg"
+Content-Transfer-Encoding: BASE64
+Content-Disposition: inlInE; FileNaMe="inline-jpg-image-filename.jpg"
+Content-ID: <inline-jpg-image.jpg@example.com>
+
+/9j/2wBDAAMCAgICAgMCAgIDAwMDBAYEBAQEBAgGBgUGCQgKCgkICQkKDA8MCgsOCwkJDRENDg8Q
+EBEQCgwSExIQEw8QEBD/yQALCAABAAEBAREA/8wABgAQEAX/2gAIAQEAAD8A0s8g/9k=
+
+--RelatedBoundaryString--
+
+--MixedBoundaryString
+Content-Type: APPLICATIon/PdF; NAME="attached-pdf-name.pdf"
+Content-Transfer-Encoding: BASE64
+Content-Disposition: atTaChmEnT; FiLENAME="attached-pdf-filename.pdf"
+
+JVBERi0xLg10cmFpbGVyPDwvUm9vdDw8L1BhZ2VzPDwvS2lkc1s8PC9NZWRpYUJveFswIDAgMyAz
+XT4+XT4+Pj4+Pg==
+
+--MixedBoundaryString
+Content-Type: appliCAtIOn/pdF; Name="attached-pdf-without-disposition.pdf"
+Content-Transfer-Encoding: baSe64
+
+JVBERi0xLg10cmFpbGVyPDwvUm9vdDw8L1BhZ2VzPDwvS2lkc1s8PC9NZWRpYUJveFswIDAgMyAz
+XT4+XT4+Pj4+Pg==
+
+--MixedBoundaryString
+Content-Type: APPlIcATIOn/JSoN; NamE="attached-json-name.json"
+Content-Disposition: ATtacHMEnt; FILeNAMe="attached-json-filename.json"
+
+{"foo":"bar"}
+--MixedBoundaryString
+Content-Type: tExt/PlaIN; NAmE="attached-text-plain-name.txt"
+Content-Disposition: aTTACHMENt; fiLeName="attached-text-plain-filename.txt"
+Content-Transfer-Encoding: bASE64
+
+VGV4dC9wbGFpbiBjb250ZW50IGFzIGFuIGF0dGFjaGVkIC50eHQgZmlsZS4=
+
+--MixedBoundaryString
+Content-Type: TexT/HTML; NAme="attached-text-html-name.html"
+Content-Disposition: atTacHmeNT; FIlEnamE="attached-text-html-filename.html"
+Content-Transfer-Encoding: BaSe64
+
+VGV4dC9odG1sIGNvbnRlbnQgYXMgYW4gYXR0YWNoZWQgLmh0bWwgZmlsZS4=
+--MixedBoundaryString--

--- a/tests/test_thai_multipart_mixed_tis-620_over_base64.txt
+++ b/tests/test_thai_multipart_mixed_tis-620_over_base64.txt
@@ -1,0 +1,130 @@
+Date: Mon, 01 Apr 2019 07:55:00 +0700 (+07)
+From: =?tIS-620?b?zcXUqyC82enK6KeotMvB0sI=?= <alis.phusngcdhmay@example.com>,
+ =?tIS-620?b?zcXUqyC82enK6KeotMvB0sI=?= <alis.phusngcdhmay@example.net>
+Sender: =?tIS-620?b?zcXUqyC82enK6KeotMvB0sI=?= <alis.phusngcdhmay@example.com>
+Reply-To: =?tIS-620?b?zcXUqyC82enK6KeotMvB0sI=?= <alis.phusngcdhmay@example.net>
+To: =?TIS-620?B?uurNuiC82enD0bo=?= <bob.phurab@example.com>,
+ =?Tis-620?B?pNLiw8UgvNnpw9G6?= <carol.phurab@example.com>
+Cc: =?Tis-620?b?4bS5ILzZ6cPRug==?= <dan.phurab@example.com>,
+ =?tIS-620?b?zdW/ILzZ6cPRug==?= <eve.phurab@example.com>
+Bcc: =?tIs-620?b?4b/Dp6TsILzZ6cPRug==?= <frank.phurab@example.com>,
+ =?Tis-620?B?4KHDqyC82enD0bo=?= <grace.phurab@example.com>
+Subject: =?UTF-8?B?8J+Tpw==?= Test
+ =?TiS-620?b?4b654aHDwcDSydLkt8I=?=
+In-Reply-To: <Message-Id-0@example.com>
+References: <Message-Id-0@example.com>
+Message-ID: <Message-Id-1@example.com>
+Comments: Message Header Comment
+Keywords: Keyword 1, Keyword 2
+Resent-Date: Mon, 01 Apr 2019 07:55:00 +0700 (+07)
+Resent-From: =?tIS-620?b?zcXUqyC82enK6KeotMvB0sI=?= <alis.phusngcdhmay@example.net>,
+ =?tIS-620?b?zcXUqyC82enK6KeotMvB0sI=?= <alis.phusngcdhmay@example.com>
+Resent-Sender: =?tIS-620?b?zcXUqyC82enK6KeotMvB0sI=?= <alis.phusngcdhmay@example.net>
+Resent-To: =?TIS-620?B?uurNuiC82enD0bo=?= <bob.phurab@example.net>,
+ =?Tis-620?B?pNLiw8UgvNnpw9G6?= <carol.phurab@example.net>
+Resent-Cc: =?Tis-620?b?4bS5ILzZ6cPRug==?= <dan.phurab@example.net>,
+ =?tIS-620?b?zdW/ILzZ6cPRug==?= <eve.phurab@example.net>
+Resent-Bcc: =?tIs-620?b?4b/Dp6TsILzZ6cPRug==?= <frank.phurab@example.net>,
+ =?Tis-620?B?4KHDqyC82enD0bo=?= <grace.phurab@example.net>
+Resent-Message-ID: <Message-Id-1@example.net>
+Content-Type: MULTiPArT/MIxEd; ChaRsET="tIS-620"; bouNdary="MixedBoundaryString"
+Content-Transfer-Encoding: BASE64
+X-Clacks-Overhead: GNU Terry Pratchett
+
+
+--MixedBoundaryString
+Content-Type: mUlTipArt/RELaTEd; bouNDarY="RelatedBoundaryString"
+
+--RelatedBoundaryString
+Content-Type: MulTiPaRT/AlTeRNatIVe; BOundaRY="AlternativeBoundaryString"
+
+--AlternativeBoundaryString
+Content-Type: TeXT/PlaIn; ChaRSEt="tiS-620"
+Content-Transfer-Encoding: BasE64
+
+4LvnucG52MnC7MrYtLvD0ODKw9Sw4MXUyKTYs6To0iChx+jSusPDtNK92afK0bXH7OC0w9GoqdK5
+IKinvejSv9G5vtGyudLH1KrSodLDIM3C6NLF6dKnvMXSrcTl4KLouabo0rrVsdLjpMMg5MHottfN
+4rfJ4qHDuOGq6Ker0bTO1rTO0bS06NIgy9G0zcDRwuDLwdfNuaHVzNLN0aqs0srRwiC7r9S60bXU
+u8PQvsS11KGuodPLubTjqCC+2bSo0uPL6ajq0OYgqOvS5iC56NK/0afgzcLPCgq50sLK0aemwNGz
+sewg4M6nvtS30aHJ7L3R6KcgvNnp4LLo0qvW6KfB1c3SqtW+4LvnuaW5otLCo8e0ILbZobXTw8eo
+u6/UutG11KHSw6jRur/pzafI0sUgsNK5xdGhudLM1KHSpNizy63Up6nRtcOqrtIgrNK5ysHSuNQ
+
+--AlternativeBoundaryString
+Content-Type: TExT/EnRicHeD; CHaRseT="tIs-620"
+Content-Transfer-Encoding: bASe64
+
+PGJvbGQ+4LvnucG52MnC7MrYtLvD0ODKw9Sw4MXUyKTYs6To0jwvYm9sZD4gPGl0YWxpYz6hx+jS
+usPDtNK92afK0bXH7OC0w9GoqdK5PC9pdGFsaWM+IDxmaXhlZD6op73o0r/Rub7RsrnSx9Sq0qHS
+wzwvZml4ZWQ+IDx1bmRlcmxpbmU+zcLo0sXp0qe8xdKtxOXgoui5pujSutWx0uOkwzwvdW5kZXJs
+aW5lPiDkwei2183it8niocO44arop6vRtM7WtM7RtLTo0iDL0bTNwNHC4MvB1825odXM0s3RqqzS
+ytHCILuv1LrRtdS7w9C+xLXUoa6h08u5tOOoIL7ZtKjS48vpqOrQ5iCo69LmILno0r/Rp+DNws8K
+CrnSwsrRp6bA0bOx7CDgzqe+1LfRocnsvdHopyC82engsujSq9bop8HVzdKq1b7gu+e5pbmi0sKj
+x7QgttmhtdPDx6i7r9S60bXUodLDqNG6v+nNp8jSxSCw0rnF0aG50szUodKk2LPLrdSnqdG1w6qu
+0iCs0rnKwdK41A==
+
+--AlternativeBoundaryString
+Content-Type: texT/Html; CHaRsET="tiS-620"
+Content-Transfer-Encoding: bASe64
+
+PGh0bWw+CjxkaXYgZGlyPSJsdHIiPgo8cD7gu+e5wbnYycLsyti0u8PQ4MrD1LDgxdTIpNizpOjS
+IKHH6NK6w8O00r3Zp8rRtcfs4LTD0aip0rkgqKe96NK/0bm+0bK50sfUqtKh0sMgzcLo0sXp0qe8
+xdKtxOXgoui5pujSutWx0uOkwyDkwei2183it8niocO44arop6vRtM7WtM7RtLTo0iDL0bTNwNHC
+4MvB1825odXM0s3RqqzSytHCILuv1LrRtdS7w9C+xLXUoa6h08u5tOOoIL7ZtKjS48vpqOrQ5iCo
+69LmILno0r/Rp+DNws88L3A+Cgo8cD650sLK0aemwNGzsewg4M6nvtS30aHJ7L3R6KcgvNnp4LLo
+0qvW6KfB1c3SqtW+4LvnuaW5otLCo8e0ILbZobXTw8eou6/UutG11KHSw6jRur/pzafI0sUgsNK5
+xdGhudLM1KHSpNizy63Up6nRtcOqrtIgrNK5ysHSuNQ8L3A+CjwvZGl2Pgo8L2h0bWw+
+
+--AlternativeBoundaryString--
+
+--RelatedBoundaryString
+Content-Type: image/jpeg; nAMe="inline-jpg-image-without-disposition.jpg"
+Content-Transfer-Encoding: BaSE64
+
+/9j/2wBDAAMCAgICAgMCAgIDAwMDBAYEBAQEBAgGBgUGCQgKCgkICQkKDA8MCgsOCwkJDRENDg8Q
+EBEQCgwSExIQEw8QEBD/yQALCAABAAEBAREA/8wABgAQEAX/2gAIAQEAAD8A0s8g/9k=
+
+--RelatedBoundaryString
+Content-Type: image/jpeg; NaMe="inline-jpg-image-name.jpg"
+Content-Transfer-Encoding: BaSe64
+Content-Disposition: InlINe; FiLEnAME="inline-jpg-image-filename.jpg"
+Content-ID: <inline-jpg-image.jpg@example.com>
+
+/9j/2wBDAAMCAgICAgMCAgIDAwMDBAYEBAQEBAgGBgUGCQgKCgkICQkKDA8MCgsOCwkJDRENDg8Q
+EBEQCgwSExIQEw8QEBD/yQALCAABAAEBAREA/8wABgAQEAX/2gAIAQEAAD8A0s8g/9k=
+
+--RelatedBoundaryString--
+
+--MixedBoundaryString
+Content-Type: APplICatIoN/Pdf; Name="attached-pdf-name.pdf"
+Content-Transfer-Encoding: BAse64
+Content-Disposition: attachMenT; Filename="attached-pdf-filename.pdf"
+
+JVBERi0xLg10cmFpbGVyPDwvUm9vdDw8L1BhZ2VzPDwvS2lkc1s8PC9NZWRpYUJveFswIDAgMyAz
+XT4+XT4+Pj4+Pg==
+
+--MixedBoundaryString
+Content-Type: aPplicaTIOn/PDF; naME="attached-pdf-without-disposition.pdf"
+Content-Transfer-Encoding: bAse64
+
+JVBERi0xLg10cmFpbGVyPDwvUm9vdDw8L1BhZ2VzPDwvS2lkc1s8PC9NZWRpYUJveFswIDAgMyAz
+XT4+XT4+Pj4+Pg==
+
+--MixedBoundaryString
+Content-Type: aPPLiCaTION/JSOn; NaME="attached-json-name.json"
+Content-Disposition: AtTAchmEnT; FILEname="attached-json-filename.json"
+
+{"foo":"bar"}
+--MixedBoundaryString
+Content-Type: text/pLaiN; NamE="attached-text-plain-name.txt"
+Content-Disposition: AttAcHMenT; fileNAME="attached-text-plain-filename.txt"
+Content-Transfer-Encoding: bASE64
+
+VGV4dC9wbGFpbiBjb250ZW50IGFzIGFuIGF0dGFjaGVkIC50eHQgZmlsZS4=
+
+--MixedBoundaryString
+Content-Type: TexT/HTMl; NAMe="attached-text-html-name.html"
+Content-Disposition: aTTaChMENT; fILEnAme="attached-text-html-filename.html"
+Content-Transfer-Encoding: baSE64
+
+VGV4dC9odG1sIGNvbnRlbnQgYXMgYW4gYXR0YWNoZWQgLmh0bWwgZmlsZS4=
+--MixedBoundaryString--

--- a/tests/test_thai_multipart_mixed_tis-620_over_quoted-printable.txt
+++ b/tests/test_thai_multipart_mixed_tis-620_over_quoted-printable.txt
@@ -1,0 +1,159 @@
+Date: Mon, 01 Apr 2019 07:55:00 +0700 (+07)
+From: =?tiS-620?q?=CD=C5=D4=AB_=BC=D9=E9=CA=E8=A7=A8=B4=CB=C1=D2=C2?= <alis.phusngcdhmay@example.com>,
+ =?tiS-620?q?=CD=C5=D4=AB_=BC=D9=E9=CA=E8=A7=A8=B4=CB=C1=D2=C2?= <alis.phusngcdhmay@example.net>
+Sender: =?tiS-620?q?=CD=C5=D4=AB_=BC=D9=E9=CA=E8=A7=A8=B4=CB=C1=D2=C2?= <alis.phusngcdhmay@example.com>
+Reply-To: =?tiS-620?q?=CD=C5=D4=AB_=BC=D9=E9=CA=E8=A7=A8=B4=CB=C1=D2=C2?= <alis.phusngcdhmay@example.net>
+To: =?TIs-620?q?=BA=EA=CD=BA_=BC=D9=E9=C3=D1=BA?= <bob.phurab@example.com>,
+ =?tis-620?Q?=A4=D2=E2=C3=C5_=BC=D9=E9=C3=D1=BA?= <carol.phurab@example.com>
+Cc: =?tiS-620?Q?=E1=B4=B9_=BC=D9=E9=C3=D1=BA?= <dan.phurab@example.com>,
+ =?tis-620?q?=CD=D5=BF_=BC=D9=E9=C3=D1=BA?= <eve.phurab@example.com>
+Bcc: =?tis-620?q?=E1=BF=C3=A7=A4=EC_=BC=D9=E9=C3=D1=BA?= <frank.phurab@example.com>,
+ =?tIs-620?q?=E0=A1=C3=AB_=BC=D9=E9=C3=D1=BA?= <grace.phurab@example.com>
+Subject: =?UTF-8?B?8J+Tpw==?= Test
+ =?tis-620?Q?=E1=BE=B9=E1=A1=C3=C1=C0=D2=C9=D2=E4=B7=C2?=
+In-Reply-To: <Message-Id-0@example.com>
+References: <Message-Id-0@example.com>
+Message-ID: <Message-Id-1@example.com>
+Comments: Message Header Comment
+Keywords: Keyword 1, Keyword 2
+Resent-Date: Mon, 01 Apr 2019 07:55:00 +0700 (+07)
+Resent-From: =?tiS-620?q?=CD=C5=D4=AB_=BC=D9=E9=CA=E8=A7=A8=B4=CB=C1=D2=C2?= <alis.phusngcdhmay@example.net>,
+ =?tiS-620?q?=CD=C5=D4=AB_=BC=D9=E9=CA=E8=A7=A8=B4=CB=C1=D2=C2?= <alis.phusngcdhmay@example.com>
+Resent-Sender: =?tiS-620?q?=CD=C5=D4=AB_=BC=D9=E9=CA=E8=A7=A8=B4=CB=C1=D2=C2?= <alis.phusngcdhmay@example.net>
+Resent-To: =?TIs-620?q?=BA=EA=CD=BA_=BC=D9=E9=C3=D1=BA?= <bob.phurab@example.net>,
+ =?tis-620?Q?=A4=D2=E2=C3=C5_=BC=D9=E9=C3=D1=BA?= <carol.phurab@example.net>
+Resent-Cc: =?tiS-620?Q?=E1=B4=B9_=BC=D9=E9=C3=D1=BA?= <dan.phurab@example.net>,
+ =?tis-620?q?=CD=D5=BF_=BC=D9=E9=C3=D1=BA?= <eve.phurab@example.net>
+Resent-Bcc: =?tis-620?q?=E1=BF=C3=A7=A4=EC_=BC=D9=E9=C3=D1=BA?= <frank.phurab@example.net>,
+ =?tIs-620?q?=E0=A1=C3=AB_=BC=D9=E9=C3=D1=BA?= <grace.phurab@example.net>
+Resent-Message-ID: <Message-Id-1@example.net>
+Content-Type: muLTIParT/mIxEd; cHaRSET="tis-620"; BounDARy="MixedBoundaryString"
+Content-Transfer-Encoding: quOteD-PRinTAble
+X-Clacks-Overhead: GNU Terry Pratchett
+
+
+--MixedBoundaryString
+Content-Type: MULTIparT/rELAteD; boUnDAry="RelatedBoundaryString"
+
+--RelatedBoundaryString
+Content-Type: MulTIpaRT/AltErNaTiVe; bOunDAry="AlternativeBoundaryString"
+
+--AlternativeBoundaryString
+Content-Type: tExT/PLaIN; chaRSet="TIS-620"
+Content-Transfer-Encoding: quoTEd-pRInTabLE
+
+=E0=BB=E7=B9=C1=B9=D8=C9=C2=EC=CA=D8=B4=BB=C3=D0=E0=CA=C3=D4=B0=E0=C5=D4=C8=
+=A4=D8=B3=A4=E8=D2 =A1=C7=E8=D2=BA=C3=C3=B4=D2=BD=D9=A7=CA=D1=B5=C7=EC=E0=
+=B4=C3=D1=A8=A9=D2=B9 =A8=A7=BD=E8=D2=BF=D1=B9=BE=D1=B2=B9=D2=C7=D4=AA=D2=
+=A1=D2=C3 =CD=C2=E8=D2=C5=E9=D2=A7=BC=C5=D2=AD=C4=E5=E0=A2=E8=B9=A6=E8=D2=
+=BA=D5=B1=D2=E3=A4=C3 =E4=C1=E8=B6=D7=CD=E2=B7=C9=E2=A1=C3=B8=E1=AA=E8=A7=
+=AB=D1=B4=CE=D6=B4=CE=D1=B4=B4=E8=D2 =CB=D1=B4=CD=C0=D1=C2=E0=CB=C1=D7=CD=
+=B9=A1=D5=CC=D2=CD=D1=AA=AC=D2=CA=D1=C2 =BB=AF=D4=BA=D1=B5=D4=BB=C3=D0=BE=
+=C4=B5=D4=A1=AE=A1=D3=CB=B9=B4=E3=A8 =BE=D9=B4=A8=D2=E3=CB=E9=A8=EA=D0=E6 =
+=A8=EB=D2=E6 =B9=E8=D2=BF=D1=A7=E0=CD=C2=CF
+
+=B9=D2=C2=CA=D1=A7=A6=C0=D1=B3=B1=EC =E0=CE=A7=BE=D4=B7=D1=A1=C9=EC=BD=D1=
+=E8=A7 =BC=D9=E9=E0=B2=E8=D2=AB=D6=E8=A7=C1=D5=CD=D2=AA=D5=BE=E0=BB=E7=B9=
+=A5=B9=A2=D2=C2=A3=C7=B4 =B6=D9=A1=B5=D3=C3=C7=A8=BB=AF=D4=BA=D1=B5=D4=A1=
+=D2=C3=A8=D1=BA=BF=E9=CD=A7=C8=D2=C5 =B0=D2=B9=C5=D1=A1=B9=D2=CC=D4=A1=D2=
+=A4=D8=B3=CB=AD=D4=A7=A9=D1=B5=C3=AA=AE=D2 =AC=D2=B9=CA=C1=D2=B8=D4
+
+--AlternativeBoundaryString
+Content-Type: tExt/EnRIchEd; cHaRsEt="tIs-620"
+Content-Transfer-Encoding: QUoTed-priNtAblE
+
+<bold>=E0=BB=E7=B9=C1=B9=D8=C9=C2=EC=CA=D8=B4=BB=C3=D0=E0=CA=C3=D4=B0=E0=C5=
+=D4=C8=A4=D8=B3=A4=E8=D2</bold> <italic>=A1=C7=E8=D2=BA=C3=C3=B4=D2=BD=D9=
+=A7=CA=D1=B5=C7=EC=E0=B4=C3=D1=A8=A9=D2=B9</italic> <fixed>=A8=A7=BD=E8=D2=
+=BF=D1=B9=BE=D1=B2=B9=D2=C7=D4=AA=D2=A1=D2=C3</fixed> <underline>=CD=C2=E8=
+=D2=C5=E9=D2=A7=BC=C5=D2=AD=C4=E5=E0=A2=E8=B9=A6=E8=D2=BA=D5=B1=D2=E3=A4=C3=
+</underline> =E4=C1=E8=B6=D7=CD=E2=B7=C9=E2=A1=C3=B8=E1=AA=E8=A7=AB=D1=B4=
+=CE=D6=B4=CE=D1=B4=B4=E8=D2 =CB=D1=B4=CD=C0=D1=C2=E0=CB=C1=D7=CD=B9=A1=D5=
+=CC=D2=CD=D1=AA=AC=D2=CA=D1=C2 =BB=AF=D4=BA=D1=B5=D4=BB=C3=D0=BE=C4=B5=D4=
+=A1=AE=A1=D3=CB=B9=B4=E3=A8 =BE=D9=B4=A8=D2=E3=CB=E9=A8=EA=D0=E6 =A8=EB=D2=
+=E6 =B9=E8=D2=BF=D1=A7=E0=CD=C2=CF
+
+=B9=D2=C2=CA=D1=A7=A6=C0=D1=B3=B1=EC =E0=CE=A7=BE=D4=B7=D1=A1=C9=EC=BD=D1=
+=E8=A7 =BC=D9=E9=E0=B2=E8=D2=AB=D6=E8=A7=C1=D5=CD=D2=AA=D5=BE=E0=BB=E7=B9=
+=A5=B9=A2=D2=C2=A3=C7=B4 =B6=D9=A1=B5=D3=C3=C7=A8=BB=AF=D4=BA=D1=B5=D4=A1=
+=D2=C3=A8=D1=BA=BF=E9=CD=A7=C8=D2=C5 =B0=D2=B9=C5=D1=A1=B9=D2=CC=D4=A1=D2=
+=A4=D8=B3=CB=AD=D4=A7=A9=D1=B5=C3=AA=AE=D2 =AC=D2=B9=CA=C1=D2=B8=D4
+
+--AlternativeBoundaryString
+Content-Type: TExt/hTml; ChaRSet="tIs-620"
+Content-Transfer-Encoding: QuoTeD-PRINTablE
+
+<html>
+<div dir=3D"ltr">
+<p>=E0=BB=E7=B9=C1=B9=D8=C9=C2=EC=CA=D8=B4=BB=C3=D0=E0=CA=C3=D4=B0=E0=C5=D4=
+=C8=A4=D8=B3=A4=E8=D2 =A1=C7=E8=D2=BA=C3=C3=B4=D2=BD=D9=A7=CA=D1=B5=C7=EC=
+=E0=B4=C3=D1=A8=A9=D2=B9 =A8=A7=BD=E8=D2=BF=D1=B9=BE=D1=B2=B9=D2=C7=D4=AA=
+=D2=A1=D2=C3 =CD=C2=E8=D2=C5=E9=D2=A7=BC=C5=D2=AD=C4=E5=E0=A2=E8=B9=A6=E8=
+=D2=BA=D5=B1=D2=E3=A4=C3 =E4=C1=E8=B6=D7=CD=E2=B7=C9=E2=A1=C3=B8=E1=AA=E8=
+=A7=AB=D1=B4=CE=D6=B4=CE=D1=B4=B4=E8=D2 =CB=D1=B4=CD=C0=D1=C2=E0=CB=C1=D7=
+=CD=B9=A1=D5=CC=D2=CD=D1=AA=AC=D2=CA=D1=C2 =BB=AF=D4=BA=D1=B5=D4=BB=C3=D0=
+=BE=C4=B5=D4=A1=AE=A1=D3=CB=B9=B4=E3=A8 =BE=D9=B4=A8=D2=E3=CB=E9=A8=EA=D0=
+=E6 =A8=EB=D2=E6 =B9=E8=D2=BF=D1=A7=E0=CD=C2=CF</p>
+
+<p>=B9=D2=C2=CA=D1=A7=A6=C0=D1=B3=B1=EC =E0=CE=A7=BE=D4=B7=D1=A1=C9=EC=BD=
+=D1=E8=A7 =BC=D9=E9=E0=B2=E8=D2=AB=D6=E8=A7=C1=D5=CD=D2=AA=D5=BE=E0=BB=E7=
+=B9=A5=B9=A2=D2=C2=A3=C7=B4 =B6=D9=A1=B5=D3=C3=C7=A8=BB=AF=D4=BA=D1=B5=D4=
+=A1=D2=C3=A8=D1=BA=BF=E9=CD=A7=C8=D2=C5 =B0=D2=B9=C5=D1=A1=B9=D2=CC=D4=A1=
+=D2=A4=D8=B3=CB=AD=D4=A7=A9=D1=B5=C3=AA=AE=D2 =AC=D2=B9=CA=C1=D2=B8=D4</p>
+</div>
+</html>
+
+--AlternativeBoundaryString--
+
+--RelatedBoundaryString
+Content-Type: image/jpeg; NamE="inline-jpg-image-without-disposition.jpg"
+Content-Transfer-Encoding: basE64
+
+/9j/2wBDAAMCAgICAgMCAgIDAwMDBAYEBAQEBAgGBgUGCQgKCgkICQkKDA8MCgsOCwkJDRENDg8Q
+EBEQCgwSExIQEw8QEBD/yQALCAABAAEBAREA/8wABgAQEAX/2gAIAQEAAD8A0s8g/9k=
+
+--RelatedBoundaryString
+Content-Type: image/jpeg; NAmE="inline-jpg-image-name.jpg"
+Content-Transfer-Encoding: basE64
+Content-Disposition: inLiNe; fIlenaME="inline-jpg-image-filename.jpg"
+Content-ID: <inline-jpg-image.jpg@example.com>
+
+/9j/2wBDAAMCAgICAgMCAgIDAwMDBAYEBAQEBAgGBgUGCQgKCgkICQkKDA8MCgsOCwkJDRENDg8Q
+EBEQCgwSExIQEw8QEBD/yQALCAABAAEBAREA/8wABgAQEAX/2gAIAQEAAD8A0s8g/9k=
+
+--RelatedBoundaryString--
+
+--MixedBoundaryString
+Content-Type: aPPlIcAtIoN/pDf; NAme="attached-pdf-name.pdf"
+Content-Transfer-Encoding: basE64
+Content-Disposition: atTACHmEnt; FilENAMe="attached-pdf-filename.pdf"
+
+JVBERi0xLg10cmFpbGVyPDwvUm9vdDw8L1BhZ2VzPDwvS2lkc1s8PC9NZWRpYUJveFswIDAgMyAz
+XT4+XT4+Pj4+Pg==
+
+--MixedBoundaryString
+Content-Type: AppLicatIOn/PDF; nAME="attached-pdf-without-disposition.pdf"
+Content-Transfer-Encoding: baSe64
+
+JVBERi0xLg10cmFpbGVyPDwvUm9vdDw8L1BhZ2VzPDwvS2lkc1s8PC9NZWRpYUJveFswIDAgMyAz
+XT4+XT4+Pj4+Pg==
+
+--MixedBoundaryString
+Content-Type: APpLiCatiOn/JSON; name="attached-json-name.json"
+Content-Disposition: attAChmeNT; filENamE="attached-json-filename.json"
+
+{"foo":"bar"}
+--MixedBoundaryString
+Content-Type: tEXt/PlaiN; NaMe="attached-text-plain-name.txt"
+Content-Disposition: aTtaCHment; fILENAME="attached-text-plain-filename.txt"
+Content-Transfer-Encoding: BASe64
+
+VGV4dC9wbGFpbiBjb250ZW50IGFzIGFuIGF0dGFjaGVkIC50eHQgZmlsZS4=
+
+--MixedBoundaryString
+Content-Type: tExT/html; NAme="attached-text-html-name.html"
+Content-Disposition: attacHMent; fILenAMe="attached-text-html-filename.html"
+Content-Transfer-Encoding: BAse64
+
+VGV4dC9odG1sIGNvbnRlbnQgYXMgYW4gYXR0YWNoZWQgLmh0bWwgZmlsZS4=
+--MixedBoundaryString--

--- a/tests/test_thai_multipart_mixed_windows-874_over_base64.txt
+++ b/tests/test_thai_multipart_mixed_windows-874_over_base64.txt
@@ -1,0 +1,130 @@
+Date: Mon, 01 Apr 2019 07:55:00 +0700 (+07)
+From: =?wiNdOWs-874?B?zcXUqyC82enK6KeotMvB0sI=?= <alis.phusngcdhmay@example.com>,
+ =?wiNdOWs-874?B?zcXUqyC82enK6KeotMvB0sI=?= <alis.phusngcdhmay@example.net>
+Sender: =?wiNdOWs-874?B?zcXUqyC82enK6KeotMvB0sI=?= <alis.phusngcdhmay@example.com>
+Reply-To: =?wiNdOWs-874?B?zcXUqyC82enK6KeotMvB0sI=?= <alis.phusngcdhmay@example.net>
+To: =?WindoWS-874?B?uurNuiC82enD0bo=?= <bob.phurab@example.com>,
+ =?WINDoWS-874?B?pNLiw8UgvNnpw9G6?= <carol.phurab@example.com>
+Cc: =?WinDOWs-874?b?4bS5ILzZ6cPRug==?= <dan.phurab@example.com>,
+ =?WInDOws-874?b?zdW/ILzZ6cPRug==?= <eve.phurab@example.com>
+Bcc: =?WiNDOWS-874?B?4b/Dp6TsILzZ6cPRug==?= <frank.phurab@example.com>,
+ =?WIndowS-874?B?4KHDqyC82enD0bo=?= <grace.phurab@example.com>
+Subject: =?UTF-8?B?8J+Tpw==?= Test
+ =?WInDOWS-874?B?4b654aHDwcDSydLkt8I=?=
+In-Reply-To: <Message-Id-0@example.com>
+References: <Message-Id-0@example.com>
+Message-ID: <Message-Id-1@example.com>
+Comments: Message Header Comment
+Keywords: Keyword 1, Keyword 2
+Resent-Date: Mon, 01 Apr 2019 07:55:00 +0700 (+07)
+Resent-From: =?wiNdOWs-874?B?zcXUqyC82enK6KeotMvB0sI=?= <alis.phusngcdhmay@example.net>,
+ =?wiNdOWs-874?B?zcXUqyC82enK6KeotMvB0sI=?= <alis.phusngcdhmay@example.com>
+Resent-Sender: =?wiNdOWs-874?B?zcXUqyC82enK6KeotMvB0sI=?= <alis.phusngcdhmay@example.net>
+Resent-To: =?WindoWS-874?B?uurNuiC82enD0bo=?= <bob.phurab@example.net>,
+ =?WINDoWS-874?B?pNLiw8UgvNnpw9G6?= <carol.phurab@example.net>
+Resent-Cc: =?WinDOWs-874?b?4bS5ILzZ6cPRug==?= <dan.phurab@example.net>,
+ =?WInDOws-874?b?zdW/ILzZ6cPRug==?= <eve.phurab@example.net>
+Resent-Bcc: =?WiNDOWS-874?B?4b/Dp6TsILzZ6cPRug==?= <frank.phurab@example.net>,
+ =?WIndowS-874?B?4KHDqyC82enD0bo=?= <grace.phurab@example.net>
+Resent-Message-ID: <Message-Id-1@example.net>
+Content-Type: multiPaRT/MiXed; CHArSet="wiNdoWs-874"; BoundarY="MixedBoundaryString"
+Content-Transfer-Encoding: BASE64
+X-Clacks-Overhead: GNU Terry Pratchett
+
+
+--MixedBoundaryString
+Content-Type: MUlTIPart/RelAteD; BOUNDary="RelatedBoundaryString"
+
+--RelatedBoundaryString
+Content-Type: mUltIparT/ALTErNatIvE; BounDaRy="AlternativeBoundaryString"
+
+--AlternativeBoundaryString
+Content-Type: tEXT/pLaIN; chARSEt="WINDOwS-874"
+Content-Transfer-Encoding: bAse64
+
+4LvnucG52MnC7MrYtLvD0ODKw9Sw4MXUyKTYs6To0iChx+jSusPDtNK92afK0bXH7OC0w9GoqdK5
+IKinvejSv9G5vtGyudLH1KrSodLDIM3C6NLF6dKnvMXSrcTl4KLouabo0rrVsdLjpMMg5MHottfN
+4rfJ4qHDuOGq6Ker0bTO1rTO0bS06NIgy9G0zcDRwuDLwdfNuaHVzNLN0aqs0srRwiC7r9S60bXU
+u8PQvsS11KGuodPLubTjqCC+2bSo0uPL6ajq0OYgqOvS5iC56NK/0afgzcLPCgq50sLK0aemwNGz
+sewg4M6nvtS30aHJ7L3R6KcgvNnp4LLo0qvW6KfB1c3SqtW+4LvnuaW5otLCo8e0ILbZobXTw8eo
+u6/UutG11KHSw6jRur/pzafI0sUgsNK5xdGhudLM1KHSpNizy63Up6nRtcOqrtIgrNK5ysHSuNQ
+
+--AlternativeBoundaryString
+Content-Type: tEXT/enRiChED; CHarsET="WINdoWS-874"
+Content-Transfer-Encoding: bAse64
+
+PGJvbGQ+4LvnucG52MnC7MrYtLvD0ODKw9Sw4MXUyKTYs6To0jwvYm9sZD4gPGl0YWxpYz6hx+jS
+usPDtNK92afK0bXH7OC0w9GoqdK5PC9pdGFsaWM+IDxmaXhlZD6op73o0r/Rub7RsrnSx9Sq0qHS
+wzwvZml4ZWQ+IDx1bmRlcmxpbmU+zcLo0sXp0qe8xdKtxOXgoui5pujSutWx0uOkwzwvdW5kZXJs
+aW5lPiDkwei2183it8niocO44arop6vRtM7WtM7RtLTo0iDL0bTNwNHC4MvB1825odXM0s3RqqzS
+ytHCILuv1LrRtdS7w9C+xLXUoa6h08u5tOOoIL7ZtKjS48vpqOrQ5iCo69LmILno0r/Rp+DNws8K
+CrnSwsrRp6bA0bOx7CDgzqe+1LfRocnsvdHopyC82engsujSq9bop8HVzdKq1b7gu+e5pbmi0sKj
+x7QgttmhtdPDx6i7r9S60bXUodLDqNG6v+nNp8jSxSCw0rnF0aG50szUodKk2LPLrdSnqdG1w6qu
+0iCs0rnKwdK41A==
+
+--AlternativeBoundaryString
+Content-Type: TexT/HTMl; cHaRsET="wINdows-874"
+Content-Transfer-Encoding: basE64
+
+PGh0bWw+CjxkaXYgZGlyPSJsdHIiPgo8cD7gu+e5wbnYycLsyti0u8PQ4MrD1LDgxdTIpNizpOjS
+IKHH6NK6w8O00r3Zp8rRtcfs4LTD0aip0rkgqKe96NK/0bm+0bK50sfUqtKh0sMgzcLo0sXp0qe8
+xdKtxOXgoui5pujSutWx0uOkwyDkwei2183it8niocO44arop6vRtM7WtM7RtLTo0iDL0bTNwNHC
+4MvB1825odXM0s3RqqzSytHCILuv1LrRtdS7w9C+xLXUoa6h08u5tOOoIL7ZtKjS48vpqOrQ5iCo
+69LmILno0r/Rp+DNws88L3A+Cgo8cD650sLK0aemwNGzsewg4M6nvtS30aHJ7L3R6KcgvNnp4LLo
+0qvW6KfB1c3SqtW+4LvnuaW5otLCo8e0ILbZobXTw8eou6/UutG11KHSw6jRur/pzafI0sUgsNK5
+xdGhudLM1KHSpNizy63Up6nRtcOqrtIgrNK5ysHSuNQ8L3A+CjwvZGl2Pgo8L2h0bWw+
+
+--AlternativeBoundaryString--
+
+--RelatedBoundaryString
+Content-Type: image/jpeg; nAme="inline-jpg-image-without-disposition.jpg"
+Content-Transfer-Encoding: BASe64
+
+/9j/2wBDAAMCAgICAgMCAgIDAwMDBAYEBAQEBAgGBgUGCQgKCgkICQkKDA8MCgsOCwkJDRENDg8Q
+EBEQCgwSExIQEw8QEBD/yQALCAABAAEBAREA/8wABgAQEAX/2gAIAQEAAD8A0s8g/9k=
+
+--RelatedBoundaryString
+Content-Type: image/jpeg; nAme="inline-jpg-image-name.jpg"
+Content-Transfer-Encoding: Base64
+Content-Disposition: INLiNe; FIleNamE="inline-jpg-image-filename.jpg"
+Content-ID: <inline-jpg-image.jpg@example.com>
+
+/9j/2wBDAAMCAgICAgMCAgIDAwMDBAYEBAQEBAgGBgUGCQgKCgkICQkKDA8MCgsOCwkJDRENDg8Q
+EBEQCgwSExIQEw8QEBD/yQALCAABAAEBAREA/8wABgAQEAX/2gAIAQEAAD8A0s8g/9k=
+
+--RelatedBoundaryString--
+
+--MixedBoundaryString
+Content-Type: apPliCATiON/Pdf; name="attached-pdf-name.pdf"
+Content-Transfer-Encoding: BAsE64
+Content-Disposition: AttAcHmEnT; FilEnAmE="attached-pdf-filename.pdf"
+
+JVBERi0xLg10cmFpbGVyPDwvUm9vdDw8L1BhZ2VzPDwvS2lkc1s8PC9NZWRpYUJveFswIDAgMyAz
+XT4+XT4+Pj4+Pg==
+
+--MixedBoundaryString
+Content-Type: aPPLIcAtion/PDF; NAme="attached-pdf-without-disposition.pdf"
+Content-Transfer-Encoding: base64
+
+JVBERi0xLg10cmFpbGVyPDwvUm9vdDw8L1BhZ2VzPDwvS2lkc1s8PC9NZWRpYUJveFswIDAgMyAz
+XT4+XT4+Pj4+Pg==
+
+--MixedBoundaryString
+Content-Type: ApPLicatiOn/jSon; nAmE="attached-json-name.json"
+Content-Disposition: aTtAcHMenT; fILenaME="attached-json-filename.json"
+
+{"foo":"bar"}
+--MixedBoundaryString
+Content-Type: TExT/PlAiN; naMe="attached-text-plain-name.txt"
+Content-Disposition: attachmeNt; FilEnAmE="attached-text-plain-filename.txt"
+Content-Transfer-Encoding: Base64
+
+VGV4dC9wbGFpbiBjb250ZW50IGFzIGFuIGF0dGFjaGVkIC50eHQgZmlsZS4=
+
+--MixedBoundaryString
+Content-Type: texT/HTml; NaMe="attached-text-html-name.html"
+Content-Disposition: AtTACHMeNt; fILEName="attached-text-html-filename.html"
+Content-Transfer-Encoding: baSE64
+
+VGV4dC9odG1sIGNvbnRlbnQgYXMgYW4gYXR0YWNoZWQgLmh0bWwgZmlsZS4=
+--MixedBoundaryString--

--- a/tests/test_thai_multipart_mixed_windows-874_over_quoted-printable.txt
+++ b/tests/test_thai_multipart_mixed_windows-874_over_quoted-printable.txt
@@ -1,0 +1,159 @@
+Date: Mon, 01 Apr 2019 07:55:00 +0700 (+07)
+From: =?windows-874?Q?=CD=C5=D4=AB_=BC=D9=E9=CA=E8=A7=A8=B4=CB=C1=D2=C2?= <alis.phusngcdhmay@example.com>,
+ =?windows-874?Q?=CD=C5=D4=AB_=BC=D9=E9=CA=E8=A7=A8=B4=CB=C1=D2=C2?= <alis.phusngcdhmay@example.net>
+Sender: =?windows-874?Q?=CD=C5=D4=AB_=BC=D9=E9=CA=E8=A7=A8=B4=CB=C1=D2=C2?= <alis.phusngcdhmay@example.com>
+Reply-To: =?windows-874?Q?=CD=C5=D4=AB_=BC=D9=E9=CA=E8=A7=A8=B4=CB=C1=D2=C2?= <alis.phusngcdhmay@example.net>
+To: =?WiNDOWs-874?Q?=BA=EA=CD=BA_=BC=D9=E9=C3=D1=BA?= <bob.phurab@example.com>,
+ =?wIndOWs-874?Q?=A4=D2=E2=C3=C5_=BC=D9=E9=C3=D1=BA?= <carol.phurab@example.com>
+Cc: =?wINdOws-874?Q?=E1=B4=B9_=BC=D9=E9=C3=D1=BA?= <dan.phurab@example.com>,
+ =?WIndows-874?Q?=CD=D5=BF_=BC=D9=E9=C3=D1=BA?= <eve.phurab@example.com>
+Bcc: =?wINDOWS-874?Q?=E1=BF=C3=A7=A4=EC_=BC=D9=E9=C3=D1=BA?= <frank.phurab@example.com>,
+ =?WinDOWS-874?Q?=E0=A1=C3=AB_=BC=D9=E9=C3=D1=BA?= <grace.phurab@example.com>
+Subject: =?UTF-8?B?8J+Tpw==?= Test
+ =?wINdOwS-874?q?=E1=BE=B9=E1=A1=C3=C1=C0=D2=C9=D2=E4=B7=C2?=
+In-Reply-To: <Message-Id-0@example.com>
+References: <Message-Id-0@example.com>
+Message-ID: <Message-Id-1@example.com>
+Comments: Message Header Comment
+Keywords: Keyword 1, Keyword 2
+Resent-Date: Mon, 01 Apr 2019 07:55:00 +0700 (+07)
+Resent-From: =?windows-874?Q?=CD=C5=D4=AB_=BC=D9=E9=CA=E8=A7=A8=B4=CB=C1=D2=C2?= <alis.phusngcdhmay@example.net>,
+ =?windows-874?Q?=CD=C5=D4=AB_=BC=D9=E9=CA=E8=A7=A8=B4=CB=C1=D2=C2?= <alis.phusngcdhmay@example.com>
+Resent-Sender: =?windows-874?Q?=CD=C5=D4=AB_=BC=D9=E9=CA=E8=A7=A8=B4=CB=C1=D2=C2?= <alis.phusngcdhmay@example.net>
+Resent-To: =?WiNDOWs-874?Q?=BA=EA=CD=BA_=BC=D9=E9=C3=D1=BA?= <bob.phurab@example.net>,
+ =?wIndOWs-874?Q?=A4=D2=E2=C3=C5_=BC=D9=E9=C3=D1=BA?= <carol.phurab@example.net>
+Resent-Cc: =?wINdOws-874?Q?=E1=B4=B9_=BC=D9=E9=C3=D1=BA?= <dan.phurab@example.net>,
+ =?WIndows-874?Q?=CD=D5=BF_=BC=D9=E9=C3=D1=BA?= <eve.phurab@example.net>
+Resent-Bcc: =?wINDOWS-874?Q?=E1=BF=C3=A7=A4=EC_=BC=D9=E9=C3=D1=BA?= <frank.phurab@example.net>,
+ =?WinDOWS-874?Q?=E0=A1=C3=AB_=BC=D9=E9=C3=D1=BA?= <grace.phurab@example.net>
+Resent-Message-ID: <Message-Id-1@example.net>
+Content-Type: MULtipART/mIxeD; cHARsEt="WiNdowS-874"; BOUNdaRY="MixedBoundaryString"
+Content-Transfer-Encoding: quOTed-PrintaBLE
+X-Clacks-Overhead: GNU Terry Pratchett
+
+
+--MixedBoundaryString
+Content-Type: mULtiParT/rELATed; BOundARY="RelatedBoundaryString"
+
+--RelatedBoundaryString
+Content-Type: MUltiPArt/aLteRNAtIVE; BOUNDARy="AlternativeBoundaryString"
+
+--AlternativeBoundaryString
+Content-Type: TeXT/plAin; ChaRSEt="wINdows-874"
+Content-Transfer-Encoding: QUOTEd-prINTAbLE
+
+=E0=BB=E7=B9=C1=B9=D8=C9=C2=EC=CA=D8=B4=BB=C3=D0=E0=CA=C3=D4=B0=E0=C5=D4=C8=
+=A4=D8=B3=A4=E8=D2 =A1=C7=E8=D2=BA=C3=C3=B4=D2=BD=D9=A7=CA=D1=B5=C7=EC=E0=
+=B4=C3=D1=A8=A9=D2=B9 =A8=A7=BD=E8=D2=BF=D1=B9=BE=D1=B2=B9=D2=C7=D4=AA=D2=
+=A1=D2=C3 =CD=C2=E8=D2=C5=E9=D2=A7=BC=C5=D2=AD=C4=E5=E0=A2=E8=B9=A6=E8=D2=
+=BA=D5=B1=D2=E3=A4=C3 =E4=C1=E8=B6=D7=CD=E2=B7=C9=E2=A1=C3=B8=E1=AA=E8=A7=
+=AB=D1=B4=CE=D6=B4=CE=D1=B4=B4=E8=D2 =CB=D1=B4=CD=C0=D1=C2=E0=CB=C1=D7=CD=
+=B9=A1=D5=CC=D2=CD=D1=AA=AC=D2=CA=D1=C2 =BB=AF=D4=BA=D1=B5=D4=BB=C3=D0=BE=
+=C4=B5=D4=A1=AE=A1=D3=CB=B9=B4=E3=A8 =BE=D9=B4=A8=D2=E3=CB=E9=A8=EA=D0=E6 =
+=A8=EB=D2=E6 =B9=E8=D2=BF=D1=A7=E0=CD=C2=CF
+
+=B9=D2=C2=CA=D1=A7=A6=C0=D1=B3=B1=EC =E0=CE=A7=BE=D4=B7=D1=A1=C9=EC=BD=D1=
+=E8=A7 =BC=D9=E9=E0=B2=E8=D2=AB=D6=E8=A7=C1=D5=CD=D2=AA=D5=BE=E0=BB=E7=B9=
+=A5=B9=A2=D2=C2=A3=C7=B4 =B6=D9=A1=B5=D3=C3=C7=A8=BB=AF=D4=BA=D1=B5=D4=A1=
+=D2=C3=A8=D1=BA=BF=E9=CD=A7=C8=D2=C5 =B0=D2=B9=C5=D1=A1=B9=D2=CC=D4=A1=D2=
+=A4=D8=B3=CB=AD=D4=A7=A9=D1=B5=C3=AA=AE=D2 =AC=D2=B9=CA=C1=D2=B8=D4
+
+--AlternativeBoundaryString
+Content-Type: TeXT/enrICHed; cHaRsET="WIndOWs-874"
+Content-Transfer-Encoding: QUOTed-prInTAblE
+
+<bold>=E0=BB=E7=B9=C1=B9=D8=C9=C2=EC=CA=D8=B4=BB=C3=D0=E0=CA=C3=D4=B0=E0=C5=
+=D4=C8=A4=D8=B3=A4=E8=D2</bold> <italic>=A1=C7=E8=D2=BA=C3=C3=B4=D2=BD=D9=
+=A7=CA=D1=B5=C7=EC=E0=B4=C3=D1=A8=A9=D2=B9</italic> <fixed>=A8=A7=BD=E8=D2=
+=BF=D1=B9=BE=D1=B2=B9=D2=C7=D4=AA=D2=A1=D2=C3</fixed> <underline>=CD=C2=E8=
+=D2=C5=E9=D2=A7=BC=C5=D2=AD=C4=E5=E0=A2=E8=B9=A6=E8=D2=BA=D5=B1=D2=E3=A4=C3=
+</underline> =E4=C1=E8=B6=D7=CD=E2=B7=C9=E2=A1=C3=B8=E1=AA=E8=A7=AB=D1=B4=
+=CE=D6=B4=CE=D1=B4=B4=E8=D2 =CB=D1=B4=CD=C0=D1=C2=E0=CB=C1=D7=CD=B9=A1=D5=
+=CC=D2=CD=D1=AA=AC=D2=CA=D1=C2 =BB=AF=D4=BA=D1=B5=D4=BB=C3=D0=BE=C4=B5=D4=
+=A1=AE=A1=D3=CB=B9=B4=E3=A8 =BE=D9=B4=A8=D2=E3=CB=E9=A8=EA=D0=E6 =A8=EB=D2=
+=E6 =B9=E8=D2=BF=D1=A7=E0=CD=C2=CF
+
+=B9=D2=C2=CA=D1=A7=A6=C0=D1=B3=B1=EC =E0=CE=A7=BE=D4=B7=D1=A1=C9=EC=BD=D1=
+=E8=A7 =BC=D9=E9=E0=B2=E8=D2=AB=D6=E8=A7=C1=D5=CD=D2=AA=D5=BE=E0=BB=E7=B9=
+=A5=B9=A2=D2=C2=A3=C7=B4 =B6=D9=A1=B5=D3=C3=C7=A8=BB=AF=D4=BA=D1=B5=D4=A1=
+=D2=C3=A8=D1=BA=BF=E9=CD=A7=C8=D2=C5 =B0=D2=B9=C5=D1=A1=B9=D2=CC=D4=A1=D2=
+=A4=D8=B3=CB=AD=D4=A7=A9=D1=B5=C3=AA=AE=D2 =AC=D2=B9=CA=C1=D2=B8=D4
+
+--AlternativeBoundaryString
+Content-Type: tEXT/HtMl; cHaRset="wInDOws-874"
+Content-Transfer-Encoding: qUOTeD-PRIntABle
+
+<html>
+<div dir=3D"ltr">
+<p>=E0=BB=E7=B9=C1=B9=D8=C9=C2=EC=CA=D8=B4=BB=C3=D0=E0=CA=C3=D4=B0=E0=C5=D4=
+=C8=A4=D8=B3=A4=E8=D2 =A1=C7=E8=D2=BA=C3=C3=B4=D2=BD=D9=A7=CA=D1=B5=C7=EC=
+=E0=B4=C3=D1=A8=A9=D2=B9 =A8=A7=BD=E8=D2=BF=D1=B9=BE=D1=B2=B9=D2=C7=D4=AA=
+=D2=A1=D2=C3 =CD=C2=E8=D2=C5=E9=D2=A7=BC=C5=D2=AD=C4=E5=E0=A2=E8=B9=A6=E8=
+=D2=BA=D5=B1=D2=E3=A4=C3 =E4=C1=E8=B6=D7=CD=E2=B7=C9=E2=A1=C3=B8=E1=AA=E8=
+=A7=AB=D1=B4=CE=D6=B4=CE=D1=B4=B4=E8=D2 =CB=D1=B4=CD=C0=D1=C2=E0=CB=C1=D7=
+=CD=B9=A1=D5=CC=D2=CD=D1=AA=AC=D2=CA=D1=C2 =BB=AF=D4=BA=D1=B5=D4=BB=C3=D0=
+=BE=C4=B5=D4=A1=AE=A1=D3=CB=B9=B4=E3=A8 =BE=D9=B4=A8=D2=E3=CB=E9=A8=EA=D0=
+=E6 =A8=EB=D2=E6 =B9=E8=D2=BF=D1=A7=E0=CD=C2=CF</p>
+
+<p>=B9=D2=C2=CA=D1=A7=A6=C0=D1=B3=B1=EC =E0=CE=A7=BE=D4=B7=D1=A1=C9=EC=BD=
+=D1=E8=A7 =BC=D9=E9=E0=B2=E8=D2=AB=D6=E8=A7=C1=D5=CD=D2=AA=D5=BE=E0=BB=E7=
+=B9=A5=B9=A2=D2=C2=A3=C7=B4 =B6=D9=A1=B5=D3=C3=C7=A8=BB=AF=D4=BA=D1=B5=D4=
+=A1=D2=C3=A8=D1=BA=BF=E9=CD=A7=C8=D2=C5 =B0=D2=B9=C5=D1=A1=B9=D2=CC=D4=A1=
+=D2=A4=D8=B3=CB=AD=D4=A7=A9=D1=B5=C3=AA=AE=D2 =AC=D2=B9=CA=C1=D2=B8=D4</p>
+</div>
+</html>
+
+--AlternativeBoundaryString--
+
+--RelatedBoundaryString
+Content-Type: image/jpeg; NaMe="inline-jpg-image-without-disposition.jpg"
+Content-Transfer-Encoding: BaSE64
+
+/9j/2wBDAAMCAgICAgMCAgIDAwMDBAYEBAQEBAgGBgUGCQgKCgkICQkKDA8MCgsOCwkJDRENDg8Q
+EBEQCgwSExIQEw8QEBD/yQALCAABAAEBAREA/8wABgAQEAX/2gAIAQEAAD8A0s8g/9k=
+
+--RelatedBoundaryString
+Content-Type: image/jpeg; nAme="inline-jpg-image-name.jpg"
+Content-Transfer-Encoding: BasE64
+Content-Disposition: INline; FilENAme="inline-jpg-image-filename.jpg"
+Content-ID: <inline-jpg-image.jpg@example.com>
+
+/9j/2wBDAAMCAgICAgMCAgIDAwMDBAYEBAQEBAgGBgUGCQgKCgkICQkKDA8MCgsOCwkJDRENDg8Q
+EBEQCgwSExIQEw8QEBD/yQALCAABAAEBAREA/8wABgAQEAX/2gAIAQEAAD8A0s8g/9k=
+
+--RelatedBoundaryString--
+
+--MixedBoundaryString
+Content-Type: AppLICaTion/pDF; naME="attached-pdf-name.pdf"
+Content-Transfer-Encoding: BASE64
+Content-Disposition: AttAChmEnt; FiLenAmE="attached-pdf-filename.pdf"
+
+JVBERi0xLg10cmFpbGVyPDwvUm9vdDw8L1BhZ2VzPDwvS2lkc1s8PC9NZWRpYUJveFswIDAgMyAz
+XT4+XT4+Pj4+Pg==
+
+--MixedBoundaryString
+Content-Type: applIcAtion/PDF; NamE="attached-pdf-without-disposition.pdf"
+Content-Transfer-Encoding: baSe64
+
+JVBERi0xLg10cmFpbGVyPDwvUm9vdDw8L1BhZ2VzPDwvS2lkc1s8PC9NZWRpYUJveFswIDAgMyAz
+XT4+XT4+Pj4+Pg==
+
+--MixedBoundaryString
+Content-Type: APplICATION/JsON; NaME="attached-json-name.json"
+Content-Disposition: aTtAchmEnT; FiLeNAme="attached-json-filename.json"
+
+{"foo":"bar"}
+--MixedBoundaryString
+Content-Type: tEXT/PlAIN; NaME="attached-text-plain-name.txt"
+Content-Disposition: attAchment; fILENAmE="attached-text-plain-filename.txt"
+Content-Transfer-Encoding: bAse64
+
+VGV4dC9wbGFpbiBjb250ZW50IGFzIGFuIGF0dGFjaGVkIC50eHQgZmlsZS4=
+
+--MixedBoundaryString
+Content-Type: TexT/HTML; NaMe="attached-text-html-name.html"
+Content-Disposition: atTachMeNT; fileNaME="attached-text-html-filename.html"
+Content-Transfer-Encoding: Base64
+
+VGV4dC9odG1sIGNvbnRlbnQgYXMgYW4gYXR0YWNoZWQgLmh0bWwgZmlsZS4=
+--MixedBoundaryString--

--- a/tests/test_thai_multipart_related_iso-8859-11_over_base64.txt
+++ b/tests/test_thai_multipart_related_iso-8859-11_over_base64.txt
@@ -1,0 +1,85 @@
+Date: Mon, 01 Apr 2019 07:55:00 +0700 (+07)
+From: =?iSo-8859-11?b?zcXUqyC82enK6KeotMvB0sI=?= <alis.phusngcdhmay@example.com>,
+ =?iSo-8859-11?b?zcXUqyC82enK6KeotMvB0sI=?= <alis.phusngcdhmay@example.net>
+Sender: =?iSo-8859-11?b?zcXUqyC82enK6KeotMvB0sI=?= <alis.phusngcdhmay@example.com>
+Reply-To: =?iSo-8859-11?b?zcXUqyC82enK6KeotMvB0sI=?= <alis.phusngcdhmay@example.net>
+To: =?isO-8859-11?b?uurNuiC82enD0bo=?= <bob.phurab@example.com>,
+ =?iso-8859-11?b?pNLiw8UgvNnpw9G6?= <carol.phurab@example.com>
+Cc: =?ISo-8859-11?b?4bS5ILzZ6cPRug==?= <dan.phurab@example.com>,
+ =?ISo-8859-11?B?zdW/ILzZ6cPRug==?= <eve.phurab@example.com>
+Bcc: =?iso-8859-11?B?4b/Dp6TsILzZ6cPRug==?= <frank.phurab@example.com>,
+ =?IsO-8859-11?B?4KHDqyC82enD0bo=?= <grace.phurab@example.com>
+Subject: =?UTF-8?B?8J+Tpw==?= Test
+ =?iSo-8859-11?B?4b654aHDwcDSydLkt8I=?=
+In-Reply-To: <Message-Id-0@example.com>
+References: <Message-Id-0@example.com>
+Message-ID: <Message-Id-1@example.com>
+Comments: Message Header Comment
+Keywords: Keyword 1, Keyword 2
+Resent-Date: Mon, 01 Apr 2019 07:55:00 +0700 (+07)
+Resent-From: =?iSo-8859-11?b?zcXUqyC82enK6KeotMvB0sI=?= <alis.phusngcdhmay@example.net>,
+ =?iSo-8859-11?b?zcXUqyC82enK6KeotMvB0sI=?= <alis.phusngcdhmay@example.com>
+Resent-Sender: =?iSo-8859-11?b?zcXUqyC82enK6KeotMvB0sI=?= <alis.phusngcdhmay@example.net>
+Resent-To: =?isO-8859-11?b?uurNuiC82enD0bo=?= <bob.phurab@example.net>,
+ =?iso-8859-11?b?pNLiw8UgvNnpw9G6?= <carol.phurab@example.net>
+Resent-Cc: =?ISo-8859-11?b?4bS5ILzZ6cPRug==?= <dan.phurab@example.net>,
+ =?ISo-8859-11?B?zdW/ILzZ6cPRug==?= <eve.phurab@example.net>
+Resent-Bcc: =?iso-8859-11?B?4b/Dp6TsILzZ6cPRug==?= <frank.phurab@example.net>,
+ =?IsO-8859-11?B?4KHDqyC82enD0bo=?= <grace.phurab@example.net>
+Resent-Message-ID: <Message-Id-1@example.net>
+Content-Type: mUlTipArt/RELATED; CHarSEt="iSo-8859-11"; bOUnDaRy="RelatedBoundaryString"
+Content-Transfer-Encoding: BaSE64
+X-Clacks-Overhead: GNU Terry Pratchett
+
+
+--RelatedBoundaryString
+Content-Type: mUlTIpArt/aLtErnaTIve; BoUNDarY="AlternativeBoundaryString"
+
+--AlternativeBoundaryString
+Content-Type: TExt/PLAIn; cHARsEt="isO-8859-11"
+Content-Transfer-Encoding: bAse64
+
+4LvnucG52MnC7MrYtLvD0ODKw9Sw4MXUyKTYs6To0iChx+jSusPDtNK92afK0bXH7OC0w9GoqdK5
+IKinvejSv9G5vtGyudLH1KrSodLDIM3C6NLF6dKnvMXSrcTl4KLouabo0rrVsdLjpMMg5MHottfN
+4rfJ4qHDuOGq6Ker0bTO1rTO0bS06NIgy9G0zcDRwuDLwdfNuaHVzNLN0aqs0srRwiC7r9S60bXU
+u8PQvsS11KGuodPLubTjqCC+2bSo0uPL6ajq0OYgqOvS5iC56NK/0afgzcLPCgq50sLK0aemwNGz
+sewg4M6nvtS30aHJ7L3R6KcgvNnp4LLo0qvW6KfB1c3SqtW+4LvnuaW5otLCo8e0ILbZobXTw8eo
+u6/UutG11KHSw6jRur/pzafI0sUgsNK5xdGhudLM1KHSpNizy63Up6nRtcOqrtIgrNK5ysHSuNQ
+
+--AlternativeBoundaryString
+Content-Type: tExt/eNRIcHEd; CHarsEt="ISo-8859-11"
+Content-Transfer-Encoding: BASE64
+
+PGJvbGQ+4LvnucG52MnC7MrYtLvD0ODKw9Sw4MXUyKTYs6To0jwvYm9sZD4gPGl0YWxpYz6hx+jS
+usPDtNK92afK0bXH7OC0w9GoqdK5PC9pdGFsaWM+IDxmaXhlZD6op73o0r/Rub7RsrnSx9Sq0qHS
+wzwvZml4ZWQ+IDx1bmRlcmxpbmU+zcLo0sXp0qe8xdKtxOXgoui5pujSutWx0uOkwzwvdW5kZXJs
+aW5lPiDkwei2183it8niocO44arop6vRtM7WtM7RtLTo0iDL0bTNwNHC4MvB1825odXM0s3RqqzS
+ytHCILuv1LrRtdS7w9C+xLXUoa6h08u5tOOoIL7ZtKjS48vpqOrQ5iCo69LmILno0r/Rp+DNws8K
+CrnSwsrRp6bA0bOx7CDgzqe+1LfRocnsvdHopyC82engsujSq9bop8HVzdKq1b7gu+e5pbmi0sKj
+x7QgttmhtdPDx6i7r9S60bXUodLDqNG6v+nNp8jSxSCw0rnF0aG50szUodKk2LPLrdSnqdG1w6qu
+0iCs0rnKwdK41A==
+
+--AlternativeBoundaryString
+Content-Type: texT/htMl; ChArseT="IsO-8859-11"
+Content-Transfer-Encoding: bAse64
+
+PGh0bWw+CjxkaXYgZGlyPSJsdHIiPgo8cD7gu+e5wbnYycLsyti0u8PQ4MrD1LDgxdTIpNizpOjS
+IKHH6NK6w8O00r3Zp8rRtcfs4LTD0aip0rkgqKe96NK/0bm+0bK50sfUqtKh0sMgzcLo0sXp0qe8
+xdKtxOXgoui5pujSutWx0uOkwyDkwei2183it8niocO44arop6vRtM7WtM7RtLTo0iDL0bTNwNHC
+4MvB1825odXM0s3RqqzSytHCILuv1LrRtdS7w9C+xLXUoa6h08u5tOOoIL7ZtKjS48vpqOrQ5iCo
+69LmILno0r/Rp+DNws88L3A+Cgo8cD650sLK0aemwNGzsewg4M6nvtS30aHJ7L3R6KcgvNnp4LLo
+0qvW6KfB1c3SqtW+4LvnuaW5otLCo8e0ILbZobXTw8eou6/UutG11KHSw6jRur/pzafI0sUgsNK5
+xdGhudLM1KHSpNizy63Up6nRtcOqrtIgrNK5ysHSuNQ8L3A+CjwvZGl2Pgo8L2h0bWw+
+
+--AlternativeBoundaryString--
+
+--RelatedBoundaryString
+Content-Type: image/jpeg; NaMe="inline-jpg-image-name.jpg"
+Content-Transfer-Encoding: BaSE64
+Content-Disposition: iNlIne; fIlEnAMe="inline-jpg-image-filename.jpg"
+Content-ID: <inline-jpg-image.jpg@example.com>
+
+/9j/2wBDAAMCAgICAgMCAgIDAwMDBAYEBAQEBAgGBgUGCQgKCgkICQkKDA8MCgsOCwkJDRENDg8Q
+EBEQCgwSExIQEw8QEBD/yQALCAABAAEBAREA/8wABgAQEAX/2gAIAQEAAD8A0s8g/9k=
+
+--RelatedBoundaryString--

--- a/tests/test_thai_multipart_related_iso-8859-11_over_quoted-printable.txt
+++ b/tests/test_thai_multipart_related_iso-8859-11_over_quoted-printable.txt
@@ -1,0 +1,114 @@
+Date: Mon, 01 Apr 2019 07:55:00 +0700 (+07)
+From: =?iSO-8859-11?q?=CD=C5=D4=AB_=BC=D9=E9=CA=E8=A7=A8=B4=CB=C1=D2=C2?= <alis.phusngcdhmay@example.com>,
+ =?iSO-8859-11?q?=CD=C5=D4=AB_=BC=D9=E9=CA=E8=A7=A8=B4=CB=C1=D2=C2?= <alis.phusngcdhmay@example.net>
+Sender: =?iSO-8859-11?q?=CD=C5=D4=AB_=BC=D9=E9=CA=E8=A7=A8=B4=CB=C1=D2=C2?= <alis.phusngcdhmay@example.com>
+Reply-To: =?iSO-8859-11?q?=CD=C5=D4=AB_=BC=D9=E9=CA=E8=A7=A8=B4=CB=C1=D2=C2?= <alis.phusngcdhmay@example.net>
+To: =?isO-8859-11?Q?=BA=EA=CD=BA_=BC=D9=E9=C3=D1=BA?= <bob.phurab@example.com>,
+ =?ISO-8859-11?q?=A4=D2=E2=C3=C5_=BC=D9=E9=C3=D1=BA?= <carol.phurab@example.com>
+Cc: =?iso-8859-11?q?=E1=B4=B9_=BC=D9=E9=C3=D1=BA?= <dan.phurab@example.com>,
+ =?iSO-8859-11?q?=CD=D5=BF_=BC=D9=E9=C3=D1=BA?= <eve.phurab@example.com>
+Bcc: =?iSO-8859-11?Q?=E1=BF=C3=A7=A4=EC_=BC=D9=E9=C3=D1=BA?= <frank.phurab@example.com>,
+ =?isO-8859-11?q?=E0=A1=C3=AB_=BC=D9=E9=C3=D1=BA?= <grace.phurab@example.com>
+Subject: =?UTF-8?B?8J+Tpw==?= Test
+ =?isO-8859-11?q?=E1=BE=B9=E1=A1=C3=C1=C0=D2=C9=D2=E4=B7=C2?=
+In-Reply-To: <Message-Id-0@example.com>
+References: <Message-Id-0@example.com>
+Message-ID: <Message-Id-1@example.com>
+Comments: Message Header Comment
+Keywords: Keyword 1, Keyword 2
+Resent-Date: Mon, 01 Apr 2019 07:55:00 +0700 (+07)
+Resent-From: =?iSO-8859-11?q?=CD=C5=D4=AB_=BC=D9=E9=CA=E8=A7=A8=B4=CB=C1=D2=C2?= <alis.phusngcdhmay@example.net>,
+ =?iSO-8859-11?q?=CD=C5=D4=AB_=BC=D9=E9=CA=E8=A7=A8=B4=CB=C1=D2=C2?= <alis.phusngcdhmay@example.com>
+Resent-Sender: =?iSO-8859-11?q?=CD=C5=D4=AB_=BC=D9=E9=CA=E8=A7=A8=B4=CB=C1=D2=C2?= <alis.phusngcdhmay@example.net>
+Resent-To: =?isO-8859-11?Q?=BA=EA=CD=BA_=BC=D9=E9=C3=D1=BA?= <bob.phurab@example.net>,
+ =?ISO-8859-11?q?=A4=D2=E2=C3=C5_=BC=D9=E9=C3=D1=BA?= <carol.phurab@example.net>
+Resent-Cc: =?iso-8859-11?q?=E1=B4=B9_=BC=D9=E9=C3=D1=BA?= <dan.phurab@example.net>,
+ =?iSO-8859-11?q?=CD=D5=BF_=BC=D9=E9=C3=D1=BA?= <eve.phurab@example.net>
+Resent-Bcc: =?iSO-8859-11?Q?=E1=BF=C3=A7=A4=EC_=BC=D9=E9=C3=D1=BA?= <frank.phurab@example.net>,
+ =?isO-8859-11?q?=E0=A1=C3=AB_=BC=D9=E9=C3=D1=BA?= <grace.phurab@example.net>
+Resent-Message-ID: <Message-Id-1@example.net>
+Content-Type: MuLtiPaRt/relATEd; cHarseT="ISO-8859-11"; boundaRy="RelatedBoundaryString"
+Content-Transfer-Encoding: quotEd-prinTABLe
+X-Clacks-Overhead: GNU Terry Pratchett
+
+
+--RelatedBoundaryString
+Content-Type: MultiPArt/ALTerNaTiVe; BOUNDarY="AlternativeBoundaryString"
+
+--AlternativeBoundaryString
+Content-Type: text/pLaiN; chaRSeT="ISO-8859-11"
+Content-Transfer-Encoding: qUOteD-PrinTABLE
+
+=E0=BB=E7=B9=C1=B9=D8=C9=C2=EC=CA=D8=B4=BB=C3=D0=E0=CA=C3=D4=B0=E0=C5=D4=C8=
+=A4=D8=B3=A4=E8=D2 =A1=C7=E8=D2=BA=C3=C3=B4=D2=BD=D9=A7=CA=D1=B5=C7=EC=E0=
+=B4=C3=D1=A8=A9=D2=B9 =A8=A7=BD=E8=D2=BF=D1=B9=BE=D1=B2=B9=D2=C7=D4=AA=D2=
+=A1=D2=C3 =CD=C2=E8=D2=C5=E9=D2=A7=BC=C5=D2=AD=C4=E5=E0=A2=E8=B9=A6=E8=D2=
+=BA=D5=B1=D2=E3=A4=C3 =E4=C1=E8=B6=D7=CD=E2=B7=C9=E2=A1=C3=B8=E1=AA=E8=A7=
+=AB=D1=B4=CE=D6=B4=CE=D1=B4=B4=E8=D2 =CB=D1=B4=CD=C0=D1=C2=E0=CB=C1=D7=CD=
+=B9=A1=D5=CC=D2=CD=D1=AA=AC=D2=CA=D1=C2 =BB=AF=D4=BA=D1=B5=D4=BB=C3=D0=BE=
+=C4=B5=D4=A1=AE=A1=D3=CB=B9=B4=E3=A8 =BE=D9=B4=A8=D2=E3=CB=E9=A8=EA=D0=E6 =
+=A8=EB=D2=E6 =B9=E8=D2=BF=D1=A7=E0=CD=C2=CF
+
+=B9=D2=C2=CA=D1=A7=A6=C0=D1=B3=B1=EC =E0=CE=A7=BE=D4=B7=D1=A1=C9=EC=BD=D1=
+=E8=A7 =BC=D9=E9=E0=B2=E8=D2=AB=D6=E8=A7=C1=D5=CD=D2=AA=D5=BE=E0=BB=E7=B9=
+=A5=B9=A2=D2=C2=A3=C7=B4 =B6=D9=A1=B5=D3=C3=C7=A8=BB=AF=D4=BA=D1=B5=D4=A1=
+=D2=C3=A8=D1=BA=BF=E9=CD=A7=C8=D2=C5 =B0=D2=B9=C5=D1=A1=B9=D2=CC=D4=A1=D2=
+=A4=D8=B3=CB=AD=D4=A7=A9=D1=B5=C3=AA=AE=D2 =AC=D2=B9=CA=C1=D2=B8=D4
+
+--AlternativeBoundaryString
+Content-Type: TEXT/enrICHed; CHaRseT="isO-8859-11"
+Content-Transfer-Encoding: qUoTED-pRINtaBlE
+
+<bold>=E0=BB=E7=B9=C1=B9=D8=C9=C2=EC=CA=D8=B4=BB=C3=D0=E0=CA=C3=D4=B0=E0=C5=
+=D4=C8=A4=D8=B3=A4=E8=D2</bold> <italic>=A1=C7=E8=D2=BA=C3=C3=B4=D2=BD=D9=
+=A7=CA=D1=B5=C7=EC=E0=B4=C3=D1=A8=A9=D2=B9</italic> <fixed>=A8=A7=BD=E8=D2=
+=BF=D1=B9=BE=D1=B2=B9=D2=C7=D4=AA=D2=A1=D2=C3</fixed> <underline>=CD=C2=E8=
+=D2=C5=E9=D2=A7=BC=C5=D2=AD=C4=E5=E0=A2=E8=B9=A6=E8=D2=BA=D5=B1=D2=E3=A4=C3=
+</underline> =E4=C1=E8=B6=D7=CD=E2=B7=C9=E2=A1=C3=B8=E1=AA=E8=A7=AB=D1=B4=
+=CE=D6=B4=CE=D1=B4=B4=E8=D2 =CB=D1=B4=CD=C0=D1=C2=E0=CB=C1=D7=CD=B9=A1=D5=
+=CC=D2=CD=D1=AA=AC=D2=CA=D1=C2 =BB=AF=D4=BA=D1=B5=D4=BB=C3=D0=BE=C4=B5=D4=
+=A1=AE=A1=D3=CB=B9=B4=E3=A8 =BE=D9=B4=A8=D2=E3=CB=E9=A8=EA=D0=E6 =A8=EB=D2=
+=E6 =B9=E8=D2=BF=D1=A7=E0=CD=C2=CF
+
+=B9=D2=C2=CA=D1=A7=A6=C0=D1=B3=B1=EC =E0=CE=A7=BE=D4=B7=D1=A1=C9=EC=BD=D1=
+=E8=A7 =BC=D9=E9=E0=B2=E8=D2=AB=D6=E8=A7=C1=D5=CD=D2=AA=D5=BE=E0=BB=E7=B9=
+=A5=B9=A2=D2=C2=A3=C7=B4 =B6=D9=A1=B5=D3=C3=C7=A8=BB=AF=D4=BA=D1=B5=D4=A1=
+=D2=C3=A8=D1=BA=BF=E9=CD=A7=C8=D2=C5 =B0=D2=B9=C5=D1=A1=B9=D2=CC=D4=A1=D2=
+=A4=D8=B3=CB=AD=D4=A7=A9=D1=B5=C3=AA=AE=D2 =AC=D2=B9=CA=C1=D2=B8=D4
+
+--AlternativeBoundaryString
+Content-Type: TEXt/hTmL; chArsET="IsO-8859-11"
+Content-Transfer-Encoding: QUOTed-PrIntABLE
+
+<html>
+<div dir=3D"ltr">
+<p>=E0=BB=E7=B9=C1=B9=D8=C9=C2=EC=CA=D8=B4=BB=C3=D0=E0=CA=C3=D4=B0=E0=C5=D4=
+=C8=A4=D8=B3=A4=E8=D2 =A1=C7=E8=D2=BA=C3=C3=B4=D2=BD=D9=A7=CA=D1=B5=C7=EC=
+=E0=B4=C3=D1=A8=A9=D2=B9 =A8=A7=BD=E8=D2=BF=D1=B9=BE=D1=B2=B9=D2=C7=D4=AA=
+=D2=A1=D2=C3 =CD=C2=E8=D2=C5=E9=D2=A7=BC=C5=D2=AD=C4=E5=E0=A2=E8=B9=A6=E8=
+=D2=BA=D5=B1=D2=E3=A4=C3 =E4=C1=E8=B6=D7=CD=E2=B7=C9=E2=A1=C3=B8=E1=AA=E8=
+=A7=AB=D1=B4=CE=D6=B4=CE=D1=B4=B4=E8=D2 =CB=D1=B4=CD=C0=D1=C2=E0=CB=C1=D7=
+=CD=B9=A1=D5=CC=D2=CD=D1=AA=AC=D2=CA=D1=C2 =BB=AF=D4=BA=D1=B5=D4=BB=C3=D0=
+=BE=C4=B5=D4=A1=AE=A1=D3=CB=B9=B4=E3=A8 =BE=D9=B4=A8=D2=E3=CB=E9=A8=EA=D0=
+=E6 =A8=EB=D2=E6 =B9=E8=D2=BF=D1=A7=E0=CD=C2=CF</p>
+
+<p>=B9=D2=C2=CA=D1=A7=A6=C0=D1=B3=B1=EC =E0=CE=A7=BE=D4=B7=D1=A1=C9=EC=BD=
+=D1=E8=A7 =BC=D9=E9=E0=B2=E8=D2=AB=D6=E8=A7=C1=D5=CD=D2=AA=D5=BE=E0=BB=E7=
+=B9=A5=B9=A2=D2=C2=A3=C7=B4 =B6=D9=A1=B5=D3=C3=C7=A8=BB=AF=D4=BA=D1=B5=D4=
+=A1=D2=C3=A8=D1=BA=BF=E9=CD=A7=C8=D2=C5 =B0=D2=B9=C5=D1=A1=B9=D2=CC=D4=A1=
+=D2=A4=D8=B3=CB=AD=D4=A7=A9=D1=B5=C3=AA=AE=D2 =AC=D2=B9=CA=C1=D2=B8=D4</p>
+</div>
+</html>
+
+--AlternativeBoundaryString--
+
+--RelatedBoundaryString
+Content-Type: image/jpeg; name="inline-jpg-image-name.jpg"
+Content-Transfer-Encoding: bASe64
+Content-Disposition: InLinE; FILEnaMe="inline-jpg-image-filename.jpg"
+Content-ID: <inline-jpg-image.jpg@example.com>
+
+/9j/2wBDAAMCAgICAgMCAgIDAwMDBAYEBAQEBAgGBgUGCQgKCgkICQkKDA8MCgsOCwkJDRENDg8Q
+EBEQCgwSExIQEw8QEBD/yQALCAABAAEBAREA/8wABgAQEAX/2gAIAQEAAD8A0s8g/9k=
+
+--RelatedBoundaryString--

--- a/tests/test_thai_multipart_related_tis-620_over_base64.txt
+++ b/tests/test_thai_multipart_related_tis-620_over_base64.txt
@@ -1,0 +1,86 @@
+Date: Mon, 01 Apr 2019 07:55:00 +0700 (+07)
+From: =?TIS-620?B?zcXUqyC82enK6KeotMvB0sI=?= <alis.phusngcdhmay@example.com>,
+ =?TIS-620?B?zcXUqyC82enK6KeotMvB0sI=?= <alis.phusngcdhmay@example.net>
+Sender: =?TIS-620?B?zcXUqyC82enK6KeotMvB0sI=?= <alis.phusngcdhmay@example.com>
+Reply-To: =?TIS-620?B?zcXUqyC82enK6KeotMvB0sI=?= <alis.phusngcdhmay@example.net>
+To: =?tIs-620?B?uurNuiC82enD0bo=?= <bob.phurab@example.com>,
+ =?TiS-620?B?pNLiw8UgvNnpw9G6?= <carol.phurab@example.com>
+Cc: =?tis-620?B?4bS5ILzZ6cPRug==?= <dan.phurab@example.com>,
+ =?tIs-620?b?zdW/ILzZ6cPRug==?= <eve.phurab@example.com>
+Bcc: =?tiS-620?b?4b/Dp6TsILzZ6cPRug==?= <frank.phurab@example.com>,
+ =?tIs-620?B?4KHDqyC82enD0bo=?= <grace.phurab@example.com>
+Subject: =?UTF-8?B?8J+Tpw==?= Test
+ =?TIS-620?b?4b654aHDwcDSydLkt8I=?=
+In-Reply-To: <Message-Id-0@example.com>
+References: <Message-Id-0@example.com>
+Message-ID: <Message-Id-1@example.com>
+Comments: Message Header Comment
+Keywords: Keyword 1, Keyword 2
+Resent-Date: Mon, 01 Apr 2019 07:55:00 +0700 (+07)
+Resent-From: =?TIS-620?B?zcXUqyC82enK6KeotMvB0sI=?= <alis.phusngcdhmay@example.net>,
+ =?TIS-620?B?zcXUqyC82enK6KeotMvB0sI=?= <alis.phusngcdhmay@example.com>
+Resent-Sender: =?TIS-620?B?zcXUqyC82enK6KeotMvB0sI=?= <alis.phusngcdhmay@example.net>
+Resent-To: =?tIs-620?B?uurNuiC82enD0bo=?= <bob.phurab@example.net>,
+ =?TiS-620?B?pNLiw8UgvNnpw9G6?= <carol.phurab@example.net>
+Resent-Cc: =?tis-620?B?4bS5ILzZ6cPRug==?= <dan.phurab@example.net>,
+ =?tIs-620?b?zdW/ILzZ6cPRug==?= <eve.phurab@example.net>
+Resent-Bcc: =?tiS-620?b?4b/Dp6TsILzZ6cPRug==?= <frank.phurab@example.net>,
+ =?tIs-620?B?4KHDqyC82enD0bo=?= <grace.phurab@example.net>
+Resent-Message-ID: <Message-Id-1@example.net>
+Content-Type: MuLtIPART/rElated; cHARsET="TIS-620"; BOunDArY="RelatedBoundaryString"
+Content-Transfer-Encoding: bASe64
+X-Clacks-Overhead: GNU Terry Pratchett
+
+
+--RelatedBoundaryString
+Content-Type: multIPaRt/aLTernatiVe; bOUndARY="AlternativeBoundaryString"
+
+--AlternativeBoundaryString
+Content-Type: TexT/Plain; CHarSEt="tIS-620"
+Content-Transfer-Encoding: BaSE64
+
+4LvnucG52MnC7MrYtLvD0ODKw9Sw4MXUyKTYs6To0iChx+jSusPDtNK92afK0bXH7OC0w9GoqdK5
+IKinvejSv9G5vtGyudLH1KrSodLDIM3C6NLF6dKnvMXSrcTl4KLouabo0rrVsdLjpMMg5MHottfN
+4rfJ4qHDuOGq6Ker0bTO1rTO0bS06NIgy9G0zcDRwuDLwdfNuaHVzNLN0aqs0srRwiC7r9S60bXU
+u8PQvsS11KGuodPLubTjqCC+2bSo0uPL6ajq0OYgqOvS5iC56NK/0afgzcLPCgq50sLK0aemwNGz
+sewg4M6nvtS30aHJ7L3R6KcgvNnp4LLo0qvW6KfB1c3SqtW+4LvnuaW5otLCo8e0ILbZobXTw8eo
+u6/UutG11KHSw6jRur/pzafI0sUgsNK5xdGhudLM1KHSpNizy63Up6nRtcOqrtIgrNK5ysHSuNQ=
+
+
+--AlternativeBoundaryString
+Content-Type: tEXT/eNrICheD; cHaRSet="tIs-620"
+Content-Transfer-Encoding: bASe64
+
+PGJvbGQ+4LvnucG52MnC7MrYtLvD0ODKw9Sw4MXUyKTYs6To0jwvYm9sZD4gPGl0YWxpYz6hx+jS
+usPDtNK92afK0bXH7OC0w9GoqdK5PC9pdGFsaWM+IDxmaXhlZD6op73o0r/Rub7RsrnSx9Sq0qHS
+wzwvZml4ZWQ+IDx1bmRlcmxpbmU+zcLo0sXp0qe8xdKtxOXgoui5pujSutWx0uOkwzwvdW5kZXJs
+aW5lPiDkwei2183it8niocO44arop6vRtM7WtM7RtLTo0iDL0bTNwNHC4MvB1825odXM0s3RqqzS
+ytHCILuv1LrRtdS7w9C+xLXUoa6h08u5tOOoIL7ZtKjS48vpqOrQ5iCo69LmILno0r/Rp+DNws8K
+CrnSwsrRp6bA0bOx7CDgzqe+1LfRocnsvdHopyC82engsujSq9bop8HVzdKq1b7gu+e5pbmi0sKj
+x7QgttmhtdPDx6i7r9S60bXUodLDqNG6v+nNp8jSxSCw0rnF0aG50szUodKk2LPLrdSnqdG1w6qu
+0iCs0rnKwdK41A
+
+--AlternativeBoundaryString
+Content-Type: TeXT/htMl; cHArseT="tis-620"
+Content-Transfer-Encoding: bAse64
+
+PGh0bWw+CjxkaXYgZGlyPSJsdHIiPgo8cD7gu+e5wbnYycLsyti0u8PQ4MrD1LDgxdTIpNizpOjS
+IKHH6NK6w8O00r3Zp8rRtcfs4LTD0aip0rkgqKe96NK/0bm+0bK50sfUqtKh0sMgzcLo0sXp0qe8
+xdKtxOXgoui5pujSutWx0uOkwyDkwei2183it8niocO44arop6vRtM7WtM7RtLTo0iDL0bTNwNHC
+4MvB1825odXM0s3RqqzSytHCILuv1LrRtdS7w9C+xLXUoa6h08u5tOOoIL7ZtKjS48vpqOrQ5iCo
+69LmILno0r/Rp+DNws88L3A+Cgo8cD650sLK0aemwNGzsewg4M6nvtS30aHJ7L3R6KcgvNnp4LLo
+0qvW6KfB1c3SqtW+4LvnuaW5otLCo8e0ILbZobXTw8eou6/UutG11KHSw6jRur/pzafI0sUgsNK5
+xdGhudLM1KHSpNizy63Up6nRtcOqrtIgrNK5ysHSuNQ8L3A+CjwvZGl2Pgo8L2h0bWw+
+
+--AlternativeBoundaryString--
+
+--RelatedBoundaryString
+Content-Type: image/jpeg; NamE="inline-jpg-image-name.jpg"
+Content-Transfer-Encoding: BAse64
+Content-Disposition: iNliNE; fiLenAmE="inline-jpg-image-filename.jpg"
+Content-ID: <inline-jpg-image.jpg@example.com>
+
+/9j/2wBDAAMCAgICAgMCAgIDAwMDBAYEBAQEBAgGBgUGCQgKCgkICQkKDA8MCgsOCwkJDRENDg8Q
+EBEQCgwSExIQEw8QEBD/yQALCAABAAEBAREA/8wABgAQEAX/2gAIAQEAAD8A0s8g/9k=
+
+--RelatedBoundaryString--

--- a/tests/test_thai_multipart_related_tis-620_over_quoted-printable.txt
+++ b/tests/test_thai_multipart_related_tis-620_over_quoted-printable.txt
@@ -1,0 +1,114 @@
+Date: Mon, 01 Apr 2019 07:55:00 +0700 (+07)
+From: =?tis-620?Q?=CD=C5=D4=AB_=BC=D9=E9=CA=E8=A7=A8=B4=CB=C1=D2=C2?= <alis.phusngcdhmay@example.com>,
+ =?tis-620?Q?=CD=C5=D4=AB_=BC=D9=E9=CA=E8=A7=A8=B4=CB=C1=D2=C2?= <alis.phusngcdhmay@example.net>
+Sender: =?tis-620?Q?=CD=C5=D4=AB_=BC=D9=E9=CA=E8=A7=A8=B4=CB=C1=D2=C2?= <alis.phusngcdhmay@example.com>
+Reply-To: =?tis-620?Q?=CD=C5=D4=AB_=BC=D9=E9=CA=E8=A7=A8=B4=CB=C1=D2=C2?= <alis.phusngcdhmay@example.net>
+To: =?tiS-620?Q?=BA=EA=CD=BA_=BC=D9=E9=C3=D1=BA?= <bob.phurab@example.com>,
+ =?TIS-620?Q?=A4=D2=E2=C3=C5_=BC=D9=E9=C3=D1=BA?= <carol.phurab@example.com>
+Cc: =?TiS-620?Q?=E1=B4=B9_=BC=D9=E9=C3=D1=BA?= <dan.phurab@example.com>,
+ =?tIs-620?Q?=CD=D5=BF_=BC=D9=E9=C3=D1=BA?= <eve.phurab@example.com>
+Bcc: =?tIs-620?q?=E1=BF=C3=A7=A4=EC_=BC=D9=E9=C3=D1=BA?= <frank.phurab@example.com>,
+ =?TiS-620?q?=E0=A1=C3=AB_=BC=D9=E9=C3=D1=BA?= <grace.phurab@example.com>
+Subject: =?UTF-8?B?8J+Tpw==?= Test
+ =?Tis-620?Q?=E1=BE=B9=E1=A1=C3=C1=C0=D2=C9=D2=E4=B7=C2?=
+In-Reply-To: <Message-Id-0@example.com>
+References: <Message-Id-0@example.com>
+Message-ID: <Message-Id-1@example.com>
+Comments: Message Header Comment
+Keywords: Keyword 1, Keyword 2
+Resent-Date: Mon, 01 Apr 2019 07:55:00 +0700 (+07)
+Resent-From: =?tis-620?Q?=CD=C5=D4=AB_=BC=D9=E9=CA=E8=A7=A8=B4=CB=C1=D2=C2?= <alis.phusngcdhmay@example.net>,
+ =?tis-620?Q?=CD=C5=D4=AB_=BC=D9=E9=CA=E8=A7=A8=B4=CB=C1=D2=C2?= <alis.phusngcdhmay@example.com>
+Resent-Sender: =?tis-620?Q?=CD=C5=D4=AB_=BC=D9=E9=CA=E8=A7=A8=B4=CB=C1=D2=C2?= <alis.phusngcdhmay@example.net>
+Resent-To: =?tiS-620?Q?=BA=EA=CD=BA_=BC=D9=E9=C3=D1=BA?= <bob.phurab@example.net>,
+ =?TIS-620?Q?=A4=D2=E2=C3=C5_=BC=D9=E9=C3=D1=BA?= <carol.phurab@example.net>
+Resent-Cc: =?TiS-620?Q?=E1=B4=B9_=BC=D9=E9=C3=D1=BA?= <dan.phurab@example.net>,
+ =?tIs-620?Q?=CD=D5=BF_=BC=D9=E9=C3=D1=BA?= <eve.phurab@example.net>
+Resent-Bcc: =?tIs-620?q?=E1=BF=C3=A7=A4=EC_=BC=D9=E9=C3=D1=BA?= <frank.phurab@example.net>,
+ =?TiS-620?q?=E0=A1=C3=AB_=BC=D9=E9=C3=D1=BA?= <grace.phurab@example.net>
+Resent-Message-ID: <Message-Id-1@example.net>
+Content-Type: mulTIpARt/RElaTeD; chaRsEt="tiS-620"; BoundaRY="RelatedBoundaryString"
+Content-Transfer-Encoding: quoTEd-PRINtablE
+X-Clacks-Overhead: GNU Terry Pratchett
+
+
+--RelatedBoundaryString
+Content-Type: MultIparT/ALtErNatIVE; boundarY="AlternativeBoundaryString"
+
+--AlternativeBoundaryString
+Content-Type: TexT/pLaiN; CHArsET="tIs-620"
+Content-Transfer-Encoding: qUOTed-PRintaBlE
+
+=E0=BB=E7=B9=C1=B9=D8=C9=C2=EC=CA=D8=B4=BB=C3=D0=E0=CA=C3=D4=B0=E0=C5=D4=C8=
+=A4=D8=B3=A4=E8=D2 =A1=C7=E8=D2=BA=C3=C3=B4=D2=BD=D9=A7=CA=D1=B5=C7=EC=E0=
+=B4=C3=D1=A8=A9=D2=B9 =A8=A7=BD=E8=D2=BF=D1=B9=BE=D1=B2=B9=D2=C7=D4=AA=D2=
+=A1=D2=C3 =CD=C2=E8=D2=C5=E9=D2=A7=BC=C5=D2=AD=C4=E5=E0=A2=E8=B9=A6=E8=D2=
+=BA=D5=B1=D2=E3=A4=C3 =E4=C1=E8=B6=D7=CD=E2=B7=C9=E2=A1=C3=B8=E1=AA=E8=A7=
+=AB=D1=B4=CE=D6=B4=CE=D1=B4=B4=E8=D2 =CB=D1=B4=CD=C0=D1=C2=E0=CB=C1=D7=CD=
+=B9=A1=D5=CC=D2=CD=D1=AA=AC=D2=CA=D1=C2 =BB=AF=D4=BA=D1=B5=D4=BB=C3=D0=BE=
+=C4=B5=D4=A1=AE=A1=D3=CB=B9=B4=E3=A8 =BE=D9=B4=A8=D2=E3=CB=E9=A8=EA=D0=E6 =
+=A8=EB=D2=E6 =B9=E8=D2=BF=D1=A7=E0=CD=C2=CF
+
+=B9=D2=C2=CA=D1=A7=A6=C0=D1=B3=B1=EC =E0=CE=A7=BE=D4=B7=D1=A1=C9=EC=BD=D1=
+=E8=A7 =BC=D9=E9=E0=B2=E8=D2=AB=D6=E8=A7=C1=D5=CD=D2=AA=D5=BE=E0=BB=E7=B9=
+=A5=B9=A2=D2=C2=A3=C7=B4 =B6=D9=A1=B5=D3=C3=C7=A8=BB=AF=D4=BA=D1=B5=D4=A1=
+=D2=C3=A8=D1=BA=BF=E9=CD=A7=C8=D2=C5 =B0=D2=B9=C5=D1=A1=B9=D2=CC=D4=A1=D2=
+=A4=D8=B3=CB=AD=D4=A7=A9=D1=B5=C3=AA=AE=D2 =AC=D2=B9=CA=C1=D2=B8=D4
+
+--AlternativeBoundaryString
+Content-Type: TeXT/eNRIchED; CharSET="tIs-620"
+Content-Transfer-Encoding: qUOteD-pRiNTabLe
+
+<bold>=E0=BB=E7=B9=C1=B9=D8=C9=C2=EC=CA=D8=B4=BB=C3=D0=E0=CA=C3=D4=B0=E0=C5=
+=D4=C8=A4=D8=B3=A4=E8=D2</bold> <italic>=A1=C7=E8=D2=BA=C3=C3=B4=D2=BD=D9=
+=A7=CA=D1=B5=C7=EC=E0=B4=C3=D1=A8=A9=D2=B9</italic> <fixed>=A8=A7=BD=E8=D2=
+=BF=D1=B9=BE=D1=B2=B9=D2=C7=D4=AA=D2=A1=D2=C3</fixed> <underline>=CD=C2=E8=
+=D2=C5=E9=D2=A7=BC=C5=D2=AD=C4=E5=E0=A2=E8=B9=A6=E8=D2=BA=D5=B1=D2=E3=A4=C3=
+</underline> =E4=C1=E8=B6=D7=CD=E2=B7=C9=E2=A1=C3=B8=E1=AA=E8=A7=AB=D1=B4=
+=CE=D6=B4=CE=D1=B4=B4=E8=D2 =CB=D1=B4=CD=C0=D1=C2=E0=CB=C1=D7=CD=B9=A1=D5=
+=CC=D2=CD=D1=AA=AC=D2=CA=D1=C2 =BB=AF=D4=BA=D1=B5=D4=BB=C3=D0=BE=C4=B5=D4=
+=A1=AE=A1=D3=CB=B9=B4=E3=A8 =BE=D9=B4=A8=D2=E3=CB=E9=A8=EA=D0=E6 =A8=EB=D2=
+=E6 =B9=E8=D2=BF=D1=A7=E0=CD=C2=CF
+
+=B9=D2=C2=CA=D1=A7=A6=C0=D1=B3=B1=EC =E0=CE=A7=BE=D4=B7=D1=A1=C9=EC=BD=D1=
+=E8=A7 =BC=D9=E9=E0=B2=E8=D2=AB=D6=E8=A7=C1=D5=CD=D2=AA=D5=BE=E0=BB=E7=B9=
+=A5=B9=A2=D2=C2=A3=C7=B4 =B6=D9=A1=B5=D3=C3=C7=A8=BB=AF=D4=BA=D1=B5=D4=A1=
+=D2=C3=A8=D1=BA=BF=E9=CD=A7=C8=D2=C5 =B0=D2=B9=C5=D1=A1=B9=D2=CC=D4=A1=D2=
+=A4=D8=B3=CB=AD=D4=A7=A9=D1=B5=C3=AA=AE=D2 =AC=D2=B9=CA=C1=D2=B8=D4
+
+--AlternativeBoundaryString
+Content-Type: TExt/html; ChaRset="TIs-620"
+Content-Transfer-Encoding: qUOTeD-PrINTaBLE
+
+<html>
+<div dir=3D"ltr">
+<p>=E0=BB=E7=B9=C1=B9=D8=C9=C2=EC=CA=D8=B4=BB=C3=D0=E0=CA=C3=D4=B0=E0=C5=D4=
+=C8=A4=D8=B3=A4=E8=D2 =A1=C7=E8=D2=BA=C3=C3=B4=D2=BD=D9=A7=CA=D1=B5=C7=EC=
+=E0=B4=C3=D1=A8=A9=D2=B9 =A8=A7=BD=E8=D2=BF=D1=B9=BE=D1=B2=B9=D2=C7=D4=AA=
+=D2=A1=D2=C3 =CD=C2=E8=D2=C5=E9=D2=A7=BC=C5=D2=AD=C4=E5=E0=A2=E8=B9=A6=E8=
+=D2=BA=D5=B1=D2=E3=A4=C3 =E4=C1=E8=B6=D7=CD=E2=B7=C9=E2=A1=C3=B8=E1=AA=E8=
+=A7=AB=D1=B4=CE=D6=B4=CE=D1=B4=B4=E8=D2 =CB=D1=B4=CD=C0=D1=C2=E0=CB=C1=D7=
+=CD=B9=A1=D5=CC=D2=CD=D1=AA=AC=D2=CA=D1=C2 =BB=AF=D4=BA=D1=B5=D4=BB=C3=D0=
+=BE=C4=B5=D4=A1=AE=A1=D3=CB=B9=B4=E3=A8 =BE=D9=B4=A8=D2=E3=CB=E9=A8=EA=D0=
+=E6 =A8=EB=D2=E6 =B9=E8=D2=BF=D1=A7=E0=CD=C2=CF</p>
+
+<p>=B9=D2=C2=CA=D1=A7=A6=C0=D1=B3=B1=EC =E0=CE=A7=BE=D4=B7=D1=A1=C9=EC=BD=
+=D1=E8=A7 =BC=D9=E9=E0=B2=E8=D2=AB=D6=E8=A7=C1=D5=CD=D2=AA=D5=BE=E0=BB=E7=
+=B9=A5=B9=A2=D2=C2=A3=C7=B4 =B6=D9=A1=B5=D3=C3=C7=A8=BB=AF=D4=BA=D1=B5=D4=
+=A1=D2=C3=A8=D1=BA=BF=E9=CD=A7=C8=D2=C5 =B0=D2=B9=C5=D1=A1=B9=D2=CC=D4=A1=
+=D2=A4=D8=B3=CB=AD=D4=A7=A9=D1=B5=C3=AA=AE=D2 =AC=D2=B9=CA=C1=D2=B8=D4</p>
+</div>
+</html>
+
+--AlternativeBoundaryString--
+
+--RelatedBoundaryString
+Content-Type: image/jpeg; naME="inline-jpg-image-name.jpg"
+Content-Transfer-Encoding: BAse64
+Content-Disposition: iNlINE; FIlENAME="inline-jpg-image-filename.jpg"
+Content-ID: <inline-jpg-image.jpg@example.com>
+
+/9j/2wBDAAMCAgICAgMCAgIDAwMDBAYEBAQEBAgGBgUGCQgKCgkICQkKDA8MCgsOCwkJDRENDg8Q
+EBEQCgwSExIQEw8QEBD/yQALCAABAAEBAREA/8wABgAQEAX/2gAIAQEAAD8A0s8g/9k=
+
+--RelatedBoundaryString--

--- a/tests/test_thai_multipart_related_windows-874_over_base64.txt
+++ b/tests/test_thai_multipart_related_windows-874_over_base64.txt
@@ -1,0 +1,85 @@
+Date: Mon, 01 Apr 2019 07:55:00 +0700 (+07)
+From: =?WIndOWS-874?B?zcXUqyC82enK6KeotMvB0sI=?= <alis.phusngcdhmay@example.com>,
+ =?WIndOWS-874?B?zcXUqyC82enK6KeotMvB0sI=?= <alis.phusngcdhmay@example.net>
+Sender: =?WIndOWS-874?B?zcXUqyC82enK6KeotMvB0sI=?= <alis.phusngcdhmay@example.com>
+Reply-To: =?WIndOWS-874?B?zcXUqyC82enK6KeotMvB0sI=?= <alis.phusngcdhmay@example.net>
+To: =?wINDowS-874?B?uurNuiC82enD0bo=?= <bob.phurab@example.com>,
+ =?WIndOwS-874?B?pNLiw8UgvNnpw9G6?= <carol.phurab@example.com>
+Cc: =?WinDoWs-874?B?4bS5ILzZ6cPRug==?= <dan.phurab@example.com>,
+ =?WInDOWs-874?b?zdW/ILzZ6cPRug==?= <eve.phurab@example.com>
+Bcc: =?wInDowS-874?B?4b/Dp6TsILzZ6cPRug==?= <frank.phurab@example.com>,
+ =?wINDowS-874?B?4KHDqyC82enD0bo=?= <grace.phurab@example.com>
+Subject: =?UTF-8?B?8J+Tpw==?= Test
+ =?WINdowS-874?B?4b654aHDwcDSydLkt8I=?=
+In-Reply-To: <Message-Id-0@example.com>
+References: <Message-Id-0@example.com>
+Message-ID: <Message-Id-1@example.com>
+Comments: Message Header Comment
+Keywords: Keyword 1, Keyword 2
+Resent-Date: Mon, 01 Apr 2019 07:55:00 +0700 (+07)
+Resent-From: =?WIndOWS-874?B?zcXUqyC82enK6KeotMvB0sI=?= <alis.phusngcdhmay@example.net>,
+ =?WIndOWS-874?B?zcXUqyC82enK6KeotMvB0sI=?= <alis.phusngcdhmay@example.com>
+Resent-Sender: =?WIndOWS-874?B?zcXUqyC82enK6KeotMvB0sI=?= <alis.phusngcdhmay@example.net>
+Resent-To: =?wINDowS-874?B?uurNuiC82enD0bo=?= <bob.phurab@example.net>,
+ =?WIndOwS-874?B?pNLiw8UgvNnpw9G6?= <carol.phurab@example.net>
+Resent-Cc: =?WinDoWs-874?B?4bS5ILzZ6cPRug==?= <dan.phurab@example.net>,
+ =?WInDOWs-874?b?zdW/ILzZ6cPRug==?= <eve.phurab@example.net>
+Resent-Bcc: =?wInDowS-874?B?4b/Dp6TsILzZ6cPRug==?= <frank.phurab@example.net>,
+ =?wINDowS-874?B?4KHDqyC82enD0bo=?= <grace.phurab@example.net>
+Resent-Message-ID: <Message-Id-1@example.net>
+Content-Type: mUltiPARt/ReLateD; cHaRsEt="WINDOWS-874"; bOundARY="RelatedBoundaryString"
+Content-Transfer-Encoding: bAse64
+X-Clacks-Overhead: GNU Terry Pratchett
+
+
+--RelatedBoundaryString
+Content-Type: MultipaRt/AltErNative; BoUNdary="AlternativeBoundaryString"
+
+--AlternativeBoundaryString
+Content-Type: TEXT/PLaiN; CHARsET="WINdOWs-874"
+Content-Transfer-Encoding: bAse64
+
+4LvnucG52MnC7MrYtLvD0ODKw9Sw4MXUyKTYs6To0iChx+jSusPDtNK92afK0bXH7OC0w9GoqdK5
+IKinvejSv9G5vtGyudLH1KrSodLDIM3C6NLF6dKnvMXSrcTl4KLouabo0rrVsdLjpMMg5MHottfN
+4rfJ4qHDuOGq6Ker0bTO1rTO0bS06NIgy9G0zcDRwuDLwdfNuaHVzNLN0aqs0srRwiC7r9S60bXU
+u8PQvsS11KGuodPLubTjqCC+2bSo0uPL6ajq0OYgqOvS5iC56NK/0afgzcLPCgq50sLK0aemwNGz
+sewg4M6nvtS30aHJ7L3R6KcgvNnp4LLo0qvW6KfB1c3SqtW+4LvnuaW5otLCo8e0ILbZobXTw8eo
+u6/UutG11KHSw6jRur/pzafI0sUgsNK5xdGhudLM1KHSpNizy63Up6nRtcOqrtIgrNK5ysHSuNQ
+
+--AlternativeBoundaryString
+Content-Type: text/eNrICheD; ChARSeT="wInDOws-874"
+Content-Transfer-Encoding: baSE64
+
+PGJvbGQ+4LvnucG52MnC7MrYtLvD0ODKw9Sw4MXUyKTYs6To0jwvYm9sZD4gPGl0YWxpYz6hx+jS
+usPDtNK92afK0bXH7OC0w9GoqdK5PC9pdGFsaWM+IDxmaXhlZD6op73o0r/Rub7RsrnSx9Sq0qHS
+wzwvZml4ZWQ+IDx1bmRlcmxpbmU+zcLo0sXp0qe8xdKtxOXgoui5pujSutWx0uOkwzwvdW5kZXJs
+aW5lPiDkwei2183it8niocO44arop6vRtM7WtM7RtLTo0iDL0bTNwNHC4MvB1825odXM0s3RqqzS
+ytHCILuv1LrRtdS7w9C+xLXUoa6h08u5tOOoIL7ZtKjS48vpqOrQ5iCo69LmILno0r/Rp+DNws8K
+CrnSwsrRp6bA0bOx7CDgzqe+1LfRocnsvdHopyC82engsujSq9bop8HVzdKq1b7gu+e5pbmi0sKj
+x7QgttmhtdPDx6i7r9S60bXUodLDqNG6v+nNp8jSxSCw0rnF0aG50szUodKk2LPLrdSnqdG1w6qu
+0iCs0rnKwdK41A==
+
+--AlternativeBoundaryString
+Content-Type: TeXt/hTmL; CHArsET="WindOws-874"
+Content-Transfer-Encoding: bASe64
+
+PGh0bWw+CjxkaXYgZGlyPSJsdHIiPgo8cD7gu+e5wbnYycLsyti0u8PQ4MrD1LDgxdTIpNizpOjS
+IKHH6NK6w8O00r3Zp8rRtcfs4LTD0aip0rkgqKe96NK/0bm+0bK50sfUqtKh0sMgzcLo0sXp0qe8
+xdKtxOXgoui5pujSutWx0uOkwyDkwei2183it8niocO44arop6vRtM7WtM7RtLTo0iDL0bTNwNHC
+4MvB1825odXM0s3RqqzSytHCILuv1LrRtdS7w9C+xLXUoa6h08u5tOOoIL7ZtKjS48vpqOrQ5iCo
+69LmILno0r/Rp+DNws88L3A+Cgo8cD650sLK0aemwNGzsewg4M6nvtS30aHJ7L3R6KcgvNnp4LLo
+0qvW6KfB1c3SqtW+4LvnuaW5otLCo8e0ILbZobXTw8eou6/UutG11KHSw6jRur/pzafI0sUgsNK5
+xdGhudLM1KHSpNizy63Up6nRtcOqrtIgrNK5ysHSuNQ8L3A+CjwvZGl2Pgo8L2h0bWw+
+
+--AlternativeBoundaryString--
+
+--RelatedBoundaryString
+Content-Type: image/jpeg; nAme="inline-jpg-image-name.jpg"
+Content-Transfer-Encoding: BAse64
+Content-Disposition: inLINe; FIlENamE="inline-jpg-image-filename.jpg"
+Content-ID: <inline-jpg-image.jpg@example.com>
+
+/9j/2wBDAAMCAgICAgMCAgIDAwMDBAYEBAQEBAgGBgUGCQgKCgkICQkKDA8MCgsOCwkJDRENDg8Q
+EBEQCgwSExIQEw8QEBD/yQALCAABAAEBAREA/8wABgAQEAX/2gAIAQEAAD8A0s8g/9k=
+
+--RelatedBoundaryString--

--- a/tests/test_thai_multipart_related_windows-874_over_quoted-printable.txt
+++ b/tests/test_thai_multipart_related_windows-874_over_quoted-printable.txt
@@ -1,0 +1,114 @@
+Date: Mon, 01 Apr 2019 07:55:00 +0700 (+07)
+From: =?windOWS-874?Q?=CD=C5=D4=AB_=BC=D9=E9=CA=E8=A7=A8=B4=CB=C1=D2=C2?= <alis.phusngcdhmay@example.com>,
+ =?windOWS-874?Q?=CD=C5=D4=AB_=BC=D9=E9=CA=E8=A7=A8=B4=CB=C1=D2=C2?= <alis.phusngcdhmay@example.net>
+Sender: =?windOWS-874?Q?=CD=C5=D4=AB_=BC=D9=E9=CA=E8=A7=A8=B4=CB=C1=D2=C2?= <alis.phusngcdhmay@example.com>
+Reply-To: =?windOWS-874?Q?=CD=C5=D4=AB_=BC=D9=E9=CA=E8=A7=A8=B4=CB=C1=D2=C2?= <alis.phusngcdhmay@example.net>
+To: =?WindowS-874?q?=BA=EA=CD=BA_=BC=D9=E9=C3=D1=BA?= <bob.phurab@example.com>,
+ =?WiNDowS-874?Q?=A4=D2=E2=C3=C5_=BC=D9=E9=C3=D1=BA?= <carol.phurab@example.com>
+Cc: =?wiNDowS-874?q?=E1=B4=B9_=BC=D9=E9=C3=D1=BA?= <dan.phurab@example.com>,
+ =?WinDOws-874?Q?=CD=D5=BF_=BC=D9=E9=C3=D1=BA?= <eve.phurab@example.com>
+Bcc: =?WiNdOws-874?Q?=E1=BF=C3=A7=A4=EC_=BC=D9=E9=C3=D1=BA?= <frank.phurab@example.com>,
+ =?WIndOws-874?q?=E0=A1=C3=AB_=BC=D9=E9=C3=D1=BA?= <grace.phurab@example.com>
+Subject: =?UTF-8?B?8J+Tpw==?= Test
+ =?wIndOwS-874?q?=E1=BE=B9=E1=A1=C3=C1=C0=D2=C9=D2=E4=B7=C2?=
+In-Reply-To: <Message-Id-0@example.com>
+References: <Message-Id-0@example.com>
+Message-ID: <Message-Id-1@example.com>
+Comments: Message Header Comment
+Keywords: Keyword 1, Keyword 2
+Resent-Date: Mon, 01 Apr 2019 07:55:00 +0700 (+07)
+Resent-From: =?windOWS-874?Q?=CD=C5=D4=AB_=BC=D9=E9=CA=E8=A7=A8=B4=CB=C1=D2=C2?= <alis.phusngcdhmay@example.net>,
+ =?windOWS-874?Q?=CD=C5=D4=AB_=BC=D9=E9=CA=E8=A7=A8=B4=CB=C1=D2=C2?= <alis.phusngcdhmay@example.com>
+Resent-Sender: =?windOWS-874?Q?=CD=C5=D4=AB_=BC=D9=E9=CA=E8=A7=A8=B4=CB=C1=D2=C2?= <alis.phusngcdhmay@example.net>
+Resent-To: =?WindowS-874?q?=BA=EA=CD=BA_=BC=D9=E9=C3=D1=BA?= <bob.phurab@example.net>,
+ =?WiNDowS-874?Q?=A4=D2=E2=C3=C5_=BC=D9=E9=C3=D1=BA?= <carol.phurab@example.net>
+Resent-Cc: =?wiNDowS-874?q?=E1=B4=B9_=BC=D9=E9=C3=D1=BA?= <dan.phurab@example.net>,
+ =?WinDOws-874?Q?=CD=D5=BF_=BC=D9=E9=C3=D1=BA?= <eve.phurab@example.net>
+Resent-Bcc: =?WiNdOws-874?Q?=E1=BF=C3=A7=A4=EC_=BC=D9=E9=C3=D1=BA?= <frank.phurab@example.net>,
+ =?WIndOws-874?q?=E0=A1=C3=AB_=BC=D9=E9=C3=D1=BA?= <grace.phurab@example.net>
+Resent-Message-ID: <Message-Id-1@example.net>
+Content-Type: mULTiParT/ReLATed; ChaRSeT="WIndowS-874"; BoUNDaRY="RelatedBoundaryString"
+Content-Transfer-Encoding: QuOteD-PRInTABlE
+X-Clacks-Overhead: GNU Terry Pratchett
+
+
+--RelatedBoundaryString
+Content-Type: mulTIPart/alteRNAtIVe; bouNDARy="AlternativeBoundaryString"
+
+--AlternativeBoundaryString
+Content-Type: teXT/PlaiN; CharSEt="windoWS-874"
+Content-Transfer-Encoding: QUoTEd-printaBle
+
+=E0=BB=E7=B9=C1=B9=D8=C9=C2=EC=CA=D8=B4=BB=C3=D0=E0=CA=C3=D4=B0=E0=C5=D4=C8=
+=A4=D8=B3=A4=E8=D2 =A1=C7=E8=D2=BA=C3=C3=B4=D2=BD=D9=A7=CA=D1=B5=C7=EC=E0=
+=B4=C3=D1=A8=A9=D2=B9 =A8=A7=BD=E8=D2=BF=D1=B9=BE=D1=B2=B9=D2=C7=D4=AA=D2=
+=A1=D2=C3 =CD=C2=E8=D2=C5=E9=D2=A7=BC=C5=D2=AD=C4=E5=E0=A2=E8=B9=A6=E8=D2=
+=BA=D5=B1=D2=E3=A4=C3 =E4=C1=E8=B6=D7=CD=E2=B7=C9=E2=A1=C3=B8=E1=AA=E8=A7=
+=AB=D1=B4=CE=D6=B4=CE=D1=B4=B4=E8=D2 =CB=D1=B4=CD=C0=D1=C2=E0=CB=C1=D7=CD=
+=B9=A1=D5=CC=D2=CD=D1=AA=AC=D2=CA=D1=C2 =BB=AF=D4=BA=D1=B5=D4=BB=C3=D0=BE=
+=C4=B5=D4=A1=AE=A1=D3=CB=B9=B4=E3=A8 =BE=D9=B4=A8=D2=E3=CB=E9=A8=EA=D0=E6 =
+=A8=EB=D2=E6 =B9=E8=D2=BF=D1=A7=E0=CD=C2=CF
+
+=B9=D2=C2=CA=D1=A7=A6=C0=D1=B3=B1=EC =E0=CE=A7=BE=D4=B7=D1=A1=C9=EC=BD=D1=
+=E8=A7 =BC=D9=E9=E0=B2=E8=D2=AB=D6=E8=A7=C1=D5=CD=D2=AA=D5=BE=E0=BB=E7=B9=
+=A5=B9=A2=D2=C2=A3=C7=B4 =B6=D9=A1=B5=D3=C3=C7=A8=BB=AF=D4=BA=D1=B5=D4=A1=
+=D2=C3=A8=D1=BA=BF=E9=CD=A7=C8=D2=C5 =B0=D2=B9=C5=D1=A1=B9=D2=CC=D4=A1=D2=
+=A4=D8=B3=CB=AD=D4=A7=A9=D1=B5=C3=AA=AE=D2 =AC=D2=B9=CA=C1=D2=B8=D4
+
+--AlternativeBoundaryString
+Content-Type: texT/enRIChed; chARset="WiNDowS-874"
+Content-Transfer-Encoding: qUoTeD-PRINTABlE
+
+<bold>=E0=BB=E7=B9=C1=B9=D8=C9=C2=EC=CA=D8=B4=BB=C3=D0=E0=CA=C3=D4=B0=E0=C5=
+=D4=C8=A4=D8=B3=A4=E8=D2</bold> <italic>=A1=C7=E8=D2=BA=C3=C3=B4=D2=BD=D9=
+=A7=CA=D1=B5=C7=EC=E0=B4=C3=D1=A8=A9=D2=B9</italic> <fixed>=A8=A7=BD=E8=D2=
+=BF=D1=B9=BE=D1=B2=B9=D2=C7=D4=AA=D2=A1=D2=C3</fixed> <underline>=CD=C2=E8=
+=D2=C5=E9=D2=A7=BC=C5=D2=AD=C4=E5=E0=A2=E8=B9=A6=E8=D2=BA=D5=B1=D2=E3=A4=C3=
+</underline> =E4=C1=E8=B6=D7=CD=E2=B7=C9=E2=A1=C3=B8=E1=AA=E8=A7=AB=D1=B4=
+=CE=D6=B4=CE=D1=B4=B4=E8=D2 =CB=D1=B4=CD=C0=D1=C2=E0=CB=C1=D7=CD=B9=A1=D5=
+=CC=D2=CD=D1=AA=AC=D2=CA=D1=C2 =BB=AF=D4=BA=D1=B5=D4=BB=C3=D0=BE=C4=B5=D4=
+=A1=AE=A1=D3=CB=B9=B4=E3=A8 =BE=D9=B4=A8=D2=E3=CB=E9=A8=EA=D0=E6 =A8=EB=D2=
+=E6 =B9=E8=D2=BF=D1=A7=E0=CD=C2=CF
+
+=B9=D2=C2=CA=D1=A7=A6=C0=D1=B3=B1=EC =E0=CE=A7=BE=D4=B7=D1=A1=C9=EC=BD=D1=
+=E8=A7 =BC=D9=E9=E0=B2=E8=D2=AB=D6=E8=A7=C1=D5=CD=D2=AA=D5=BE=E0=BB=E7=B9=
+=A5=B9=A2=D2=C2=A3=C7=B4 =B6=D9=A1=B5=D3=C3=C7=A8=BB=AF=D4=BA=D1=B5=D4=A1=
+=D2=C3=A8=D1=BA=BF=E9=CD=A7=C8=D2=C5 =B0=D2=B9=C5=D1=A1=B9=D2=CC=D4=A1=D2=
+=A4=D8=B3=CB=AD=D4=A7=A9=D1=B5=C3=AA=AE=D2 =AC=D2=B9=CA=C1=D2=B8=D4
+
+--AlternativeBoundaryString
+Content-Type: tEXt/htML; cHARSEt="wIndoWs-874"
+Content-Transfer-Encoding: qUotED-prINTable
+
+<html>
+<div dir=3D"ltr">
+<p>=E0=BB=E7=B9=C1=B9=D8=C9=C2=EC=CA=D8=B4=BB=C3=D0=E0=CA=C3=D4=B0=E0=C5=D4=
+=C8=A4=D8=B3=A4=E8=D2 =A1=C7=E8=D2=BA=C3=C3=B4=D2=BD=D9=A7=CA=D1=B5=C7=EC=
+=E0=B4=C3=D1=A8=A9=D2=B9 =A8=A7=BD=E8=D2=BF=D1=B9=BE=D1=B2=B9=D2=C7=D4=AA=
+=D2=A1=D2=C3 =CD=C2=E8=D2=C5=E9=D2=A7=BC=C5=D2=AD=C4=E5=E0=A2=E8=B9=A6=E8=
+=D2=BA=D5=B1=D2=E3=A4=C3 =E4=C1=E8=B6=D7=CD=E2=B7=C9=E2=A1=C3=B8=E1=AA=E8=
+=A7=AB=D1=B4=CE=D6=B4=CE=D1=B4=B4=E8=D2 =CB=D1=B4=CD=C0=D1=C2=E0=CB=C1=D7=
+=CD=B9=A1=D5=CC=D2=CD=D1=AA=AC=D2=CA=D1=C2 =BB=AF=D4=BA=D1=B5=D4=BB=C3=D0=
+=BE=C4=B5=D4=A1=AE=A1=D3=CB=B9=B4=E3=A8 =BE=D9=B4=A8=D2=E3=CB=E9=A8=EA=D0=
+=E6 =A8=EB=D2=E6 =B9=E8=D2=BF=D1=A7=E0=CD=C2=CF</p>
+
+<p>=B9=D2=C2=CA=D1=A7=A6=C0=D1=B3=B1=EC =E0=CE=A7=BE=D4=B7=D1=A1=C9=EC=BD=
+=D1=E8=A7 =BC=D9=E9=E0=B2=E8=D2=AB=D6=E8=A7=C1=D5=CD=D2=AA=D5=BE=E0=BB=E7=
+=B9=A5=B9=A2=D2=C2=A3=C7=B4 =B6=D9=A1=B5=D3=C3=C7=A8=BB=AF=D4=BA=D1=B5=D4=
+=A1=D2=C3=A8=D1=BA=BF=E9=CD=A7=C8=D2=C5 =B0=D2=B9=C5=D1=A1=B9=D2=CC=D4=A1=
+=D2=A4=D8=B3=CB=AD=D4=A7=A9=D1=B5=C3=AA=AE=D2 =AC=D2=B9=CA=C1=D2=B8=D4</p>
+</div>
+</html>
+
+--AlternativeBoundaryString--
+
+--RelatedBoundaryString
+Content-Type: image/jpeg; NAmE="inline-jpg-image-name.jpg"
+Content-Transfer-Encoding: bASe64
+Content-Disposition: InLIne; fILenAmE="inline-jpg-image-filename.jpg"
+Content-ID: <inline-jpg-image.jpg@example.com>
+
+/9j/2wBDAAMCAgICAgMCAgIDAwMDBAYEBAQEBAgGBgUGCQgKCgkICQkKDA8MCgsOCwkJDRENDg8Q
+EBEQCgwSExIQEw8QEBD/yQALCAABAAEBAREA/8wABgAQEAX/2gAIAQEAAD8A0s8g/9k=
+
+--RelatedBoundaryString--

--- a/tests/test_thai_multipart_signed_iso-8859-11_over_base64.txt
+++ b/tests/test_thai_multipart_signed_iso-8859-11_over_base64.txt
@@ -1,0 +1,59 @@
+Date: Mon, 01 Apr 2019 07:55:00 +0700 (+07)
+From: =?iso-8859-11?b?zcXUqyC82enK6KeotMvB0sI=?= <alis.phusngcdhmay@example.com>,
+ =?iso-8859-11?b?zcXUqyC82enK6KeotMvB0sI=?= <alis.phusngcdhmay@example.net>
+Sender: =?iso-8859-11?b?zcXUqyC82enK6KeotMvB0sI=?= <alis.phusngcdhmay@example.com>
+Reply-To: =?iso-8859-11?b?zcXUqyC82enK6KeotMvB0sI=?= <alis.phusngcdhmay@example.net>
+To: =?IsO-8859-11?b?uurNuiC82enD0bo=?= <bob.phurab@example.com>,
+ =?iSo-8859-11?B?pNLiw8UgvNnpw9G6?= <carol.phurab@example.com>
+Cc: =?IsO-8859-11?b?4bS5ILzZ6cPRug==?= <dan.phurab@example.com>,
+ =?Iso-8859-11?B?zdW/ILzZ6cPRug==?= <eve.phurab@example.com>
+Bcc: =?isO-8859-11?B?4b/Dp6TsILzZ6cPRug==?= <frank.phurab@example.com>,
+ =?Iso-8859-11?B?4KHDqyC82enD0bo=?= <grace.phurab@example.com>
+Subject: =?UTF-8?B?8J+Tpw==?= Signed Test
+ =?ISO-8859-11?B?4b654aHDwcDSydLkt8I=?=
+In-Reply-To: <Message-Id-0@example.com>
+References: <Message-Id-0@example.com>
+Message-ID: <Message-Id-1@example.com>
+Comments: Message Header Comment
+Keywords: Keyword 1, Keyword 2
+Resent-Date: Mon, 01 Apr 2019 07:55:00 +0700 (+07)
+Resent-From: =?iso-8859-11?b?zcXUqyC82enK6KeotMvB0sI=?= <alis.phusngcdhmay@example.net>,
+ =?iso-8859-11?b?zcXUqyC82enK6KeotMvB0sI=?= <alis.phusngcdhmay@example.com>
+Resent-Sender: =?iso-8859-11?b?zcXUqyC82enK6KeotMvB0sI=?= <alis.phusngcdhmay@example.net>
+Resent-To: =?IsO-8859-11?b?uurNuiC82enD0bo=?= <bob.phurab@example.net>,
+ =?iSo-8859-11?B?pNLiw8UgvNnpw9G6?= <carol.phurab@example.net>
+Resent-Cc: =?IsO-8859-11?b?4bS5ILzZ6cPRug==?= <dan.phurab@example.net>,
+ =?Iso-8859-11?B?zdW/ILzZ6cPRug==?= <eve.phurab@example.net>
+Resent-Bcc: =?isO-8859-11?B?4b/Dp6TsILzZ6cPRug==?= <frank.phurab@example.net>,
+ =?Iso-8859-11?B?4KHDqyC82enD0bo=?= <grace.phurab@example.net>
+Resent-Message-ID: <Message-Id-1@example.net>
+Content-Type: MULtIpaRT/siGNed;
+              CharSET="ISO-8859-11";
+              pRoTOCoL="aPpLiCatIoN/pKcS7-SIgNaTUrE";
+              mIcaLg=SHA1;
+              bOuNdAry=SignedBoundaryString
+Content-Transfer-Encoding: BaSE64
+X-Clacks-Overhead: GNU Terry Pratchett
+
+
+--SignedBoundaryString
+Content-Type: tEXt/PLAin
+Content-Transfer-Encoding: BaSe64
+
+4LvnucG52MnC7MrYtLvD0ODKw9Sw4MXUyKTYs6To0iChx+jSusPDtNK92afK0bXH7OC0w9GoqdK5
+IKinvejSv9G5vtGyudLH1KrSodLDIM3C6NLF6dKnvMXSrcTl4KLouabo0rrVsdLjpMMg5MHottfN
+4rfJ4qHDuOGq6Ker0bTO1rTO0bS06NIgy9G0zcDRwuDLwdfNuaHVzNLN0aqs0srRwiC7r9S60bXU
+u8PQvsS11KGuodPLubTjqCC+2bSo0uPL6ajq0OYgqOvS5iC56NK/0afgzcLPCgq50sLK0aemwNGz
+sewg4M6nvtS30aHJ7L3R6KcgvNnp4LLo0qvW6KfB1c3SqtW+4LvnuaW5otLCo8e0ILbZobXTw8eo
+u6/UutG11KHSw6jRur/pzafI0sUgsNK5xdGhudLM1KHSpNizy63Up6nRtcOqrtIgrNK5ysHSuNQ
+
+--SignedBoundaryString
+Content-Type: aPplicATion/Pkcs7-SIGNaTUre; nAME=smime.p7s
+Content-Transfer-Encoding: BaSE64
+Content-Disposition: aTTAchmEnt; filENaMe=smime.p7s
+
+ghyHhHUujhJhjH77n8HHGTrfvbnj756tbB9HG4VQpfyF467GhIGfHfYT64VQpfyF467GhIGfHfYT
+6jH77n8HHGghyHhHUujhJh756tbB9HGTrfvbnjn8HHGTrfvhJhjH776tbB9HG4VQbnj7567GhIGf
+HfYT6ghyHhHUujpfyF47GhIGfHfYT64VQbnj756
+
+--SignedBoundaryString--

--- a/tests/test_thai_multipart_signed_iso-8859-11_over_quoted-printable.txt
+++ b/tests/test_thai_multipart_signed_iso-8859-11_over_quoted-printable.txt
@@ -1,0 +1,68 @@
+Date: Mon, 01 Apr 2019 07:55:00 +0700 (+07)
+From: =?iSO-8859-11?q?=CD=C5=D4=AB_=BC=D9=E9=CA=E8=A7=A8=B4=CB=C1=D2=C2?= <alis.phusngcdhmay@example.com>,
+ =?iSO-8859-11?q?=CD=C5=D4=AB_=BC=D9=E9=CA=E8=A7=A8=B4=CB=C1=D2=C2?= <alis.phusngcdhmay@example.net>
+Sender: =?iSO-8859-11?q?=CD=C5=D4=AB_=BC=D9=E9=CA=E8=A7=A8=B4=CB=C1=D2=C2?= <alis.phusngcdhmay@example.com>
+Reply-To: =?iSO-8859-11?q?=CD=C5=D4=AB_=BC=D9=E9=CA=E8=A7=A8=B4=CB=C1=D2=C2?= <alis.phusngcdhmay@example.net>
+To: =?isO-8859-11?q?=BA=EA=CD=BA_=BC=D9=E9=C3=D1=BA?= <bob.phurab@example.com>,
+ =?ISO-8859-11?q?=A4=D2=E2=C3=C5_=BC=D9=E9=C3=D1=BA?= <carol.phurab@example.com>
+Cc: =?ISo-8859-11?Q?=E1=B4=B9_=BC=D9=E9=C3=D1=BA?= <dan.phurab@example.com>,
+ =?iSo-8859-11?q?=CD=D5=BF_=BC=D9=E9=C3=D1=BA?= <eve.phurab@example.com>
+Bcc: =?IsO-8859-11?q?=E1=BF=C3=A7=A4=EC_=BC=D9=E9=C3=D1=BA?= <frank.phurab@example.com>,
+ =?iSo-8859-11?Q?=E0=A1=C3=AB_=BC=D9=E9=C3=D1=BA?= <grace.phurab@example.com>
+Subject: =?UTF-8?B?8J+Tpw==?= Signed Test
+ =?iSo-8859-11?q?=E1=BE=B9=E1=A1=C3=C1=C0=D2=C9=D2=E4=B7=C2?=
+In-Reply-To: <Message-Id-0@example.com>
+References: <Message-Id-0@example.com>
+Message-ID: <Message-Id-1@example.com>
+Comments: Message Header Comment
+Keywords: Keyword 1, Keyword 2
+Resent-Date: Mon, 01 Apr 2019 07:55:00 +0700 (+07)
+Resent-From: =?iSO-8859-11?q?=CD=C5=D4=AB_=BC=D9=E9=CA=E8=A7=A8=B4=CB=C1=D2=C2?= <alis.phusngcdhmay@example.net>,
+ =?iSO-8859-11?q?=CD=C5=D4=AB_=BC=D9=E9=CA=E8=A7=A8=B4=CB=C1=D2=C2?= <alis.phusngcdhmay@example.com>
+Resent-Sender: =?iSO-8859-11?q?=CD=C5=D4=AB_=BC=D9=E9=CA=E8=A7=A8=B4=CB=C1=D2=C2?= <alis.phusngcdhmay@example.net>
+Resent-To: =?isO-8859-11?q?=BA=EA=CD=BA_=BC=D9=E9=C3=D1=BA?= <bob.phurab@example.net>,
+ =?ISO-8859-11?q?=A4=D2=E2=C3=C5_=BC=D9=E9=C3=D1=BA?= <carol.phurab@example.net>
+Resent-Cc: =?ISo-8859-11?Q?=E1=B4=B9_=BC=D9=E9=C3=D1=BA?= <dan.phurab@example.net>,
+ =?iSo-8859-11?q?=CD=D5=BF_=BC=D9=E9=C3=D1=BA?= <eve.phurab@example.net>
+Resent-Bcc: =?IsO-8859-11?q?=E1=BF=C3=A7=A4=EC_=BC=D9=E9=C3=D1=BA?= <frank.phurab@example.net>,
+ =?iSo-8859-11?Q?=E0=A1=C3=AB_=BC=D9=E9=C3=D1=BA?= <grace.phurab@example.net>
+Resent-Message-ID: <Message-Id-1@example.net>
+Content-Type: MULTIpArt/SIGNed;
+              charSEt="iso-8859-11";
+              PROtOCoL="APPLIcATIOn/PKcS7-sIgnaTuRe";
+              MICAlG=Sha1;
+              boUnDARY=SignedBoundaryString
+Content-Transfer-Encoding: QuoTeD-pRINTablE
+X-Clacks-Overhead: GNU Terry Pratchett
+
+
+--SignedBoundaryString
+Content-Type: Text/PlAiN
+Content-Transfer-Encoding: quotEd-PRinTable
+
+=E0=BB=E7=B9=C1=B9=D8=C9=C2=EC=CA=D8=B4=BB=C3=D0=E0=CA=C3=D4=B0=E0=C5=D4=C8=
+=A4=D8=B3=A4=E8=D2 =A1=C7=E8=D2=BA=C3=C3=B4=D2=BD=D9=A7=CA=D1=B5=C7=EC=E0=
+=B4=C3=D1=A8=A9=D2=B9 =A8=A7=BD=E8=D2=BF=D1=B9=BE=D1=B2=B9=D2=C7=D4=AA=D2=
+=A1=D2=C3 =CD=C2=E8=D2=C5=E9=D2=A7=BC=C5=D2=AD=C4=E5=E0=A2=E8=B9=A6=E8=D2=
+=BA=D5=B1=D2=E3=A4=C3 =E4=C1=E8=B6=D7=CD=E2=B7=C9=E2=A1=C3=B8=E1=AA=E8=A7=
+=AB=D1=B4=CE=D6=B4=CE=D1=B4=B4=E8=D2 =CB=D1=B4=CD=C0=D1=C2=E0=CB=C1=D7=CD=
+=B9=A1=D5=CC=D2=CD=D1=AA=AC=D2=CA=D1=C2 =BB=AF=D4=BA=D1=B5=D4=BB=C3=D0=BE=
+=C4=B5=D4=A1=AE=A1=D3=CB=B9=B4=E3=A8 =BE=D9=B4=A8=D2=E3=CB=E9=A8=EA=D0=E6 =
+=A8=EB=D2=E6 =B9=E8=D2=BF=D1=A7=E0=CD=C2=CF
+
+=B9=D2=C2=CA=D1=A7=A6=C0=D1=B3=B1=EC =E0=CE=A7=BE=D4=B7=D1=A1=C9=EC=BD=D1=
+=E8=A7 =BC=D9=E9=E0=B2=E8=D2=AB=D6=E8=A7=C1=D5=CD=D2=AA=D5=BE=E0=BB=E7=B9=
+=A5=B9=A2=D2=C2=A3=C7=B4 =B6=D9=A1=B5=D3=C3=C7=A8=BB=AF=D4=BA=D1=B5=D4=A1=
+=D2=C3=A8=D1=BA=BF=E9=CD=A7=C8=D2=C5 =B0=D2=B9=C5=D1=A1=B9=D2=CC=D4=A1=D2=
+=A4=D8=B3=CB=AD=D4=A7=A9=D1=B5=C3=AA=AE=D2 =AC=D2=B9=CA=C1=D2=B8=D4
+
+--SignedBoundaryString
+Content-Type: aPpLiCATION/pkCs7-sIGNaTuRE; NAME=smime.p7s
+Content-Transfer-Encoding: baSE64
+Content-Disposition: aTTachMeNT; FilEname=smime.p7s
+
+ghyHhHUujhJhjH77n8HHGTrfvbnj756tbB9HG4VQpfyF467GhIGfHfYT64VQpfyF467GhIGfHfYT
+6jH77n8HHGghyHhHUujhJh756tbB9HGTrfvbnjn8HHGTrfvhJhjH776tbB9HG4VQbnj7567GhIGf
+HfYT6ghyHhHUujpfyF47GhIGfHfYT64VQbnj756
+
+--SignedBoundaryString--

--- a/tests/test_thai_multipart_signed_tis-620_over_base64.txt
+++ b/tests/test_thai_multipart_signed_tis-620_over_base64.txt
@@ -1,0 +1,59 @@
+Date: Mon, 01 Apr 2019 07:55:00 +0700 (+07)
+From: =?tiS-620?B?zcXUqyC82enK6KeotMvB0sI=?= <alis.phusngcdhmay@example.com>,
+ =?tiS-620?B?zcXUqyC82enK6KeotMvB0sI=?= <alis.phusngcdhmay@example.net>
+Sender: =?tiS-620?B?zcXUqyC82enK6KeotMvB0sI=?= <alis.phusngcdhmay@example.com>
+Reply-To: =?tiS-620?B?zcXUqyC82enK6KeotMvB0sI=?= <alis.phusngcdhmay@example.net>
+To: =?TIS-620?b?uurNuiC82enD0bo=?= <bob.phurab@example.com>,
+ =?tis-620?B?pNLiw8UgvNnpw9G6?= <carol.phurab@example.com>
+Cc: =?tis-620?b?4bS5ILzZ6cPRug==?= <dan.phurab@example.com>,
+ =?tIs-620?b?zdW/ILzZ6cPRug==?= <eve.phurab@example.com>
+Bcc: =?tiS-620?B?4b/Dp6TsILzZ6cPRug==?= <frank.phurab@example.com>,
+ =?TIS-620?b?4KHDqyC82enD0bo=?= <grace.phurab@example.com>
+Subject: =?UTF-8?B?8J+Tpw==?= Signed Test
+ =?TiS-620?B?4b654aHDwcDSydLkt8I=?=
+In-Reply-To: <Message-Id-0@example.com>
+References: <Message-Id-0@example.com>
+Message-ID: <Message-Id-1@example.com>
+Comments: Message Header Comment
+Keywords: Keyword 1, Keyword 2
+Resent-Date: Mon, 01 Apr 2019 07:55:00 +0700 (+07)
+Resent-From: =?tiS-620?B?zcXUqyC82enK6KeotMvB0sI=?= <alis.phusngcdhmay@example.net>,
+ =?tiS-620?B?zcXUqyC82enK6KeotMvB0sI=?= <alis.phusngcdhmay@example.com>
+Resent-Sender: =?tiS-620?B?zcXUqyC82enK6KeotMvB0sI=?= <alis.phusngcdhmay@example.net>
+Resent-To: =?TIS-620?b?uurNuiC82enD0bo=?= <bob.phurab@example.net>,
+ =?tis-620?B?pNLiw8UgvNnpw9G6?= <carol.phurab@example.net>
+Resent-Cc: =?tis-620?b?4bS5ILzZ6cPRug==?= <dan.phurab@example.net>,
+ =?tIs-620?b?zdW/ILzZ6cPRug==?= <eve.phurab@example.net>
+Resent-Bcc: =?tiS-620?B?4b/Dp6TsILzZ6cPRug==?= <frank.phurab@example.net>,
+ =?TIS-620?b?4KHDqyC82enD0bo=?= <grace.phurab@example.net>
+Resent-Message-ID: <Message-Id-1@example.net>
+Content-Type: muLTIpART/SIgnED;
+              CHaRSet="Tis-620";
+              PROTOcOl="applicAtioN/pKCs7-SIgnatUrE";
+              Micalg=sha1;
+              bounDary=SignedBoundaryString
+Content-Transfer-Encoding: BaSe64
+X-Clacks-Overhead: GNU Terry Pratchett
+
+
+--SignedBoundaryString
+Content-Type: teXt/Plain
+Content-Transfer-Encoding: BaSE64
+
+4LvnucG52MnC7MrYtLvD0ODKw9Sw4MXUyKTYs6To0iChx+jSusPDtNK92afK0bXH7OC0w9GoqdK5
+IKinvejSv9G5vtGyudLH1KrSodLDIM3C6NLF6dKnvMXSrcTl4KLouabo0rrVsdLjpMMg5MHottfN
+4rfJ4qHDuOGq6Ker0bTO1rTO0bS06NIgy9G0zcDRwuDLwdfNuaHVzNLN0aqs0srRwiC7r9S60bXU
+u8PQvsS11KGuodPLubTjqCC+2bSo0uPL6ajq0OYgqOvS5iC56NK/0afgzcLPCgq50sLK0aemwNGz
+sewg4M6nvtS30aHJ7L3R6KcgvNnp4LLo0qvW6KfB1c3SqtW+4LvnuaW5otLCo8e0ILbZobXTw8eo
+u6/UutG11KHSw6jRur/pzafI0sUgsNK5xdGhudLM1KHSpNizy63Up6nRtcOqrtIgrNK5ysHSuNQ
+
+--SignedBoundaryString
+Content-Type: apPliCaTioN/pKcS7-SiGNATuRe; namE=smime.p7s
+Content-Transfer-Encoding: bAsE64
+Content-Disposition: attaChmenT; FIlEnaMe=smime.p7s
+
+ghyHhHUujhJhjH77n8HHGTrfvbnj756tbB9HG4VQpfyF467GhIGfHfYT64VQpfyF467GhIGfHfYT
+6jH77n8HHGghyHhHUujhJh756tbB9HGTrfvbnjn8HHGTrfvhJhjH776tbB9HG4VQbnj7567GhIGf
+HfYT6ghyHhHUujpfyF47GhIGfHfYT64VQbnj756
+
+--SignedBoundaryString--

--- a/tests/test_thai_multipart_signed_tis-620_over_quoted-printable.txt
+++ b/tests/test_thai_multipart_signed_tis-620_over_quoted-printable.txt
@@ -1,0 +1,68 @@
+Date: Mon, 01 Apr 2019 07:55:00 +0700 (+07)
+From: =?Tis-620?q?=CD=C5=D4=AB_=BC=D9=E9=CA=E8=A7=A8=B4=CB=C1=D2=C2?= <alis.phusngcdhmay@example.com>,
+ =?Tis-620?q?=CD=C5=D4=AB_=BC=D9=E9=CA=E8=A7=A8=B4=CB=C1=D2=C2?= <alis.phusngcdhmay@example.net>
+Sender: =?Tis-620?q?=CD=C5=D4=AB_=BC=D9=E9=CA=E8=A7=A8=B4=CB=C1=D2=C2?= <alis.phusngcdhmay@example.com>
+Reply-To: =?Tis-620?q?=CD=C5=D4=AB_=BC=D9=E9=CA=E8=A7=A8=B4=CB=C1=D2=C2?= <alis.phusngcdhmay@example.net>
+To: =?tIs-620?q?=BA=EA=CD=BA_=BC=D9=E9=C3=D1=BA?= <bob.phurab@example.com>,
+ =?tis-620?Q?=A4=D2=E2=C3=C5_=BC=D9=E9=C3=D1=BA?= <carol.phurab@example.com>
+Cc: =?tiS-620?Q?=E1=B4=B9_=BC=D9=E9=C3=D1=BA?= <dan.phurab@example.com>,
+ =?tIS-620?q?=CD=D5=BF_=BC=D9=E9=C3=D1=BA?= <eve.phurab@example.com>
+Bcc: =?tIS-620?q?=E1=BF=C3=A7=A4=EC_=BC=D9=E9=C3=D1=BA?= <frank.phurab@example.com>,
+ =?TIS-620?q?=E0=A1=C3=AB_=BC=D9=E9=C3=D1=BA?= <grace.phurab@example.com>
+Subject: =?UTF-8?B?8J+Tpw==?= Signed Test
+ =?tis-620?Q?=E1=BE=B9=E1=A1=C3=C1=C0=D2=C9=D2=E4=B7=C2?=
+In-Reply-To: <Message-Id-0@example.com>
+References: <Message-Id-0@example.com>
+Message-ID: <Message-Id-1@example.com>
+Comments: Message Header Comment
+Keywords: Keyword 1, Keyword 2
+Resent-Date: Mon, 01 Apr 2019 07:55:00 +0700 (+07)
+Resent-From: =?Tis-620?q?=CD=C5=D4=AB_=BC=D9=E9=CA=E8=A7=A8=B4=CB=C1=D2=C2?= <alis.phusngcdhmay@example.net>,
+ =?Tis-620?q?=CD=C5=D4=AB_=BC=D9=E9=CA=E8=A7=A8=B4=CB=C1=D2=C2?= <alis.phusngcdhmay@example.com>
+Resent-Sender: =?Tis-620?q?=CD=C5=D4=AB_=BC=D9=E9=CA=E8=A7=A8=B4=CB=C1=D2=C2?= <alis.phusngcdhmay@example.net>
+Resent-To: =?tIs-620?q?=BA=EA=CD=BA_=BC=D9=E9=C3=D1=BA?= <bob.phurab@example.net>,
+ =?tis-620?Q?=A4=D2=E2=C3=C5_=BC=D9=E9=C3=D1=BA?= <carol.phurab@example.net>
+Resent-Cc: =?tiS-620?Q?=E1=B4=B9_=BC=D9=E9=C3=D1=BA?= <dan.phurab@example.net>,
+ =?tIS-620?q?=CD=D5=BF_=BC=D9=E9=C3=D1=BA?= <eve.phurab@example.net>
+Resent-Bcc: =?tIS-620?q?=E1=BF=C3=A7=A4=EC_=BC=D9=E9=C3=D1=BA?= <frank.phurab@example.net>,
+ =?TIS-620?q?=E0=A1=C3=AB_=BC=D9=E9=C3=D1=BA?= <grace.phurab@example.net>
+Resent-Message-ID: <Message-Id-1@example.net>
+Content-Type: MULTIpArT/SIGnED;
+              ChaRSET="tIS-620";
+              PRotocoL="ApPlIcatiOn/PKcS7-signatUre";
+              mICAlg=sHa1;
+              boUNdarY=SignedBoundaryString
+Content-Transfer-Encoding: QuOTeD-pRINTAbLE
+X-Clacks-Overhead: GNU Terry Pratchett
+
+
+--SignedBoundaryString
+Content-Type: tExt/PLain
+Content-Transfer-Encoding: QuoteD-PRiNTABLe
+
+=E0=BB=E7=B9=C1=B9=D8=C9=C2=EC=CA=D8=B4=BB=C3=D0=E0=CA=C3=D4=B0=E0=C5=D4=C8=
+=A4=D8=B3=A4=E8=D2 =A1=C7=E8=D2=BA=C3=C3=B4=D2=BD=D9=A7=CA=D1=B5=C7=EC=E0=
+=B4=C3=D1=A8=A9=D2=B9 =A8=A7=BD=E8=D2=BF=D1=B9=BE=D1=B2=B9=D2=C7=D4=AA=D2=
+=A1=D2=C3 =CD=C2=E8=D2=C5=E9=D2=A7=BC=C5=D2=AD=C4=E5=E0=A2=E8=B9=A6=E8=D2=
+=BA=D5=B1=D2=E3=A4=C3 =E4=C1=E8=B6=D7=CD=E2=B7=C9=E2=A1=C3=B8=E1=AA=E8=A7=
+=AB=D1=B4=CE=D6=B4=CE=D1=B4=B4=E8=D2 =CB=D1=B4=CD=C0=D1=C2=E0=CB=C1=D7=CD=
+=B9=A1=D5=CC=D2=CD=D1=AA=AC=D2=CA=D1=C2 =BB=AF=D4=BA=D1=B5=D4=BB=C3=D0=BE=
+=C4=B5=D4=A1=AE=A1=D3=CB=B9=B4=E3=A8 =BE=D9=B4=A8=D2=E3=CB=E9=A8=EA=D0=E6 =
+=A8=EB=D2=E6 =B9=E8=D2=BF=D1=A7=E0=CD=C2=CF
+
+=B9=D2=C2=CA=D1=A7=A6=C0=D1=B3=B1=EC =E0=CE=A7=BE=D4=B7=D1=A1=C9=EC=BD=D1=
+=E8=A7 =BC=D9=E9=E0=B2=E8=D2=AB=D6=E8=A7=C1=D5=CD=D2=AA=D5=BE=E0=BB=E7=B9=
+=A5=B9=A2=D2=C2=A3=C7=B4 =B6=D9=A1=B5=D3=C3=C7=A8=BB=AF=D4=BA=D1=B5=D4=A1=
+=D2=C3=A8=D1=BA=BF=E9=CD=A7=C8=D2=C5 =B0=D2=B9=C5=D1=A1=B9=D2=CC=D4=A1=D2=
+=A4=D8=B3=CB=AD=D4=A7=A9=D1=B5=C3=AA=AE=D2 =AC=D2=B9=CA=C1=D2=B8=D4
+
+--SignedBoundaryString
+Content-Type: ApPLIcaTIoN/pkcS7-sIgnaTuRE; NamE=smime.p7s
+Content-Transfer-Encoding: BASe64
+Content-Disposition: AttACHMenT; FILenAmE=smime.p7s
+
+ghyHhHUujhJhjH77n8HHGTrfvbnj756tbB9HG4VQpfyF467GhIGfHfYT64VQpfyF467GhIGfHfYT
+6jH77n8HHGghyHhHUujhJh756tbB9HGTrfvbnjn8HHGTrfvhJhjH776tbB9HG4VQbnj7567GhIGf
+HfYT6ghyHhHUujpfyF47GhIGfHfYT64VQbnj756
+
+--SignedBoundaryString--

--- a/tests/test_thai_multipart_signed_windows-874_over_base64.txt
+++ b/tests/test_thai_multipart_signed_windows-874_over_base64.txt
@@ -1,0 +1,60 @@
+Date: Mon, 01 Apr 2019 07:55:00 +0700 (+07)
+From: =?winDOWs-874?B?zcXUqyC82enK6KeotMvB0sI=?= <alis.phusngcdhmay@example.com>,
+ =?winDOWs-874?B?zcXUqyC82enK6KeotMvB0sI=?= <alis.phusngcdhmay@example.net>
+Sender: =?winDOWs-874?B?zcXUqyC82enK6KeotMvB0sI=?= <alis.phusngcdhmay@example.com>
+Reply-To: =?winDOWs-874?B?zcXUqyC82enK6KeotMvB0sI=?= <alis.phusngcdhmay@example.net>
+To: =?wINDows-874?b?uurNuiC82enD0bo=?= <bob.phurab@example.com>,
+ =?wiNDOwS-874?b?pNLiw8UgvNnpw9G6?= <carol.phurab@example.com>
+Cc: =?WINDOws-874?B?4bS5ILzZ6cPRug==?= <dan.phurab@example.com>,
+ =?wINdOWs-874?b?zdW/ILzZ6cPRug==?= <eve.phurab@example.com>
+Bcc: =?WinDoWs-874?b?4b/Dp6TsILzZ6cPRug==?= <frank.phurab@example.com>,
+ =?WinDOWS-874?b?4KHDqyC82enD0bo=?= <grace.phurab@example.com>
+Subject: =?UTF-8?B?8J+Tpw==?= Signed Test
+ =?wiNDOwS-874?B?4b654aHDwcDSydLkt8I=?=
+In-Reply-To: <Message-Id-0@example.com>
+References: <Message-Id-0@example.com>
+Message-ID: <Message-Id-1@example.com>
+Comments: Message Header Comment
+Keywords: Keyword 1, Keyword 2
+Resent-Date: Mon, 01 Apr 2019 07:55:00 +0700 (+07)
+Resent-From: =?winDOWs-874?B?zcXUqyC82enK6KeotMvB0sI=?= <alis.phusngcdhmay@example.net>,
+ =?winDOWs-874?B?zcXUqyC82enK6KeotMvB0sI=?= <alis.phusngcdhmay@example.com>
+Resent-Sender: =?winDOWs-874?B?zcXUqyC82enK6KeotMvB0sI=?= <alis.phusngcdhmay@example.net>
+Resent-To: =?wINDows-874?b?uurNuiC82enD0bo=?= <bob.phurab@example.net>,
+ =?wiNDOwS-874?b?pNLiw8UgvNnpw9G6?= <carol.phurab@example.net>
+Resent-Cc: =?WINDOws-874?B?4bS5ILzZ6cPRug==?= <dan.phurab@example.net>,
+ =?wINdOWs-874?b?zdW/ILzZ6cPRug==?= <eve.phurab@example.net>
+Resent-Bcc: =?WinDoWs-874?b?4b/Dp6TsILzZ6cPRug==?= <frank.phurab@example.net>,
+ =?WinDOWS-874?b?4KHDqyC82enD0bo=?= <grace.phurab@example.net>
+Resent-Message-ID: <Message-Id-1@example.net>
+Content-Type: MuLTIPARt/sIGnED;
+              ChaRsET="WindoWs-874";
+              prOTocOl="APpLicATIon/PKcs7-SIGnATUre";
+              MIcaLg=shA1;
+              boUnDAry=SignedBoundaryString
+Content-Transfer-Encoding: bASe64
+X-Clacks-Overhead: GNU Terry Pratchett
+
+
+--SignedBoundaryString
+Content-Type: teXT/plaiN
+Content-Transfer-Encoding: BaSE64
+
+4LvnucG52MnC7MrYtLvD0ODKw9Sw4MXUyKTYs6To0iChx+jSusPDtNK92afK0bXH7OC0w9GoqdK5
+IKinvejSv9G5vtGyudLH1KrSodLDIM3C6NLF6dKnvMXSrcTl4KLouabo0rrVsdLjpMMg5MHottfN
+4rfJ4qHDuOGq6Ker0bTO1rTO0bS06NIgy9G0zcDRwuDLwdfNuaHVzNLN0aqs0srRwiC7r9S60bXU
+u8PQvsS11KGuodPLubTjqCC+2bSo0uPL6ajq0OYgqOvS5iC56NK/0afgzcLPCgq50sLK0aemwNGz
+sewg4M6nvtS30aHJ7L3R6KcgvNnp4LLo0qvW6KfB1c3SqtW+4LvnuaW5otLCo8e0ILbZobXTw8eo
+u6/UutG11KHSw6jRur/pzafI0sUgsNK5xdGhudLM1KHSpNizy63Up6nRtcOqrtIgrNK5ysHSuNQ=
+
+
+--SignedBoundaryString
+Content-Type: ApPLiCaTiON/pKCS7-signaTUre; name=smime.p7s
+Content-Transfer-Encoding: BaSE64
+Content-Disposition: attaCHmenT; FIlENAMe=smime.p7s
+
+ghyHhHUujhJhjH77n8HHGTrfvbnj756tbB9HG4VQpfyF467GhIGfHfYT64VQpfyF467GhIGfHfYT
+6jH77n8HHGghyHhHUujhJh756tbB9HGTrfvbnjn8HHGTrfvhJhjH776tbB9HG4VQbnj7567GhIGf
+HfYT6ghyHhHUujpfyF47GhIGfHfYT64VQbnj756
+
+--SignedBoundaryString--

--- a/tests/test_thai_multipart_signed_windows-874_over_quoted-printable.txt
+++ b/tests/test_thai_multipart_signed_windows-874_over_quoted-printable.txt
@@ -1,0 +1,68 @@
+Date: Mon, 01 Apr 2019 07:55:00 +0700 (+07)
+From: =?WINdOWS-874?Q?=CD=C5=D4=AB_=BC=D9=E9=CA=E8=A7=A8=B4=CB=C1=D2=C2?= <alis.phusngcdhmay@example.com>,
+ =?WINdOWS-874?Q?=CD=C5=D4=AB_=BC=D9=E9=CA=E8=A7=A8=B4=CB=C1=D2=C2?= <alis.phusngcdhmay@example.net>
+Sender: =?WINdOWS-874?Q?=CD=C5=D4=AB_=BC=D9=E9=CA=E8=A7=A8=B4=CB=C1=D2=C2?= <alis.phusngcdhmay@example.com>
+Reply-To: =?WINdOWS-874?Q?=CD=C5=D4=AB_=BC=D9=E9=CA=E8=A7=A8=B4=CB=C1=D2=C2?= <alis.phusngcdhmay@example.net>
+To: =?wINDOws-874?q?=BA=EA=CD=BA_=BC=D9=E9=C3=D1=BA?= <bob.phurab@example.com>,
+ =?wIndowS-874?q?=A4=D2=E2=C3=C5_=BC=D9=E9=C3=D1=BA?= <carol.phurab@example.com>
+Cc: =?wINdoWs-874?Q?=E1=B4=B9_=BC=D9=E9=C3=D1=BA?= <dan.phurab@example.com>,
+ =?wINdoWs-874?Q?=CD=D5=BF_=BC=D9=E9=C3=D1=BA?= <eve.phurab@example.com>
+Bcc: =?wiNdOWs-874?Q?=E1=BF=C3=A7=A4=EC_=BC=D9=E9=C3=D1=BA?= <frank.phurab@example.com>,
+ =?windowS-874?q?=E0=A1=C3=AB_=BC=D9=E9=C3=D1=BA?= <grace.phurab@example.com>
+Subject: =?UTF-8?B?8J+Tpw==?= Signed Test
+ =?wIndoWS-874?Q?=E1=BE=B9=E1=A1=C3=C1=C0=D2=C9=D2=E4=B7=C2?=
+In-Reply-To: <Message-Id-0@example.com>
+References: <Message-Id-0@example.com>
+Message-ID: <Message-Id-1@example.com>
+Comments: Message Header Comment
+Keywords: Keyword 1, Keyword 2
+Resent-Date: Mon, 01 Apr 2019 07:55:00 +0700 (+07)
+Resent-From: =?WINdOWS-874?Q?=CD=C5=D4=AB_=BC=D9=E9=CA=E8=A7=A8=B4=CB=C1=D2=C2?= <alis.phusngcdhmay@example.net>,
+ =?WINdOWS-874?Q?=CD=C5=D4=AB_=BC=D9=E9=CA=E8=A7=A8=B4=CB=C1=D2=C2?= <alis.phusngcdhmay@example.com>
+Resent-Sender: =?WINdOWS-874?Q?=CD=C5=D4=AB_=BC=D9=E9=CA=E8=A7=A8=B4=CB=C1=D2=C2?= <alis.phusngcdhmay@example.net>
+Resent-To: =?wINDOws-874?q?=BA=EA=CD=BA_=BC=D9=E9=C3=D1=BA?= <bob.phurab@example.net>,
+ =?wIndowS-874?q?=A4=D2=E2=C3=C5_=BC=D9=E9=C3=D1=BA?= <carol.phurab@example.net>
+Resent-Cc: =?wINdoWs-874?Q?=E1=B4=B9_=BC=D9=E9=C3=D1=BA?= <dan.phurab@example.net>,
+ =?wINdoWs-874?Q?=CD=D5=BF_=BC=D9=E9=C3=D1=BA?= <eve.phurab@example.net>
+Resent-Bcc: =?wiNdOWs-874?Q?=E1=BF=C3=A7=A4=EC_=BC=D9=E9=C3=D1=BA?= <frank.phurab@example.net>,
+ =?windowS-874?q?=E0=A1=C3=AB_=BC=D9=E9=C3=D1=BA?= <grace.phurab@example.net>
+Resent-Message-ID: <Message-Id-1@example.net>
+Content-Type: MULtiParT/sIgNed;
+              ChaRseT="WInDoWs-874";
+              pRotocOl="aPPlIcATioN/PKCs7-SignAtUre";
+              mICAlG=sHA1;
+              bOuNDaRy=SignedBoundaryString
+Content-Transfer-Encoding: qUoTED-pRINtaBle
+X-Clacks-Overhead: GNU Terry Pratchett
+
+
+--SignedBoundaryString
+Content-Type: tExt/PlAiN
+Content-Transfer-Encoding: quoTeD-pRINtabLe
+
+=E0=BB=E7=B9=C1=B9=D8=C9=C2=EC=CA=D8=B4=BB=C3=D0=E0=CA=C3=D4=B0=E0=C5=D4=C8=
+=A4=D8=B3=A4=E8=D2 =A1=C7=E8=D2=BA=C3=C3=B4=D2=BD=D9=A7=CA=D1=B5=C7=EC=E0=
+=B4=C3=D1=A8=A9=D2=B9 =A8=A7=BD=E8=D2=BF=D1=B9=BE=D1=B2=B9=D2=C7=D4=AA=D2=
+=A1=D2=C3 =CD=C2=E8=D2=C5=E9=D2=A7=BC=C5=D2=AD=C4=E5=E0=A2=E8=B9=A6=E8=D2=
+=BA=D5=B1=D2=E3=A4=C3 =E4=C1=E8=B6=D7=CD=E2=B7=C9=E2=A1=C3=B8=E1=AA=E8=A7=
+=AB=D1=B4=CE=D6=B4=CE=D1=B4=B4=E8=D2 =CB=D1=B4=CD=C0=D1=C2=E0=CB=C1=D7=CD=
+=B9=A1=D5=CC=D2=CD=D1=AA=AC=D2=CA=D1=C2 =BB=AF=D4=BA=D1=B5=D4=BB=C3=D0=BE=
+=C4=B5=D4=A1=AE=A1=D3=CB=B9=B4=E3=A8 =BE=D9=B4=A8=D2=E3=CB=E9=A8=EA=D0=E6 =
+=A8=EB=D2=E6 =B9=E8=D2=BF=D1=A7=E0=CD=C2=CF
+
+=B9=D2=C2=CA=D1=A7=A6=C0=D1=B3=B1=EC =E0=CE=A7=BE=D4=B7=D1=A1=C9=EC=BD=D1=
+=E8=A7 =BC=D9=E9=E0=B2=E8=D2=AB=D6=E8=A7=C1=D5=CD=D2=AA=D5=BE=E0=BB=E7=B9=
+=A5=B9=A2=D2=C2=A3=C7=B4 =B6=D9=A1=B5=D3=C3=C7=A8=BB=AF=D4=BA=D1=B5=D4=A1=
+=D2=C3=A8=D1=BA=BF=E9=CD=A7=C8=D2=C5 =B0=D2=B9=C5=D1=A1=B9=D2=CC=D4=A1=D2=
+=A4=D8=B3=CB=AD=D4=A7=A9=D1=B5=C3=AA=AE=D2 =AC=D2=B9=CA=C1=D2=B8=D4
+
+--SignedBoundaryString
+Content-Type: apPLiCATIon/pkCS7-SIgNaTuRe; naMe=smime.p7s
+Content-Transfer-Encoding: bASE64
+Content-Disposition: attAChMeNt; FIlenAme=smime.p7s
+
+ghyHhHUujhJhjH77n8HHGTrfvbnj756tbB9HG4VQpfyF467GhIGfHfYT64VQpfyF467GhIGfHfYT
+6jH77n8HHGghyHhHUujhJh756tbB9HGTrfvbnjn8HHGTrfvhJhjH776tbB9HG4VQbnj7567GhIGf
+HfYT6ghyHhHUujpfyF47GhIGfHfYT64VQbnj756
+
+--SignedBoundaryString--

--- a/tests/test_thai_plaintext_iso-8859-11_over_base64.txt
+++ b/tests/test_thai_plaintext_iso-8859-11_over_base64.txt
@@ -1,0 +1,40 @@
+Date: Mon, 01 Apr 2019 07:55:00 +0700 (+07)
+From: =?IsO-8859-11?B?zcXUqyC82enK6KeotMvB0sI=?= <alis.phusngcdhmay@example.com>,
+ =?IsO-8859-11?B?zcXUqyC82enK6KeotMvB0sI=?= <alis.phusngcdhmay@example.net>
+Sender: =?IsO-8859-11?B?zcXUqyC82enK6KeotMvB0sI=?= <alis.phusngcdhmay@example.com>
+Reply-To: =?IsO-8859-11?B?zcXUqyC82enK6KeotMvB0sI=?= <alis.phusngcdhmay@example.net>
+To: =?ISO-8859-11?b?uurNuiC82enD0bo=?= <bob.phurab@example.com>,
+ =?Iso-8859-11?B?pNLiw8UgvNnpw9G6?= <carol.phurab@example.com>
+Cc: =?iso-8859-11?b?4bS5ILzZ6cPRug==?= <dan.phurab@example.com>,
+ =?iSo-8859-11?B?zdW/ILzZ6cPRug==?= <eve.phurab@example.com>
+Bcc: =?Iso-8859-11?b?4b/Dp6TsILzZ6cPRug==?= <frank.phurab@example.com>,
+ =?iSO-8859-11?b?4KHDqyC82enD0bo=?= <grace.phurab@example.com>
+Subject: =?UTF-8?B?8J+Tpw==?= Test
+ =?iSO-8859-11?b?4b654aHDwcDSydLkt8I=?=
+In-Reply-To: <Message-Id-0@example.com>
+References: <Message-Id-0@example.com>
+Message-ID: <Message-Id-1@example.com>
+Comments: Message Header Comment
+Keywords: Keyword 1, Keyword 2
+Resent-Date: Mon, 01 Apr 2019 07:55:00 +0700 (+07)
+Resent-From: =?IsO-8859-11?B?zcXUqyC82enK6KeotMvB0sI=?= <alis.phusngcdhmay@example.net>,
+ =?IsO-8859-11?B?zcXUqyC82enK6KeotMvB0sI=?= <alis.phusngcdhmay@example.com>
+Resent-Sender: =?IsO-8859-11?B?zcXUqyC82enK6KeotMvB0sI=?= <alis.phusngcdhmay@example.net>
+Resent-To: =?ISO-8859-11?b?uurNuiC82enD0bo=?= <bob.phurab@example.net>,
+ =?Iso-8859-11?B?pNLiw8UgvNnpw9G6?= <carol.phurab@example.net>
+Resent-Cc: =?iso-8859-11?b?4bS5ILzZ6cPRug==?= <dan.phurab@example.net>,
+ =?iSo-8859-11?B?zdW/ILzZ6cPRug==?= <eve.phurab@example.net>
+Resent-Bcc: =?Iso-8859-11?b?4b/Dp6TsILzZ6cPRug==?= <frank.phurab@example.net>,
+ =?iSO-8859-11?b?4KHDqyC82enD0bo=?= <grace.phurab@example.net>
+Resent-Message-ID: <Message-Id-1@example.net>
+Content-Type: TeXt/pLaIn; chARseT=iso-8859-11
+Content-Transfer-Encoding: base64
+X-Clacks-Overhead: GNU Terry Pratchett
+
+
+4LvnucG52MnC7MrYtLvD0ODKw9Sw4MXUyKTYs6To0iChx+jSusPDtNK92afK0bXH7OC0w9GoqdK5
+IKinvejSv9G5vtGyudLH1KrSodLDIM3C6NLF6dKnvMXSrcTl4KLouabo0rrVsdLjpMMg5MHottfN
+4rfJ4qHDuOGq6Ker0bTO1rTO0bS06NIgy9G0zcDRwuDLwdfNuaHVzNLN0aqs0srRwiC7r9S60bXU
+u8PQvsS11KGuodPLubTjqCC+2bSo0uPL6ajq0OYgqOvS5iC56NK/0afgzcLPCgq50sLK0aemwNGz
+sewg4M6nvtS30aHJ7L3R6KcgvNnp4LLo0qvW6KfB1c3SqtW+4LvnuaW5otLCo8e0ILbZobXTw8eo
+u6/UutG11KHSw6jRur/pzafI0sUgsNK5xdGhudLM1KHSpNizy63Up6nRtcOqrtIgrNK5ysHSuNQ

--- a/tests/test_thai_plaintext_iso-8859-11_over_quoted-printable.txt
+++ b/tests/test_thai_plaintext_iso-8859-11_over_quoted-printable.txt
@@ -1,0 +1,49 @@
+Date: Mon, 01 Apr 2019 07:55:00 +0700 (+07)
+From: =?Iso-8859-11?Q?=CD=C5=D4=AB_=BC=D9=E9=CA=E8=A7=A8=B4=CB=C1=D2=C2?= <alis.phusngcdhmay@example.com>,
+ =?Iso-8859-11?Q?=CD=C5=D4=AB_=BC=D9=E9=CA=E8=A7=A8=B4=CB=C1=D2=C2?= <alis.phusngcdhmay@example.net>
+Sender: =?Iso-8859-11?Q?=CD=C5=D4=AB_=BC=D9=E9=CA=E8=A7=A8=B4=CB=C1=D2=C2?= <alis.phusngcdhmay@example.com>
+Reply-To: =?Iso-8859-11?Q?=CD=C5=D4=AB_=BC=D9=E9=CA=E8=A7=A8=B4=CB=C1=D2=C2?= <alis.phusngcdhmay@example.net>
+To: =?iSO-8859-11?Q?=BA=EA=CD=BA_=BC=D9=E9=C3=D1=BA?= <bob.phurab@example.com>,
+ =?iso-8859-11?q?=A4=D2=E2=C3=C5_=BC=D9=E9=C3=D1=BA?= <carol.phurab@example.com>
+Cc: =?isO-8859-11?q?=E1=B4=B9_=BC=D9=E9=C3=D1=BA?= <dan.phurab@example.com>,
+ =?IsO-8859-11?Q?=CD=D5=BF_=BC=D9=E9=C3=D1=BA?= <eve.phurab@example.com>
+Bcc: =?ISO-8859-11?q?=E1=BF=C3=A7=A4=EC_=BC=D9=E9=C3=D1=BA?= <frank.phurab@example.com>,
+ =?iSO-8859-11?q?=E0=A1=C3=AB_=BC=D9=E9=C3=D1=BA?= <grace.phurab@example.com>
+Subject: =?UTF-8?B?8J+Tpw==?= Test
+ =?ISo-8859-11?q?=E1=BE=B9=E1=A1=C3=C1=C0=D2=C9=D2=E4=B7=C2?=
+In-Reply-To: <Message-Id-0@example.com>
+References: <Message-Id-0@example.com>
+Message-ID: <Message-Id-1@example.com>
+Comments: Message Header Comment
+Keywords: Keyword 1, Keyword 2
+Resent-Date: Mon, 01 Apr 2019 07:55:00 +0700 (+07)
+Resent-From: =?Iso-8859-11?Q?=CD=C5=D4=AB_=BC=D9=E9=CA=E8=A7=A8=B4=CB=C1=D2=C2?= <alis.phusngcdhmay@example.net>,
+ =?Iso-8859-11?Q?=CD=C5=D4=AB_=BC=D9=E9=CA=E8=A7=A8=B4=CB=C1=D2=C2?= <alis.phusngcdhmay@example.com>
+Resent-Sender: =?Iso-8859-11?Q?=CD=C5=D4=AB_=BC=D9=E9=CA=E8=A7=A8=B4=CB=C1=D2=C2?= <alis.phusngcdhmay@example.net>
+Resent-To: =?iSO-8859-11?Q?=BA=EA=CD=BA_=BC=D9=E9=C3=D1=BA?= <bob.phurab@example.net>,
+ =?iso-8859-11?q?=A4=D2=E2=C3=C5_=BC=D9=E9=C3=D1=BA?= <carol.phurab@example.net>
+Resent-Cc: =?isO-8859-11?q?=E1=B4=B9_=BC=D9=E9=C3=D1=BA?= <dan.phurab@example.net>,
+ =?IsO-8859-11?Q?=CD=D5=BF_=BC=D9=E9=C3=D1=BA?= <eve.phurab@example.net>
+Resent-Bcc: =?ISO-8859-11?q?=E1=BF=C3=A7=A4=EC_=BC=D9=E9=C3=D1=BA?= <frank.phurab@example.net>,
+ =?iSO-8859-11?q?=E0=A1=C3=AB_=BC=D9=E9=C3=D1=BA?= <grace.phurab@example.net>
+Resent-Message-ID: <Message-Id-1@example.net>
+Content-Type: tExt/plAIN; charsEt=IsO-8859-11
+Content-Transfer-Encoding: QuoteD-PrINTaBle
+X-Clacks-Overhead: GNU Terry Pratchett
+
+
+=E0=BB=E7=B9=C1=B9=D8=C9=C2=EC=CA=D8=B4=BB=C3=D0=E0=CA=C3=D4=B0=E0=C5=D4=C8=
+=A4=D8=B3=A4=E8=D2 =A1=C7=E8=D2=BA=C3=C3=B4=D2=BD=D9=A7=CA=D1=B5=C7=EC=E0=
+=B4=C3=D1=A8=A9=D2=B9 =A8=A7=BD=E8=D2=BF=D1=B9=BE=D1=B2=B9=D2=C7=D4=AA=D2=
+=A1=D2=C3 =CD=C2=E8=D2=C5=E9=D2=A7=BC=C5=D2=AD=C4=E5=E0=A2=E8=B9=A6=E8=D2=
+=BA=D5=B1=D2=E3=A4=C3 =E4=C1=E8=B6=D7=CD=E2=B7=C9=E2=A1=C3=B8=E1=AA=E8=A7=
+=AB=D1=B4=CE=D6=B4=CE=D1=B4=B4=E8=D2 =CB=D1=B4=CD=C0=D1=C2=E0=CB=C1=D7=CD=
+=B9=A1=D5=CC=D2=CD=D1=AA=AC=D2=CA=D1=C2 =BB=AF=D4=BA=D1=B5=D4=BB=C3=D0=BE=
+=C4=B5=D4=A1=AE=A1=D3=CB=B9=B4=E3=A8 =BE=D9=B4=A8=D2=E3=CB=E9=A8=EA=D0=E6 =
+=A8=EB=D2=E6 =B9=E8=D2=BF=D1=A7=E0=CD=C2=CF
+
+=B9=D2=C2=CA=D1=A7=A6=C0=D1=B3=B1=EC =E0=CE=A7=BE=D4=B7=D1=A1=C9=EC=BD=D1=
+=E8=A7 =BC=D9=E9=E0=B2=E8=D2=AB=D6=E8=A7=C1=D5=CD=D2=AA=D5=BE=E0=BB=E7=B9=
+=A5=B9=A2=D2=C2=A3=C7=B4 =B6=D9=A1=B5=D3=C3=C7=A8=BB=AF=D4=BA=D1=B5=D4=A1=
+=D2=C3=A8=D1=BA=BF=E9=CD=A7=C8=D2=C5 =B0=D2=B9=C5=D1=A1=B9=D2=CC=D4=A1=D2=
+=A4=D8=B3=CB=AD=D4=A7=A9=D1=B5=C3=AA=AE=D2 =AC=D2=B9=CA=C1=D2=B8=D4

--- a/tests/test_thai_plaintext_tis-620_over_base64.txt
+++ b/tests/test_thai_plaintext_tis-620_over_base64.txt
@@ -1,0 +1,40 @@
+Date: Mon, 01 Apr 2019 07:55:00 +0700 (+07)
+From: =?Tis-620?B?zcXUqyC82enK6KeotMvB0sI=?= <alis.phusngcdhmay@example.com>,
+ =?Tis-620?B?zcXUqyC82enK6KeotMvB0sI=?= <alis.phusngcdhmay@example.net>
+Sender: =?Tis-620?B?zcXUqyC82enK6KeotMvB0sI=?= <alis.phusngcdhmay@example.com>
+Reply-To: =?Tis-620?B?zcXUqyC82enK6KeotMvB0sI=?= <alis.phusngcdhmay@example.net>
+To: =?tIS-620?b?uurNuiC82enD0bo=?= <bob.phurab@example.com>,
+ =?tIS-620?B?pNLiw8UgvNnpw9G6?= <carol.phurab@example.com>
+Cc: =?TiS-620?B?4bS5ILzZ6cPRug==?= <dan.phurab@example.com>,
+ =?TIs-620?B?zdW/ILzZ6cPRug==?= <eve.phurab@example.com>
+Bcc: =?TiS-620?B?4b/Dp6TsILzZ6cPRug==?= <frank.phurab@example.com>,
+ =?tis-620?B?4KHDqyC82enD0bo=?= <grace.phurab@example.com>
+Subject: =?UTF-8?B?8J+Tpw==?= Test
+ =?TIs-620?B?4b654aHDwcDSydLkt8I=?=
+In-Reply-To: <Message-Id-0@example.com>
+References: <Message-Id-0@example.com>
+Message-ID: <Message-Id-1@example.com>
+Comments: Message Header Comment
+Keywords: Keyword 1, Keyword 2
+Resent-Date: Mon, 01 Apr 2019 07:55:00 +0700 (+07)
+Resent-From: =?Tis-620?B?zcXUqyC82enK6KeotMvB0sI=?= <alis.phusngcdhmay@example.net>,
+ =?Tis-620?B?zcXUqyC82enK6KeotMvB0sI=?= <alis.phusngcdhmay@example.com>
+Resent-Sender: =?Tis-620?B?zcXUqyC82enK6KeotMvB0sI=?= <alis.phusngcdhmay@example.net>
+Resent-To: =?tIS-620?b?uurNuiC82enD0bo=?= <bob.phurab@example.net>,
+ =?tIS-620?B?pNLiw8UgvNnpw9G6?= <carol.phurab@example.net>
+Resent-Cc: =?TiS-620?B?4bS5ILzZ6cPRug==?= <dan.phurab@example.net>,
+ =?TIs-620?B?zdW/ILzZ6cPRug==?= <eve.phurab@example.net>
+Resent-Bcc: =?TiS-620?B?4b/Dp6TsILzZ6cPRug==?= <frank.phurab@example.net>,
+ =?tis-620?B?4KHDqyC82enD0bo=?= <grace.phurab@example.net>
+Resent-Message-ID: <Message-Id-1@example.net>
+Content-Type: tEXT/pLAIN; charset=TiS-620
+Content-Transfer-Encoding: BAsE64
+X-Clacks-Overhead: GNU Terry Pratchett
+
+
+4LvnucG52MnC7MrYtLvD0ODKw9Sw4MXUyKTYs6To0iChx+jSusPDtNK92afK0bXH7OC0w9GoqdK5
+IKinvejSv9G5vtGyudLH1KrSodLDIM3C6NLF6dKnvMXSrcTl4KLouabo0rrVsdLjpMMg5MHottfN
+4rfJ4qHDuOGq6Ker0bTO1rTO0bS06NIgy9G0zcDRwuDLwdfNuaHVzNLN0aqs0srRwiC7r9S60bXU
+u8PQvsS11KGuodPLubTjqCC+2bSo0uPL6ajq0OYgqOvS5iC56NK/0afgzcLPCgq50sLK0aemwNGz
+sewg4M6nvtS30aHJ7L3R6KcgvNnp4LLo0qvW6KfB1c3SqtW+4LvnuaW5otLCo8e0ILbZobXTw8eo
+u6/UutG11KHSw6jRur/pzafI0sUgsNK5xdGhudLM1KHSpNizy63Up6nRtcOqrtIgrNK5ysHSuNQ=

--- a/tests/test_thai_plaintext_tis-620_over_quoted-printable.txt
+++ b/tests/test_thai_plaintext_tis-620_over_quoted-printable.txt
@@ -1,0 +1,49 @@
+Date: Mon, 01 Apr 2019 07:55:00 +0700 (+07)
+From: =?tis-620?q?=CD=C5=D4=AB_=BC=D9=E9=CA=E8=A7=A8=B4=CB=C1=D2=C2?= <alis.phusngcdhmay@example.com>,
+ =?tis-620?q?=CD=C5=D4=AB_=BC=D9=E9=CA=E8=A7=A8=B4=CB=C1=D2=C2?= <alis.phusngcdhmay@example.net>
+Sender: =?tis-620?q?=CD=C5=D4=AB_=BC=D9=E9=CA=E8=A7=A8=B4=CB=C1=D2=C2?= <alis.phusngcdhmay@example.com>
+Reply-To: =?tis-620?q?=CD=C5=D4=AB_=BC=D9=E9=CA=E8=A7=A8=B4=CB=C1=D2=C2?= <alis.phusngcdhmay@example.net>
+To: =?Tis-620?Q?=BA=EA=CD=BA_=BC=D9=E9=C3=D1=BA?= <bob.phurab@example.com>,
+ =?TIS-620?Q?=A4=D2=E2=C3=C5_=BC=D9=E9=C3=D1=BA?= <carol.phurab@example.com>
+Cc: =?TiS-620?q?=E1=B4=B9_=BC=D9=E9=C3=D1=BA?= <dan.phurab@example.com>,
+ =?TIs-620?q?=CD=D5=BF_=BC=D9=E9=C3=D1=BA?= <eve.phurab@example.com>
+Bcc: =?tIs-620?q?=E1=BF=C3=A7=A4=EC_=BC=D9=E9=C3=D1=BA?= <frank.phurab@example.com>,
+ =?tiS-620?Q?=E0=A1=C3=AB_=BC=D9=E9=C3=D1=BA?= <grace.phurab@example.com>
+Subject: =?UTF-8?B?8J+Tpw==?= Test
+ =?tiS-620?Q?=E1=BE=B9=E1=A1=C3=C1=C0=D2=C9=D2=E4=B7=C2?=
+In-Reply-To: <Message-Id-0@example.com>
+References: <Message-Id-0@example.com>
+Message-ID: <Message-Id-1@example.com>
+Comments: Message Header Comment
+Keywords: Keyword 1, Keyword 2
+Resent-Date: Mon, 01 Apr 2019 07:55:00 +0700 (+07)
+Resent-From: =?tis-620?q?=CD=C5=D4=AB_=BC=D9=E9=CA=E8=A7=A8=B4=CB=C1=D2=C2?= <alis.phusngcdhmay@example.net>,
+ =?tis-620?q?=CD=C5=D4=AB_=BC=D9=E9=CA=E8=A7=A8=B4=CB=C1=D2=C2?= <alis.phusngcdhmay@example.com>
+Resent-Sender: =?tis-620?q?=CD=C5=D4=AB_=BC=D9=E9=CA=E8=A7=A8=B4=CB=C1=D2=C2?= <alis.phusngcdhmay@example.net>
+Resent-To: =?Tis-620?Q?=BA=EA=CD=BA_=BC=D9=E9=C3=D1=BA?= <bob.phurab@example.net>,
+ =?TIS-620?Q?=A4=D2=E2=C3=C5_=BC=D9=E9=C3=D1=BA?= <carol.phurab@example.net>
+Resent-Cc: =?TiS-620?q?=E1=B4=B9_=BC=D9=E9=C3=D1=BA?= <dan.phurab@example.net>,
+ =?TIs-620?q?=CD=D5=BF_=BC=D9=E9=C3=D1=BA?= <eve.phurab@example.net>
+Resent-Bcc: =?tIs-620?q?=E1=BF=C3=A7=A4=EC_=BC=D9=E9=C3=D1=BA?= <frank.phurab@example.net>,
+ =?tiS-620?Q?=E0=A1=C3=AB_=BC=D9=E9=C3=D1=BA?= <grace.phurab@example.net>
+Resent-Message-ID: <Message-Id-1@example.net>
+Content-Type: teXT/Plain; charsET=tIs-620
+Content-Transfer-Encoding: qUoTED-pRiNTabLE
+X-Clacks-Overhead: GNU Terry Pratchett
+
+
+=E0=BB=E7=B9=C1=B9=D8=C9=C2=EC=CA=D8=B4=BB=C3=D0=E0=CA=C3=D4=B0=E0=C5=D4=C8=
+=A4=D8=B3=A4=E8=D2 =A1=C7=E8=D2=BA=C3=C3=B4=D2=BD=D9=A7=CA=D1=B5=C7=EC=E0=
+=B4=C3=D1=A8=A9=D2=B9 =A8=A7=BD=E8=D2=BF=D1=B9=BE=D1=B2=B9=D2=C7=D4=AA=D2=
+=A1=D2=C3 =CD=C2=E8=D2=C5=E9=D2=A7=BC=C5=D2=AD=C4=E5=E0=A2=E8=B9=A6=E8=D2=
+=BA=D5=B1=D2=E3=A4=C3 =E4=C1=E8=B6=D7=CD=E2=B7=C9=E2=A1=C3=B8=E1=AA=E8=A7=
+=AB=D1=B4=CE=D6=B4=CE=D1=B4=B4=E8=D2 =CB=D1=B4=CD=C0=D1=C2=E0=CB=C1=D7=CD=
+=B9=A1=D5=CC=D2=CD=D1=AA=AC=D2=CA=D1=C2 =BB=AF=D4=BA=D1=B5=D4=BB=C3=D0=BE=
+=C4=B5=D4=A1=AE=A1=D3=CB=B9=B4=E3=A8 =BE=D9=B4=A8=D2=E3=CB=E9=A8=EA=D0=E6 =
+=A8=EB=D2=E6 =B9=E8=D2=BF=D1=A7=E0=CD=C2=CF
+
+=B9=D2=C2=CA=D1=A7=A6=C0=D1=B3=B1=EC =E0=CE=A7=BE=D4=B7=D1=A1=C9=EC=BD=D1=
+=E8=A7 =BC=D9=E9=E0=B2=E8=D2=AB=D6=E8=A7=C1=D5=CD=D2=AA=D5=BE=E0=BB=E7=B9=
+=A5=B9=A2=D2=C2=A3=C7=B4 =B6=D9=A1=B5=D3=C3=C7=A8=BB=AF=D4=BA=D1=B5=D4=A1=
+=D2=C3=A8=D1=BA=BF=E9=CD=A7=C8=D2=C5 =B0=D2=B9=C5=D1=A1=B9=D2=CC=D4=A1=D2=
+=A4=D8=B3=CB=AD=D4=A7=A9=D1=B5=C3=AA=AE=D2 =AC=D2=B9=CA=C1=D2=B8=D4

--- a/tests/test_thai_plaintext_windows-874_over_base64.txt
+++ b/tests/test_thai_plaintext_windows-874_over_base64.txt
@@ -1,0 +1,40 @@
+Date: Mon, 01 Apr 2019 07:55:00 +0700 (+07)
+From: =?WiNdOWs-874?B?zcXUqyC82enK6KeotMvB0sI=?= <alis.phusngcdhmay@example.com>,
+ =?WiNdOWs-874?B?zcXUqyC82enK6KeotMvB0sI=?= <alis.phusngcdhmay@example.net>
+Sender: =?WiNdOWs-874?B?zcXUqyC82enK6KeotMvB0sI=?= <alis.phusngcdhmay@example.com>
+Reply-To: =?WiNdOWs-874?B?zcXUqyC82enK6KeotMvB0sI=?= <alis.phusngcdhmay@example.net>
+To: =?WiNdOwS-874?B?uurNuiC82enD0bo=?= <bob.phurab@example.com>,
+ =?WIndOWS-874?B?pNLiw8UgvNnpw9G6?= <carol.phurab@example.com>
+Cc: =?wINDOWs-874?b?4bS5ILzZ6cPRug==?= <dan.phurab@example.com>,
+ =?WInDOws-874?B?zdW/ILzZ6cPRug==?= <eve.phurab@example.com>
+Bcc: =?WIndOwS-874?b?4b/Dp6TsILzZ6cPRug==?= <frank.phurab@example.com>,
+ =?WiNDOWs-874?b?4KHDqyC82enD0bo=?= <grace.phurab@example.com>
+Subject: =?UTF-8?B?8J+Tpw==?= Test
+ =?wInDowS-874?B?4b654aHDwcDSydLkt8I=?=
+In-Reply-To: <Message-Id-0@example.com>
+References: <Message-Id-0@example.com>
+Message-ID: <Message-Id-1@example.com>
+Comments: Message Header Comment
+Keywords: Keyword 1, Keyword 2
+Resent-Date: Mon, 01 Apr 2019 07:55:00 +0700 (+07)
+Resent-From: =?WiNdOWs-874?B?zcXUqyC82enK6KeotMvB0sI=?= <alis.phusngcdhmay@example.net>,
+ =?WiNdOWs-874?B?zcXUqyC82enK6KeotMvB0sI=?= <alis.phusngcdhmay@example.com>
+Resent-Sender: =?WiNdOWs-874?B?zcXUqyC82enK6KeotMvB0sI=?= <alis.phusngcdhmay@example.net>
+Resent-To: =?WiNdOwS-874?B?uurNuiC82enD0bo=?= <bob.phurab@example.net>,
+ =?WIndOWS-874?B?pNLiw8UgvNnpw9G6?= <carol.phurab@example.net>
+Resent-Cc: =?wINDOWs-874?b?4bS5ILzZ6cPRug==?= <dan.phurab@example.net>,
+ =?WInDOws-874?B?zdW/ILzZ6cPRug==?= <eve.phurab@example.net>
+Resent-Bcc: =?WIndOwS-874?b?4b/Dp6TsILzZ6cPRug==?= <frank.phurab@example.net>,
+ =?WiNDOWs-874?b?4KHDqyC82enD0bo=?= <grace.phurab@example.net>
+Resent-Message-ID: <Message-Id-1@example.net>
+Content-Type: teXt/PLAIN; chARSEt=Windows-874
+Content-Transfer-Encoding: bASE64
+X-Clacks-Overhead: GNU Terry Pratchett
+
+
+4LvnucG52MnC7MrYtLvD0ODKw9Sw4MXUyKTYs6To0iChx+jSusPDtNK92afK0bXH7OC0w9GoqdK5
+IKinvejSv9G5vtGyudLH1KrSodLDIM3C6NLF6dKnvMXSrcTl4KLouabo0rrVsdLjpMMg5MHottfN
+4rfJ4qHDuOGq6Ker0bTO1rTO0bS06NIgy9G0zcDRwuDLwdfNuaHVzNLN0aqs0srRwiC7r9S60bXU
+u8PQvsS11KGuodPLubTjqCC+2bSo0uPL6ajq0OYgqOvS5iC56NK/0afgzcLPCgq50sLK0aemwNGz
+sewg4M6nvtS30aHJ7L3R6KcgvNnp4LLo0qvW6KfB1c3SqtW+4LvnuaW5otLCo8e0ILbZobXTw8eo
+u6/UutG11KHSw6jRur/pzafI0sUgsNK5xdGhudLM1KHSpNizy63Up6nRtcOqrtIgrNK5ysHSuNQ

--- a/tests/test_thai_plaintext_windows-874_over_quoted-printable.txt
+++ b/tests/test_thai_plaintext_windows-874_over_quoted-printable.txt
@@ -1,0 +1,49 @@
+Date: Mon, 01 Apr 2019 07:55:00 +0700 (+07)
+From: =?wINDOws-874?Q?=CD=C5=D4=AB_=BC=D9=E9=CA=E8=A7=A8=B4=CB=C1=D2=C2?= <alis.phusngcdhmay@example.com>,
+ =?wINDOws-874?Q?=CD=C5=D4=AB_=BC=D9=E9=CA=E8=A7=A8=B4=CB=C1=D2=C2?= <alis.phusngcdhmay@example.net>
+Sender: =?wINDOws-874?Q?=CD=C5=D4=AB_=BC=D9=E9=CA=E8=A7=A8=B4=CB=C1=D2=C2?= <alis.phusngcdhmay@example.com>
+Reply-To: =?wINDOws-874?Q?=CD=C5=D4=AB_=BC=D9=E9=CA=E8=A7=A8=B4=CB=C1=D2=C2?= <alis.phusngcdhmay@example.net>
+To: =?wINDOWs-874?Q?=BA=EA=CD=BA_=BC=D9=E9=C3=D1=BA?= <bob.phurab@example.com>,
+ =?WINDoWS-874?Q?=A4=D2=E2=C3=C5_=BC=D9=E9=C3=D1=BA?= <carol.phurab@example.com>
+Cc: =?wIndoWS-874?Q?=E1=B4=B9_=BC=D9=E9=C3=D1=BA?= <dan.phurab@example.com>,
+ =?wINDows-874?Q?=CD=D5=BF_=BC=D9=E9=C3=D1=BA?= <eve.phurab@example.com>
+Bcc: =?WInDows-874?q?=E1=BF=C3=A7=A4=EC_=BC=D9=E9=C3=D1=BA?= <frank.phurab@example.com>,
+ =?WiNDOws-874?Q?=E0=A1=C3=AB_=BC=D9=E9=C3=D1=BA?= <grace.phurab@example.com>
+Subject: =?UTF-8?B?8J+Tpw==?= Test
+ =?WIndOwS-874?q?=E1=BE=B9=E1=A1=C3=C1=C0=D2=C9=D2=E4=B7=C2?=
+In-Reply-To: <Message-Id-0@example.com>
+References: <Message-Id-0@example.com>
+Message-ID: <Message-Id-1@example.com>
+Comments: Message Header Comment
+Keywords: Keyword 1, Keyword 2
+Resent-Date: Mon, 01 Apr 2019 07:55:00 +0700 (+07)
+Resent-From: =?wINDOws-874?Q?=CD=C5=D4=AB_=BC=D9=E9=CA=E8=A7=A8=B4=CB=C1=D2=C2?= <alis.phusngcdhmay@example.net>,
+ =?wINDOws-874?Q?=CD=C5=D4=AB_=BC=D9=E9=CA=E8=A7=A8=B4=CB=C1=D2=C2?= <alis.phusngcdhmay@example.com>
+Resent-Sender: =?wINDOws-874?Q?=CD=C5=D4=AB_=BC=D9=E9=CA=E8=A7=A8=B4=CB=C1=D2=C2?= <alis.phusngcdhmay@example.net>
+Resent-To: =?wINDOWs-874?Q?=BA=EA=CD=BA_=BC=D9=E9=C3=D1=BA?= <bob.phurab@example.net>,
+ =?WINDoWS-874?Q?=A4=D2=E2=C3=C5_=BC=D9=E9=C3=D1=BA?= <carol.phurab@example.net>
+Resent-Cc: =?wIndoWS-874?Q?=E1=B4=B9_=BC=D9=E9=C3=D1=BA?= <dan.phurab@example.net>,
+ =?wINDows-874?Q?=CD=D5=BF_=BC=D9=E9=C3=D1=BA?= <eve.phurab@example.net>
+Resent-Bcc: =?WInDows-874?q?=E1=BF=C3=A7=A4=EC_=BC=D9=E9=C3=D1=BA?= <frank.phurab@example.net>,
+ =?WiNDOws-874?Q?=E0=A1=C3=AB_=BC=D9=E9=C3=D1=BA?= <grace.phurab@example.net>
+Resent-Message-ID: <Message-Id-1@example.net>
+Content-Type: TeXT/PlAiN; CHArSET=winDOws-874
+Content-Transfer-Encoding: qUOTED-printaBLe
+X-Clacks-Overhead: GNU Terry Pratchett
+
+
+=E0=BB=E7=B9=C1=B9=D8=C9=C2=EC=CA=D8=B4=BB=C3=D0=E0=CA=C3=D4=B0=E0=C5=D4=C8=
+=A4=D8=B3=A4=E8=D2 =A1=C7=E8=D2=BA=C3=C3=B4=D2=BD=D9=A7=CA=D1=B5=C7=EC=E0=
+=B4=C3=D1=A8=A9=D2=B9 =A8=A7=BD=E8=D2=BF=D1=B9=BE=D1=B2=B9=D2=C7=D4=AA=D2=
+=A1=D2=C3 =CD=C2=E8=D2=C5=E9=D2=A7=BC=C5=D2=AD=C4=E5=E0=A2=E8=B9=A6=E8=D2=
+=BA=D5=B1=D2=E3=A4=C3 =E4=C1=E8=B6=D7=CD=E2=B7=C9=E2=A1=C3=B8=E1=AA=E8=A7=
+=AB=D1=B4=CE=D6=B4=CE=D1=B4=B4=E8=D2 =CB=D1=B4=CD=C0=D1=C2=E0=CB=C1=D7=CD=
+=B9=A1=D5=CC=D2=CD=D1=AA=AC=D2=CA=D1=C2 =BB=AF=D4=BA=D1=B5=D4=BB=C3=D0=BE=
+=C4=B5=D4=A1=AE=A1=D3=CB=B9=B4=E3=A8 =BE=D9=B4=A8=D2=E3=CB=E9=A8=EA=D0=E6 =
+=A8=EB=D2=E6 =B9=E8=D2=BF=D1=A7=E0=CD=C2=CF
+
+=B9=D2=C2=CA=D1=A7=A6=C0=D1=B3=B1=EC =E0=CE=A7=BE=D4=B7=D1=A1=C9=EC=BD=D1=
+=E8=A7 =BC=D9=E9=E0=B2=E8=D2=AB=D6=E8=A7=C1=D5=CD=D2=AA=D5=BE=E0=BB=E7=B9=
+=A5=B9=A2=D2=C2=A3=C7=B4 =B6=D9=A1=B5=D3=C3=C7=A8=BB=AF=D4=BA=D1=B5=D4=A1=
+=D2=C3=A8=D1=BA=BF=E9=CD=A7=C8=D2=C5 =B0=D2=B9=C5=D1=A1=B9=D2=CC=D4=A1=D2=
+=A4=D8=B3=CB=AD=D4=A7=A9=D1=B5=C3=AA=AE=D2 =AC=D2=B9=CA=C1=D2=B8=D4


### PR DESCRIPTION
# Description

As reported by @nikonov1101 in https://github.com/mnako/letters/issues/49, `CharsetReader` was not performing a correct lookup for labels that do start with `windows-`.

This PR uses Thai language and encodings to illustrate the problem, add test cases, and fix the bug by first attempting a lookup of the original label, then (if not found) attempting a lookup of the normalised label, and (if not found again) raising an informative error. Assuming that most labels are correct and do not need the string replace, this should be the fastest approach.

## Commits:

1. Tests should fail on: [Add test cases for iso-8859-11, windows-874, and tis-620 encoding using Thai as an example](https://github.com/mnako/letters/commit/9a5efda85edac54f0af29b45ccc8e508f1deb87d);
2. Fix: [modify `decoders.decodeHeader.CharsetReader` to lookup the original label, replace `windows-` with `cp` only if not found, and raise informative error, if not found again](https://github.com/mnako/letters/pull/54/commits/522453b72edfc983f7999a4b4fccb5ad7414a4fd) and show all test cases passing again.
