### PR TITLE
optionally only parse email headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,15 @@ email.Text
 // "色は匂えど散りぬるを..."
 ```
 
+To only parse headers:
+
+```go
+email, err := letters.ParseEmail(r, "HeadersOnly")
+if err != nil {
+    log.Fatal(err)
+}
+```
+
 ## Current Scope and Features
 
 * Parsing plaintext emails and recursively traversing multipart

--- a/go.mod
+++ b/go.mod
@@ -6,3 +6,5 @@ require (
 	golang.org/x/net v0.21.0
 	golang.org/x/text v0.14.0
 )
+
+require github.com/google/go-cmp v0.6.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/mnako/letters
+module github.com/rorycl/letters
 
 go 1.17
 

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
+github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=

--- a/structs.go
+++ b/structs.go
@@ -550,7 +550,8 @@ func (eb *emailBodies) extend(b emailBodies) {
 }
 
 type Email struct {
-	Headers Headers
+	Headers     Headers
+	HeadersOnly bool
 
 	Text         string
 	EnrichedText string // See RFC 1523, RFC 1563, and RFC 1896


### PR DESCRIPTION
Hi @mnako

Based on a need to parse the headers of a lot of emails, I've suggested a small patch to optionally do this following the suggestion in Discussions [here](https://github.com/mnako/letters/discussions/64).

A couple of points.

1. I thought the simplest way of making this change was to send an optional string to `ParseEmail`; eg: `email, err := letters.ParseEmail(r, "HeadersOnly")`.

2. The `email` struct is reinitialised in ParseEmail to set the Headers -- see deleted line 26. I've changed that.

3. Partly because of 2. above I had an error in the test I copied and couldn't easily see what the error was. I used Google's `go-cmp` module which makes it easy to diff test errors.

This is my first github pull request. Please feel free to criticise it in any way.

Cheers!
Rory