### PR TITLE
Quote commas in test emails' addresses according to RFC5322

### DIFF
--- a/tests/test_polish_multipart_mixed_iso-8859-2_over_base64.txt
+++ b/tests/test_polish_multipart_mixed_iso-8859-2_over_base64.txt
@@ -1,14 +1,14 @@
 Date: Mon, 01 Apr 2019 07:55:00 +0200 (CEST)
-From: =?Iso-8859-2?B?TmFkYWqxY2EsIEFsaWNqYQ==?= <alicja.nadajaca@example.com>,
- =?Iso-8859-2?B?TmFkYWqxY2EsIEFsaWNqYQ==?= <alicja.nadajaca@example.net>
-Sender: =?Iso-8859-2?B?TmFkYWqxY2EsIEFsaWNqYQ==?= <alicja.nadajaca@example.com>
-Reply-To: =?Iso-8859-2?B?TmFkYWqxY2EsIEFsaWNqYQ==?= <alicja.nadajaca@example.net>
-To: =?iSo-8859-2?B?T2RiaWVyYWqxY3ksIEJvYg==?= <bob.odbierajacy@example.com>,
- =?IsO-8859-2?B?T2RiaWVyYWqxY2EsIEthcm9saW5h?= <karolina.odbierajaca@example.com>
-Cc: =?ISO-8859-2?b?T2RiaWVyYWqxY3ksIERhbmllbA==?= <daniel.odbierajacy@example.com>,
- =?ISO-8859-2?b?T2RiaWVyYWqxY2EsIEV3YQ==?= <ewa.odbierajaca@example.com>
-Bcc: =?isO-8859-2?B?T2RiaWVyYWqxY3ksIEZyYW5law==?= <franek.odbierajacy@example.com>,
- =?IsO-8859-2?b?T2RiaWVyYWqxY2EsIEdyYb95bmE=?= <grazyna.odbierajaca@example.com>
+From: =?Iso-8859-2?B?Ik5hZGFqsWNhLCBBbGljamEi?= <alicja.nadajaca@example.com>,
+ =?Iso-8859-2?B?Ik5hZGFqsWNhLCBBbGljamEi?= <alicja.nadajaca@example.net>
+Sender: =?Iso-8859-2?B?Ik5hZGFqsWNhLCBBbGljamEi?= <alicja.nadajaca@example.com>
+Reply-To: =?Iso-8859-2?B?Ik5hZGFqsWNhLCBBbGljamEi?= <alicja.nadajaca@example.net>
+To: =?iSo-8859-2?B?Ik9kYmllcmFqsWN5LCBCb2Ii?= <bob.odbierajacy@example.com>,
+ =?IsO-8859-2?B?Ik9kYmllcmFqsWNhLCBLYXJvbGluYSI=?= <karolina.odbierajaca@example.com>
+Cc: =?ISO-8859-2?b?Ik9kYmllcmFqsWN5LCBEYW5pZWwi?= <daniel.odbierajacy@example.com>,
+ =?ISO-8859-2?b?Ik9kYmllcmFqsWNhLCBFd2Ei?= <ewa.odbierajaca@example.com>
+Bcc: =?isO-8859-2?B?Ik9kYmllcmFqsWN5LCBGcmFuZWsi?= <franek.odbierajacy@example.com>,
+ =?IsO-8859-2?b?Ik9kYmllcmFqsWNhLCBHcmG/eW5hIg==?= <grazyna.odbierajaca@example.com>
 Subject: =?UTF-8?B?8J+Tpw==?= Test
  =?iso-8859-2?B?UG9sc2tpZSBwYW5ncmFteQ==?=
 In-Reply-To: <Message-Id-0@example.com>
@@ -17,15 +17,15 @@ Message-ID: <Message-Id-1@example.com>
 Comments: Message Header Comment
 Keywords: Keyword 1, Keyword 2
 Resent-Date: Mon, 01 Apr 2019 07:55:00 +0200 (CEST)
-Resent-From: =?Iso-8859-2?B?TmFkYWqxY2EsIEFsaWNqYQ==?= <alicja.nadajaca@example.net>,
- =?Iso-8859-2?B?TmFkYWqxY2EsIEFsaWNqYQ==?= <alicja.nadajaca@example.com>
-Resent-Sender: =?Iso-8859-2?B?TmFkYWqxY2EsIEFsaWNqYQ==?= <alicja.nadajaca@example.net>
-Resent-To: =?iSo-8859-2?B?T2RiaWVyYWqxY3ksIEJvYg==?= <bob.odbierajacy@example.net>,
- =?IsO-8859-2?B?T2RiaWVyYWqxY2EsIEthcm9saW5h?= <karolina.odbierajaca@example.net>
-Resent-Cc: =?ISO-8859-2?b?T2RiaWVyYWqxY3ksIERhbmllbA==?= <daniel.odbierajacy@example.net>,
- =?ISO-8859-2?b?T2RiaWVyYWqxY2EsIEV3YQ==?= <ewa.odbierajaca@example.net>
-Resent-Bcc: =?isO-8859-2?B?T2RiaWVyYWqxY3ksIEZyYW5law==?= <franek.odbierajacy@example.net>,
- =?IsO-8859-2?b?T2RiaWVyYWqxY2EsIEdyYb95bmE=?= <grazyna.odbierajaca@example.net>
+Resent-From: =?Iso-8859-2?B?Ik5hZGFqsWNhLCBBbGljamEi?= <alicja.nadajaca@example.net>,
+ =?Iso-8859-2?B?Ik5hZGFqsWNhLCBBbGljamEi?= <alicja.nadajaca@example.com>
+Resent-Sender: =?Iso-8859-2?B?Ik5hZGFqsWNhLCBBbGljamEi?= <alicja.nadajaca@example.net>
+Resent-To: =?iSo-8859-2?B?Ik9kYmllcmFqsWN5LCBCb2Ii?= <bob.odbierajacy@example.net>,
+ =?IsO-8859-2?B?Ik9kYmllcmFqsWNhLCBLYXJvbGluYSI=?= <karolina.odbierajaca@example.net>
+Resent-Cc: =?ISO-8859-2?b?Ik9kYmllcmFqsWN5LCBEYW5pZWwi?= <daniel.odbierajacy@example.net>,
+ =?ISO-8859-2?b?Ik9kYmllcmFqsWNhLCBFd2Ei?= <ewa.odbierajaca@example.net>
+Resent-Bcc: =?isO-8859-2?B?Ik9kYmllcmFqsWN5LCBGcmFuZWsi?= <franek.odbierajacy@example.net>,
+ =?IsO-8859-2?b?Ik9kYmllcmFqsWNhLCBHcmG/eW5hIg==?= <grazyna.odbierajaca@example.net>
 Resent-Message-ID: <Message-Id-1@example.net>
 Content-Type: MULTIPART/Mixed; charseT="ISO-8859-2"; boUndary="MixedBoundaryString"
 Content-Transfer-Encoding: base64

--- a/tests/test_polish_multipart_mixed_iso-8859-2_over_quoted-printable.txt
+++ b/tests/test_polish_multipart_mixed_iso-8859-2_over_quoted-printable.txt
@@ -1,14 +1,14 @@
 Date: Mon, 01 Apr 2019 07:55:00 +0200 (CEST)
-From: =?isO-8859-2?q?Nadaj=B1ca,_Alicja?= <alicja.nadajaca@example.com>,
- =?isO-8859-2?q?Nadaj=B1ca,_Alicja?= <alicja.nadajaca@example.net>
-Sender: =?isO-8859-2?q?Nadaj=B1ca,_Alicja?= <alicja.nadajaca@example.com>
-Reply-To: =?isO-8859-2?q?Nadaj=B1ca,_Alicja?= <alicja.nadajaca@example.net>
-To: =?iso-8859-2?Q?Odbieraj=B1cy,_Bob?= <bob.odbierajacy@example.com>,
- =?ISO-8859-2?q?Odbieraj=B1ca,_Karolina?= <karolina.odbierajaca@example.com>
-Cc: =?iso-8859-2?Q?Odbieraj=B1cy,_Daniel?= <daniel.odbierajacy@example.com>,
- =?ISo-8859-2?q?Odbieraj=B1ca,_Ewa?= <ewa.odbierajaca@example.com>
-Bcc: =?IsO-8859-2?Q?Odbieraj=B1cy,_Franek?= <franek.odbierajacy@example.com>,
- =?isO-8859-2?Q?Odbieraj=B1ca,_Gra=BFyna?= <grazyna.odbierajaca@example.com>
+From: =?isO-8859-2?q?"Nadaj=B1ca,_Alicja"?= <alicja.nadajaca@example.com>,
+ =?isO-8859-2?q?"Nadaj=B1ca,_Alicja"?= <alicja.nadajaca@example.net>
+Sender: =?isO-8859-2?q?"Nadaj=B1ca,_Alicja"?= <alicja.nadajaca@example.com>
+Reply-To: =?isO-8859-2?q?"Nadaj=B1ca,_Alicja"?= <alicja.nadajaca@example.net>
+To: =?iso-8859-2?Q?"Odbieraj=B1cy,_Bob"?= <bob.odbierajacy@example.com>,
+ =?ISO-8859-2?q?"Odbieraj=B1ca,_Karolina"?= <karolina.odbierajaca@example.com>
+Cc: =?iso-8859-2?Q?"Odbieraj=B1cy,_Daniel"?= <daniel.odbierajacy@example.com>,
+ =?ISo-8859-2?q?"Odbieraj=B1ca,_Ewa"?= <ewa.odbierajaca@example.com>
+Bcc: =?IsO-8859-2?Q?"Odbieraj=B1cy,_Franek"?= <franek.odbierajacy@example.com>,
+ =?isO-8859-2?Q?"Odbieraj=B1ca,_Gra=BFyna"?= <grazyna.odbierajaca@example.com>
 Subject: =?UTF-8?B?8J+Tpw==?= Test
  =?Iso-8859-2?q?Polskie_pangramy?=
 In-Reply-To: <Message-Id-0@example.com>
@@ -17,15 +17,15 @@ Message-ID: <Message-Id-1@example.com>
 Comments: Message Header Comment
 Keywords: Keyword 1, Keyword 2
 Resent-Date: Mon, 01 Apr 2019 07:55:00 +0200 (CEST)
-Resent-From: =?isO-8859-2?q?Nadaj=B1ca,_Alicja?= <alicja.nadajaca@example.net>,
- =?isO-8859-2?q?Nadaj=B1ca,_Alicja?= <alicja.nadajaca@example.com>
-Resent-Sender: =?isO-8859-2?q?Nadaj=B1ca,_Alicja?= <alicja.nadajaca@example.net>
-Resent-To: =?iso-8859-2?Q?Odbieraj=B1cy,_Bob?= <bob.odbierajacy@example.net>,
- =?ISO-8859-2?q?Odbieraj=B1ca,_Karolina?= <karolina.odbierajaca@example.net>
-Resent-Cc: =?iso-8859-2?Q?Odbieraj=B1cy,_Daniel?= <daniel.odbierajacy@example.net>,
- =?ISo-8859-2?q?Odbieraj=B1ca,_Ewa?= <ewa.odbierajaca@example.net>
-Resent-Bcc: =?IsO-8859-2?Q?Odbieraj=B1cy,_Franek?= <franek.odbierajacy@example.net>,
- =?isO-8859-2?Q?Odbieraj=B1ca,_Gra=BFyna?= <grazyna.odbierajaca@example.net>
+Resent-From: =?isO-8859-2?q?"Nadaj=B1ca,_Alicja"?= <alicja.nadajaca@example.net>,
+ =?isO-8859-2?q?"Nadaj=B1ca,_Alicja"?= <alicja.nadajaca@example.com>
+Resent-Sender: =?isO-8859-2?q?"Nadaj=B1ca,_Alicja"?= <alicja.nadajaca@example.net>
+Resent-To: =?iso-8859-2?Q?"Odbieraj=B1cy,_Bob"?= <bob.odbierajacy@example.net>,
+ =?ISO-8859-2?q?"Odbieraj=B1ca,_Karolina"?= <karolina.odbierajaca@example.net>
+Resent-Cc: =?iso-8859-2?Q?"Odbieraj=B1cy,_Daniel"?= <daniel.odbierajacy@example.net>,
+ =?ISo-8859-2?q?"Odbieraj=B1ca,_Ewa"?= <ewa.odbierajaca@example.net>
+Resent-Bcc: =?IsO-8859-2?Q?"Odbieraj=B1cy,_Franek"?= <franek.odbierajacy@example.net>,
+ =?isO-8859-2?Q?"Odbieraj=B1ca,_Gra=BFyna"?= <grazyna.odbierajaca@example.net>
 Resent-Message-ID: <Message-Id-1@example.net>
 Content-Type: multipart/mIxed; charset="iso-8859-2"; BOUNDARY="MixedBoundaryString"
 Content-Transfer-Encoding: quoted-PRINTABLE

--- a/tests/test_polish_multipart_mixed_utf-8_over_base64.txt
+++ b/tests/test_polish_multipart_mixed_utf-8_over_base64.txt
@@ -1,14 +1,14 @@
 Date: Mon, 01 Apr 2019 07:55:00 +0200 (CEST)
-From: =?utf-8?b?TmFkYWrEhWNhLCBBbGljamE=?= <alicja.nadajaca@example.com>,
- =?utf-8?b?TmFkYWrEhWNhLCBBbGljamE=?= <alicja.nadajaca@example.net>
-Sender: =?utf-8?b?TmFkYWrEhWNhLCBBbGljamE=?= <alicja.nadajaca@example.com>
-Reply-To: =?utf-8?b?TmFkYWrEhWNhLCBBbGljamE=?= <alicja.nadajaca@example.net>
-To: =?UTF-8?b?T2RiaWVyYWrEhWN5LCBCb2I=?= <bob.odbierajacy@example.com>,
- =?UTF-8?B?T2RiaWVyYWrEhWNhLCBLYXJvbGluYQ==?= <karolina.odbierajaca@example.com>
-Cc: =?uTF-8?b?T2RiaWVyYWrEhWN5LCBEYW5pZWw=?= <daniel.odbierajacy@example.com>,
- =?Utf-8?b?T2RiaWVyYWrEhWNhLCBFd2E=?= <ewa.odbierajaca@example.com>
-Bcc: =?uTF-8?b?T2RiaWVyYWrEhWN5LCBGcmFuZWs=?= <franek.odbierajacy@example.com>,
- =?utf-8?b?T2RiaWVyYWrEhWNhLCBHcmHFvHluYQ==?= <grazyna.odbierajaca@example.com>
+From: =?utf-8?b?Ik5hZGFqxIVjYSwgQWxpY2phIg==?= <alicja.nadajaca@example.com>,
+ =?utf-8?b?Ik5hZGFqxIVjYSwgQWxpY2phIg==?= <alicja.nadajaca@example.net>
+Sender: =?utf-8?b?Ik5hZGFqxIVjYSwgQWxpY2phIg==?= <alicja.nadajaca@example.com>
+Reply-To: =?utf-8?b?Ik5hZGFqxIVjYSwgQWxpY2phIg==?= <alicja.nadajaca@example.net>
+To: =?UTF-8?b?Ik9kYmllcmFqxIVjeSwgQm9iIg==?= <bob.odbierajacy@example.com>,
+ =?UTF-8?B?Ik9kYmllcmFqxIVjYSwgS2Fyb2xpbmEi?= <karolina.odbierajaca@example.com>
+Cc: =?uTF-8?b?Ik9kYmllcmFqxIVjeSwgRGFuaWVsIg==?= <daniel.odbierajacy@example.com>,
+ =?Utf-8?b?Ik9kYmllcmFqxIVjYSwgRXdhIg==?= <ewa.odbierajaca@example.com>
+Bcc: =?uTF-8?b?Ik9kYmllcmFqxIVjeSwgRnJhbmVrIg==?= <franek.odbierajacy@example.com>,
+ =?utf-8?b?Ik9kYmllcmFqxIVjYSwgR3Jhxbx5bmEi?= <grazyna.odbierajaca@example.com>
 Subject: =?UTF-8?B?8J+Tpw==?= Test
  =?utf-8?B?UG9sc2tpZSBwYW5ncmFteQ==?=
 In-Reply-To: <Message-Id-0@example.com>
@@ -17,15 +17,15 @@ Message-ID: <Message-Id-1@example.com>
 Comments: Message Header Comment
 Keywords: Keyword 1, Keyword 2
 Resent-Date: Mon, 01 Apr 2019 07:55:00 +0200 (CEST)
-Resent-From: =?utf-8?b?TmFkYWrEhWNhLCBBbGljamE=?= <alicja.nadajaca@example.net>,
- =?utf-8?b?TmFkYWrEhWNhLCBBbGljamE=?= <alicja.nadajaca@example.com>
-Resent-Sender: =?utf-8?b?TmFkYWrEhWNhLCBBbGljamE=?= <alicja.nadajaca@example.net>
-Resent-To: =?UTF-8?b?T2RiaWVyYWrEhWN5LCBCb2I=?= <bob.odbierajacy@example.net>,
- =?UTF-8?B?T2RiaWVyYWrEhWNhLCBLYXJvbGluYQ==?= <karolina.odbierajaca@example.net>
-Resent-Cc: =?uTF-8?b?T2RiaWVyYWrEhWN5LCBEYW5pZWw=?= <daniel.odbierajacy@example.net>,
- =?Utf-8?b?T2RiaWVyYWrEhWNhLCBFd2E=?= <ewa.odbierajaca@example.net>
-Resent-Bcc: =?uTF-8?b?T2RiaWVyYWrEhWN5LCBGcmFuZWs=?= <franek.odbierajacy@example.net>,
- =?utf-8?b?T2RiaWVyYWrEhWNhLCBHcmHFvHluYQ==?= <grazyna.odbierajaca@example.net>
+Resent-From: =?utf-8?b?Ik5hZGFqxIVjYSwgQWxpY2phIg==?= <alicja.nadajaca@example.net>,
+ =?utf-8?b?Ik5hZGFqxIVjYSwgQWxpY2phIg==?= <alicja.nadajaca@example.com>
+Resent-Sender: =?utf-8?b?Ik5hZGFqxIVjYSwgQWxpY2phIg==?= <alicja.nadajaca@example.net>
+Resent-To: =?UTF-8?b?Ik9kYmllcmFqxIVjeSwgQm9iIg==?= <bob.odbierajacy@example.net>,
+ =?UTF-8?B?Ik9kYmllcmFqxIVjYSwgS2Fyb2xpbmEi?= <karolina.odbierajaca@example.net>
+Resent-Cc: =?uTF-8?b?Ik9kYmllcmFqxIVjeSwgRGFuaWVsIg==?= <daniel.odbierajacy@example.net>,
+ =?Utf-8?b?Ik9kYmllcmFqxIVjYSwgRXdhIg==?= <ewa.odbierajaca@example.net>
+Resent-Bcc: =?uTF-8?b?Ik9kYmllcmFqxIVjeSwgRnJhbmVrIg==?= <franek.odbierajacy@example.net>,
+ =?utf-8?b?Ik9kYmllcmFqxIVjYSwgR3Jhxbx5bmEi?= <grazyna.odbierajaca@example.net>
 Resent-Message-ID: <Message-Id-1@example.net>
 Content-Type: multipart/mIXED; charset="utf-8"; bouNDARY="MixedBoundaryString"
 Content-Transfer-Encoding: BASE64

--- a/tests/test_polish_multipart_mixed_utf-8_over_quoted-printable.txt
+++ b/tests/test_polish_multipart_mixed_utf-8_over_quoted-printable.txt
@@ -1,14 +1,14 @@
 Date: Mon, 01 Apr 2019 07:55:00 +0200 (CEST)
-From: =?Utf-8?q?Nadaj=C4=85ca,_Alicja?= <alicja.nadajaca@example.com>,
- =?Utf-8?q?Nadaj=C4=85ca,_Alicja?= <alicja.nadajaca@example.net>
-Sender: =?Utf-8?q?Nadaj=C4=85ca,_Alicja?= <alicja.nadajaca@example.com>
-Reply-To: =?Utf-8?q?Nadaj=C4=85ca,_Alicja?= <alicja.nadajaca@example.net>
-To: =?UTf-8?Q?Odbieraj=C4=85cy,_Bob?= <bob.odbierajacy@example.com>,
- =?UTF-8?Q?Odbieraj=C4=85ca,_Karolina?= <karolina.odbierajaca@example.com>
-Cc: =?utf-8?q?Odbieraj=C4=85cy,_Daniel?= <daniel.odbierajacy@example.com>,
- =?utf-8?Q?Odbieraj=C4=85ca,_Ewa?= <ewa.odbierajaca@example.com>
-Bcc: =?UTf-8?Q?Odbieraj=C4=85cy,_Franek?= <franek.odbierajacy@example.com>,
- =?UTF-8?Q?Odbieraj=C4=85ca,_Gra=C5=BCyna?= <grazyna.odbierajaca@example.com>
+From: =?Utf-8?q?"Nadaj=C4=85ca,_Alicja"?= <alicja.nadajaca@example.com>,
+ =?Utf-8?q?"Nadaj=C4=85ca,_Alicja"?= <alicja.nadajaca@example.net>
+Sender: =?Utf-8?q?"Nadaj=C4=85ca,_Alicja"?= <alicja.nadajaca@example.com>
+Reply-To: =?Utf-8?q?"Nadaj=C4=85ca,_Alicja"?= <alicja.nadajaca@example.net>
+To: =?UTf-8?Q?"Odbieraj=C4=85cy,_Bob"?= <bob.odbierajacy@example.com>,
+ =?UTF-8?Q?"Odbieraj=C4=85ca,_Karolina"?= <karolina.odbierajaca@example.com>
+Cc: =?utf-8?q?"Odbieraj=C4=85cy,_Daniel"?= <daniel.odbierajacy@example.com>,
+ =?utf-8?Q?"Odbieraj=C4=85ca,_Ewa"?= <ewa.odbierajaca@example.com>
+Bcc: =?UTf-8?Q?"Odbieraj=C4=85cy,_Franek"?= <franek.odbierajacy@example.com>,
+ =?UTF-8?Q?"Odbieraj=C4=85ca,_Gra=C5=BCyna"?= <grazyna.odbierajaca@example.com>
 Subject: =?UTF-8?B?8J+Tpw==?= Test
  =?UTF-8?Q?Polskie_pangramy?=
 In-Reply-To: <Message-Id-0@example.com>
@@ -17,15 +17,15 @@ Message-ID: <Message-Id-1@example.com>
 Comments: Message Header Comment
 Keywords: Keyword 1, Keyword 2
 Resent-Date: Mon, 01 Apr 2019 07:55:00 +0200 (CEST)
-Resent-From: =?Utf-8?q?Nadaj=C4=85ca,_Alicja?= <alicja.nadajaca@example.net>,
- =?Utf-8?q?Nadaj=C4=85ca,_Alicja?= <alicja.nadajaca@example.com>
-Resent-Sender: =?Utf-8?q?Nadaj=C4=85ca,_Alicja?= <alicja.nadajaca@example.net>
-Resent-To: =?UTf-8?Q?Odbieraj=C4=85cy,_Bob?= <bob.odbierajacy@example.net>,
- =?UTF-8?Q?Odbieraj=C4=85ca,_Karolina?= <karolina.odbierajaca@example.net>
-Resent-Cc: =?utf-8?q?Odbieraj=C4=85cy,_Daniel?= <daniel.odbierajacy@example.net>,
- =?utf-8?Q?Odbieraj=C4=85ca,_Ewa?= <ewa.odbierajaca@example.net>
-Resent-Bcc: =?UTf-8?Q?Odbieraj=C4=85cy,_Franek?= <franek.odbierajacy@example.net>,
- =?UTF-8?Q?Odbieraj=C4=85ca,_Gra=C5=BCyna?= <grazyna.odbierajaca@example.net>
+Resent-From: =?Utf-8?q?"Nadaj=C4=85ca,_Alicja"?= <alicja.nadajaca@example.net>,
+ =?Utf-8?q?"Nadaj=C4=85ca,_Alicja"?= <alicja.nadajaca@example.com>
+Resent-Sender: =?Utf-8?q?"Nadaj=C4=85ca,_Alicja"?= <alicja.nadajaca@example.net>
+Resent-To: =?UTf-8?Q?"Odbieraj=C4=85cy,_Bob"?= <bob.odbierajacy@example.net>,
+ =?UTF-8?Q?"Odbieraj=C4=85ca,_Karolina"?= <karolina.odbierajaca@example.net>
+Resent-Cc: =?utf-8?q?"Odbieraj=C4=85cy,_Daniel"?= <daniel.odbierajacy@example.net>,
+ =?utf-8?Q?"Odbieraj=C4=85ca,_Ewa"?= <ewa.odbierajaca@example.net>
+Resent-Bcc: =?UTf-8?Q?"Odbieraj=C4=85cy,_Franek"?= <franek.odbierajacy@example.net>,
+ =?UTF-8?Q?"Odbieraj=C4=85ca,_Gra=C5=BCyna"?= <grazyna.odbierajaca@example.net>
 Resent-Message-ID: <Message-Id-1@example.net>
 Content-Type: multipart/mixed; cHARset="Utf-8"; boundary="MixedBoundaryString"
 Content-Transfer-Encoding: quoteD-PRintable

--- a/tests/test_polish_multipart_related_iso-8859-2_over_base64.txt
+++ b/tests/test_polish_multipart_related_iso-8859-2_over_base64.txt
@@ -1,14 +1,14 @@
 Date: Mon, 01 Apr 2019 07:55:00 +0200 (CEST)
-From: =?iSO-8859-2?b?TmFkYWqxY2EsIEFsaWNqYQ==?= <alicja.nadajaca@example.com>,
- =?iSO-8859-2?b?TmFkYWqxY2EsIEFsaWNqYQ==?= <alicja.nadajaca@example.net>
-Sender: =?iSO-8859-2?b?TmFkYWqxY2EsIEFsaWNqYQ==?= <alicja.nadajaca@example.com>
-Reply-To: =?iSO-8859-2?b?TmFkYWqxY2EsIEFsaWNqYQ==?= <alicja.nadajaca@example.net>
-To: =?iso-8859-2?B?T2RiaWVyYWqxY3ksIEJvYg==?= <bob.odbierajacy@example.com>,
- =?ISO-8859-2?B?T2RiaWVyYWqxY2EsIEthcm9saW5h?= <karolina.odbierajaca@example.com>
-Cc: =?ISO-8859-2?B?T2RiaWVyYWqxY3ksIERhbmllbA==?= <daniel.odbierajacy@example.com>,
- =?iSo-8859-2?B?T2RiaWVyYWqxY2EsIEV3YQ==?= <ewa.odbierajaca@example.com>
-Bcc: =?iso-8859-2?B?T2RiaWVyYWqxY3ksIEZyYW5law==?= <franek.odbierajacy@example.com>,
- =?ISo-8859-2?b?T2RiaWVyYWqxY2EsIEdyYb95bmE=?= <grazyna.odbierajaca@example.com>
+From: =?iSO-8859-2?b?Ik5hZGFqsWNhLCBBbGljamEi?= <alicja.nadajaca@example.com>,
+ =?iSO-8859-2?b?Ik5hZGFqsWNhLCBBbGljamEi?= <alicja.nadajaca@example.net>
+Sender: =?iSO-8859-2?b?Ik5hZGFqsWNhLCBBbGljamEi?= <alicja.nadajaca@example.com>
+Reply-To: =?iSO-8859-2?b?Ik5hZGFqsWNhLCBBbGljamEi?= <alicja.nadajaca@example.net>
+To: =?iso-8859-2?B?Ik9kYmllcmFqsWN5LCBCb2Ii?= <bob.odbierajacy@example.com>,
+ =?ISO-8859-2?B?Ik9kYmllcmFqsWNhLCBLYXJvbGluYSI=?= <karolina.odbierajaca@example.com>
+Cc: =?ISO-8859-2?B?Ik9kYmllcmFqsWN5LCBEYW5pZWwi?= <daniel.odbierajacy@example.com>,
+ =?iSo-8859-2?B?Ik9kYmllcmFqsWNhLCBFd2Ei?= <ewa.odbierajaca@example.com>
+Bcc: =?iso-8859-2?B?Ik9kYmllcmFqsWN5LCBGcmFuZWsi?= <franek.odbierajacy@example.com>,
+ =?ISo-8859-2?b?Ik9kYmllcmFqsWNhLCBHcmG/eW5hIg==?= <grazyna.odbierajaca@example.com>
 Subject: =?UTF-8?B?8J+Tpw==?= Test
  =?iso-8859-2?B?UG9sc2tpZSBwYW5ncmFteQ==?=
 In-Reply-To: <Message-Id-0@example.com>
@@ -17,15 +17,15 @@ Message-ID: <Message-Id-1@example.com>
 Comments: Message Header Comment
 Keywords: Keyword 1, Keyword 2
 Resent-Date: Mon, 01 Apr 2019 07:55:00 +0200 (CEST)
-Resent-From: =?iSO-8859-2?b?TmFkYWqxY2EsIEFsaWNqYQ==?= <alicja.nadajaca@example.net>,
- =?iSO-8859-2?b?TmFkYWqxY2EsIEFsaWNqYQ==?= <alicja.nadajaca@example.com>
-Resent-Sender: =?iSO-8859-2?b?TmFkYWqxY2EsIEFsaWNqYQ==?= <alicja.nadajaca@example.net>
-Resent-To: =?iso-8859-2?B?T2RiaWVyYWqxY3ksIEJvYg==?= <bob.odbierajacy@example.net>,
- =?ISO-8859-2?B?T2RiaWVyYWqxY2EsIEthcm9saW5h?= <karolina.odbierajaca@example.net>
-Resent-Cc: =?ISO-8859-2?B?T2RiaWVyYWqxY3ksIERhbmllbA==?= <daniel.odbierajacy@example.net>,
- =?iSo-8859-2?B?T2RiaWVyYWqxY2EsIEV3YQ==?= <ewa.odbierajaca@example.net>
-Resent-Bcc: =?iso-8859-2?B?T2RiaWVyYWqxY3ksIEZyYW5law==?= <franek.odbierajacy@example.net>,
- =?ISo-8859-2?b?T2RiaWVyYWqxY2EsIEdyYb95bmE=?= <grazyna.odbierajaca@example.net>
+Resent-From: =?iSO-8859-2?b?Ik5hZGFqsWNhLCBBbGljamEi?= <alicja.nadajaca@example.net>,
+ =?iSO-8859-2?b?Ik5hZGFqsWNhLCBBbGljamEi?= <alicja.nadajaca@example.com>
+Resent-Sender: =?iSO-8859-2?b?Ik5hZGFqsWNhLCBBbGljamEi?= <alicja.nadajaca@example.net>
+Resent-To: =?iso-8859-2?B?Ik9kYmllcmFqsWN5LCBCb2Ii?= <bob.odbierajacy@example.net>,
+ =?ISO-8859-2?B?Ik9kYmllcmFqsWNhLCBLYXJvbGluYSI=?= <karolina.odbierajaca@example.net>
+Resent-Cc: =?ISO-8859-2?B?Ik9kYmllcmFqsWN5LCBEYW5pZWwi?= <daniel.odbierajacy@example.net>,
+ =?iSo-8859-2?B?Ik9kYmllcmFqsWNhLCBFd2Ei?= <ewa.odbierajaca@example.net>
+Resent-Bcc: =?iso-8859-2?B?Ik9kYmllcmFqsWN5LCBGcmFuZWsi?= <franek.odbierajacy@example.net>,
+ =?ISo-8859-2?b?Ik9kYmllcmFqsWNhLCBHcmG/eW5hIg==?= <grazyna.odbierajaca@example.net>
 Resent-Message-ID: <Message-Id-1@example.net>
 Content-Type: MULTIPART/rElated; charSeT="ISO-8859-2"; BOUNdaRy="RelatedBoundaryString"
 Content-Transfer-Encoding: bAsE64

--- a/tests/test_polish_multipart_related_iso-8859-2_over_quoted-printable.txt
+++ b/tests/test_polish_multipart_related_iso-8859-2_over_quoted-printable.txt
@@ -1,14 +1,14 @@
 Date: Mon, 01 Apr 2019 07:55:00 +0200 (CEST)
-From: =?iso-8859-2?q?Nadaj=B1ca,_Alicja?= <alicja.nadajaca@example.com>,
- =?iso-8859-2?q?Nadaj=B1ca,_Alicja?= <alicja.nadajaca@example.net>
-Sender: =?iso-8859-2?q?Nadaj=B1ca,_Alicja?= <alicja.nadajaca@example.com>
-Reply-To: =?iso-8859-2?q?Nadaj=B1ca,_Alicja?= <alicja.nadajaca@example.net>
-To: =?IsO-8859-2?Q?Odbieraj=B1cy,_Bob?= <bob.odbierajacy@example.com>,
- =?iso-8859-2?Q?Odbieraj=B1ca,_Karolina?= <karolina.odbierajaca@example.com>
-Cc: =?ISo-8859-2?q?Odbieraj=B1cy,_Daniel?= <daniel.odbierajacy@example.com>,
- =?iso-8859-2?Q?Odbieraj=B1ca,_Ewa?= <ewa.odbierajaca@example.com>
-Bcc: =?ISO-8859-2?Q?Odbieraj=B1cy,_Franek?= <franek.odbierajacy@example.com>,
- =?iso-8859-2?Q?Odbieraj=B1ca,_Gra=BFyna?= <grazyna.odbierajaca@example.com>
+From: =?iso-8859-2?q?"Nadaj=B1ca,_Alicja"?= <alicja.nadajaca@example.com>,
+ =?iso-8859-2?q?"Nadaj=B1ca,_Alicja"?= <alicja.nadajaca@example.net>
+Sender: =?iso-8859-2?q?"Nadaj=B1ca,_Alicja"?= <alicja.nadajaca@example.com>
+Reply-To: =?iso-8859-2?q?"Nadaj=B1ca,_Alicja"?= <alicja.nadajaca@example.net>
+To: =?IsO-8859-2?Q?"Odbieraj=B1cy,_Bob"?= <bob.odbierajacy@example.com>,
+ =?iso-8859-2?Q?"Odbieraj=B1ca,_Karolina"?= <karolina.odbierajaca@example.com>
+Cc: =?ISo-8859-2?q?"Odbieraj=B1cy,_Daniel"?= <daniel.odbierajacy@example.com>,
+ =?iso-8859-2?Q?"Odbieraj=B1ca,_Ewa"?= <ewa.odbierajaca@example.com>
+Bcc: =?ISO-8859-2?Q?"Odbieraj=B1cy,_Franek"?= <franek.odbierajacy@example.com>,
+ =?iso-8859-2?Q?"Odbieraj=B1ca,_Gra=BFyna"?= <grazyna.odbierajaca@example.com>
 Subject: =?UTF-8?B?8J+Tpw==?= Test
  =?iso-8859-2?Q?Polskie_pangramy?=
 In-Reply-To: <Message-Id-0@example.com>
@@ -17,15 +17,15 @@ Message-ID: <Message-Id-1@example.com>
 Comments: Message Header Comment
 Keywords: Keyword 1, Keyword 2
 Resent-Date: Mon, 01 Apr 2019 07:55:00 +0200 (CEST)
-Resent-From: =?iso-8859-2?q?Nadaj=B1ca,_Alicja?= <alicja.nadajaca@example.net>,
- =?iso-8859-2?q?Nadaj=B1ca,_Alicja?= <alicja.nadajaca@example.com>
-Resent-Sender: =?iso-8859-2?q?Nadaj=B1ca,_Alicja?= <alicja.nadajaca@example.net>
-Resent-To: =?IsO-8859-2?Q?Odbieraj=B1cy,_Bob?= <bob.odbierajacy@example.net>,
- =?iso-8859-2?Q?Odbieraj=B1ca,_Karolina?= <karolina.odbierajaca@example.net>
-Resent-Cc: =?ISo-8859-2?q?Odbieraj=B1cy,_Daniel?= <daniel.odbierajacy@example.net>,
- =?iso-8859-2?Q?Odbieraj=B1ca,_Ewa?= <ewa.odbierajaca@example.net>
-Resent-Bcc: =?ISO-8859-2?Q?Odbieraj=B1cy,_Franek?= <franek.odbierajacy@example.net>,
- =?iso-8859-2?Q?Odbieraj=B1ca,_Gra=BFyna?= <grazyna.odbierajaca@example.net>
+Resent-From: =?iso-8859-2?q?"Nadaj=B1ca,_Alicja"?= <alicja.nadajaca@example.net>,
+ =?iso-8859-2?q?"Nadaj=B1ca,_Alicja"?= <alicja.nadajaca@example.com>
+Resent-Sender: =?iso-8859-2?q?"Nadaj=B1ca,_Alicja"?= <alicja.nadajaca@example.net>
+Resent-To: =?IsO-8859-2?Q?"Odbieraj=B1cy,_Bob"?= <bob.odbierajacy@example.net>,
+ =?iso-8859-2?Q?"Odbieraj=B1ca,_Karolina"?= <karolina.odbierajaca@example.net>
+Resent-Cc: =?ISo-8859-2?q?"Odbieraj=B1cy,_Daniel"?= <daniel.odbierajacy@example.net>,
+ =?iso-8859-2?Q?"Odbieraj=B1ca,_Ewa"?= <ewa.odbierajaca@example.net>
+Resent-Bcc: =?ISO-8859-2?Q?"Odbieraj=B1cy,_Franek"?= <franek.odbierajacy@example.net>,
+ =?iso-8859-2?Q?"Odbieraj=B1ca,_Gra=BFyna"?= <grazyna.odbierajaca@example.net>
 Resent-Message-ID: <Message-Id-1@example.net>
 Content-Type: MULTIPaRt/related; CHARsEt="IsO-8859-2"; boundARy="RelatedBoundaryString"
 Content-Transfer-Encoding: qUOTEd-printABlE

--- a/tests/test_polish_multipart_related_utf-8_over_base64.txt
+++ b/tests/test_polish_multipart_related_utf-8_over_base64.txt
@@ -1,14 +1,14 @@
 Date: Mon, 01 Apr 2019 07:55:00 +0200 (CEST)
-From: =?UtF-8?B?TmFkYWrEhWNhLCBBbGljamE=?= <alicja.nadajaca@example.com>,
- =?UtF-8?B?TmFkYWrEhWNhLCBBbGljamE=?= <alicja.nadajaca@example.net>
-Sender: =?UtF-8?B?TmFkYWrEhWNhLCBBbGljamE=?= <alicja.nadajaca@example.com>
-Reply-To: =?UtF-8?B?TmFkYWrEhWNhLCBBbGljamE=?= <alicja.nadajaca@example.net>
-To: =?UTF-8?B?T2RiaWVyYWrEhWN5LCBCb2I=?= <bob.odbierajacy@example.com>,
- =?utf-8?b?T2RiaWVyYWrEhWNhLCBLYXJvbGluYQ==?= <karolina.odbierajaca@example.com>
-Cc: =?uTF-8?b?T2RiaWVyYWrEhWN5LCBEYW5pZWw=?= <daniel.odbierajacy@example.com>,
- =?UTF-8?B?T2RiaWVyYWrEhWNhLCBFd2E=?= <ewa.odbierajaca@example.com>
-Bcc: =?uTF-8?B?T2RiaWVyYWrEhWN5LCBGcmFuZWs=?= <franek.odbierajacy@example.com>,
- =?UTF-8?B?T2RiaWVyYWrEhWNhLCBHcmHFvHluYQ==?= <grazyna.odbierajaca@example.com>
+From: =?UtF-8?B?Ik5hZGFqxIVjYSwgQWxpY2phIg==?= <alicja.nadajaca@example.com>,
+ =?UtF-8?B?Ik5hZGFqxIVjYSwgQWxpY2phIg==?= <alicja.nadajaca@example.net>
+Sender: =?UtF-8?B?Ik5hZGFqxIVjYSwgQWxpY2phIg==?= <alicja.nadajaca@example.com>
+Reply-To: =?UtF-8?B?Ik5hZGFqxIVjYSwgQWxpY2phIg==?= <alicja.nadajaca@example.net>
+To: =?UTF-8?B?Ik9kYmllcmFqxIVjeSwgQm9iIg==?= <bob.odbierajacy@example.com>,
+ =?utf-8?b?Ik9kYmllcmFqxIVjYSwgS2Fyb2xpbmEi?= <karolina.odbierajaca@example.com>
+Cc: =?uTF-8?b?Ik9kYmllcmFqxIVjeSwgRGFuaWVsIg==?= <daniel.odbierajacy@example.com>,
+ =?UTF-8?B?Ik9kYmllcmFqxIVjYSwgRXdhIg==?= <ewa.odbierajaca@example.com>
+Bcc: =?uTF-8?B?Ik9kYmllcmFqxIVjeSwgRnJhbmVrIg==?= <franek.odbierajacy@example.com>,
+ =?UTF-8?B?Ik9kYmllcmFqxIVjYSwgR3Jhxbx5bmEi?= <grazyna.odbierajaca@example.com>
 Subject: =?UTF-8?B?8J+Tpw==?= Test
  =?UTF-8?b?UG9sc2tpZSBwYW5ncmFteQ==?=
 In-Reply-To: <Message-Id-0@example.com>
@@ -17,15 +17,15 @@ Message-ID: <Message-Id-1@example.com>
 Comments: Message Header Comment
 Keywords: Keyword 1, Keyword 2
 Resent-Date: Mon, 01 Apr 2019 07:55:00 +0200 (CEST)
-Resent-From: =?UtF-8?B?TmFkYWrEhWNhLCBBbGljamE=?= <alicja.nadajaca@example.net>,
- =?UtF-8?B?TmFkYWrEhWNhLCBBbGljamE=?= <alicja.nadajaca@example.com>
-Resent-Sender: =?UtF-8?B?TmFkYWrEhWNhLCBBbGljamE=?= <alicja.nadajaca@example.net>
-Resent-To: =?UTF-8?B?T2RiaWVyYWrEhWN5LCBCb2I=?= <bob.odbierajacy@example.net>,
- =?utf-8?b?T2RiaWVyYWrEhWNhLCBLYXJvbGluYQ==?= <karolina.odbierajaca@example.net>
-Resent-Cc: =?uTF-8?b?T2RiaWVyYWrEhWN5LCBEYW5pZWw=?= <daniel.odbierajacy@example.net>,
- =?UTF-8?B?T2RiaWVyYWrEhWNhLCBFd2E=?= <ewa.odbierajaca@example.net>
-Resent-Bcc: =?uTF-8?B?T2RiaWVyYWrEhWN5LCBGcmFuZWs=?= <franek.odbierajacy@example.net>,
- =?UTF-8?B?T2RiaWVyYWrEhWNhLCBHcmHFvHluYQ==?= <grazyna.odbierajaca@example.net>
+Resent-From: =?UtF-8?B?Ik5hZGFqxIVjYSwgQWxpY2phIg==?= <alicja.nadajaca@example.net>,
+ =?UtF-8?B?Ik5hZGFqxIVjYSwgQWxpY2phIg==?= <alicja.nadajaca@example.com>
+Resent-Sender: =?UtF-8?B?Ik5hZGFqxIVjYSwgQWxpY2phIg==?= <alicja.nadajaca@example.net>
+Resent-To: =?UTF-8?B?Ik9kYmllcmFqxIVjeSwgQm9iIg==?= <bob.odbierajacy@example.net>,
+ =?utf-8?b?Ik9kYmllcmFqxIVjYSwgS2Fyb2xpbmEi?= <karolina.odbierajaca@example.net>
+Resent-Cc: =?uTF-8?b?Ik9kYmllcmFqxIVjeSwgRGFuaWVsIg==?= <daniel.odbierajacy@example.net>,
+ =?UTF-8?B?Ik9kYmllcmFqxIVjYSwgRXdhIg==?= <ewa.odbierajaca@example.net>
+Resent-Bcc: =?uTF-8?B?Ik9kYmllcmFqxIVjeSwgRnJhbmVrIg==?= <franek.odbierajacy@example.net>,
+ =?UTF-8?B?Ik9kYmllcmFqxIVjYSwgR3Jhxbx5bmEi?= <grazyna.odbierajaca@example.net>
 Resent-Message-ID: <Message-Id-1@example.net>
 Content-Type: MultIpart/RelatED; cHARSET="UTF-8"; BOUnDArY="RelatedBoundaryString"
 Content-Transfer-Encoding: BASE64

--- a/tests/test_polish_multipart_related_utf-8_over_quoted-printable.txt
+++ b/tests/test_polish_multipart_related_utf-8_over_quoted-printable.txt
@@ -1,14 +1,14 @@
 Date: Mon, 01 Apr 2019 07:55:00 +0200 (CEST)
-From: =?Utf-8?Q?Nadaj=C4=85ca,_Alicja?= <alicja.nadajaca@example.com>,
- =?Utf-8?Q?Nadaj=C4=85ca,_Alicja?= <alicja.nadajaca@example.net>
-Sender: =?Utf-8?Q?Nadaj=C4=85ca,_Alicja?= <alicja.nadajaca@example.com>
-Reply-To: =?Utf-8?Q?Nadaj=C4=85ca,_Alicja?= <alicja.nadajaca@example.net>
-To: =?UTF-8?Q?Odbieraj=C4=85cy,_Bob?= <bob.odbierajacy@example.com>,
- =?utF-8?q?Odbieraj=C4=85ca,_Karolina?= <karolina.odbierajaca@example.com>
-Cc: =?utf-8?Q?Odbieraj=C4=85cy,_Daniel?= <daniel.odbierajacy@example.com>,
- =?UTF-8?Q?Odbieraj=C4=85ca,_Ewa?= <ewa.odbierajaca@example.com>
-Bcc: =?uTF-8?Q?Odbieraj=C4=85cy,_Franek?= <franek.odbierajacy@example.com>,
- =?utf-8?Q?Odbieraj=C4=85ca,_Gra=C5=BCyna?= <grazyna.odbierajaca@example.com>
+From: =?Utf-8?Q?"Nadaj=C4=85ca,_Alicja"?= <alicja.nadajaca@example.com>,
+ =?Utf-8?Q?"Nadaj=C4=85ca,_Alicja"?= <alicja.nadajaca@example.net>
+Sender: =?Utf-8?Q?"Nadaj=C4=85ca,_Alicja"?= <alicja.nadajaca@example.com>
+Reply-To: =?Utf-8?Q?"Nadaj=C4=85ca,_Alicja"?= <alicja.nadajaca@example.net>
+To: =?UTF-8?Q?"Odbieraj=C4=85cy,_Bob"?= <bob.odbierajacy@example.com>,
+ =?utF-8?q?"Odbieraj=C4=85ca,_Karolina"?= <karolina.odbierajaca@example.com>
+Cc: =?utf-8?Q?"Odbieraj=C4=85cy,_Daniel"?= <daniel.odbierajacy@example.com>,
+ =?UTF-8?Q?"Odbieraj=C4=85ca,_Ewa"?= <ewa.odbierajaca@example.com>
+Bcc: =?uTF-8?Q?"Odbieraj=C4=85cy,_Franek"?= <franek.odbierajacy@example.com>,
+ =?utf-8?Q?"Odbieraj=C4=85ca,_Gra=C5=BCyna"?= <grazyna.odbierajaca@example.com>
 Subject: =?UTF-8?B?8J+Tpw==?= Test
  =?UTf-8?q?Polskie_pangramy?=
 In-Reply-To: <Message-Id-0@example.com>
@@ -17,15 +17,15 @@ Message-ID: <Message-Id-1@example.com>
 Comments: Message Header Comment
 Keywords: Keyword 1, Keyword 2
 Resent-Date: Mon, 01 Apr 2019 07:55:00 +0200 (CEST)
-Resent-From: =?Utf-8?Q?Nadaj=C4=85ca,_Alicja?= <alicja.nadajaca@example.net>,
- =?Utf-8?Q?Nadaj=C4=85ca,_Alicja?= <alicja.nadajaca@example.com>
-Resent-Sender: =?Utf-8?Q?Nadaj=C4=85ca,_Alicja?= <alicja.nadajaca@example.net>
-Resent-To: =?UTF-8?Q?Odbieraj=C4=85cy,_Bob?= <bob.odbierajacy@example.net>,
- =?utF-8?q?Odbieraj=C4=85ca,_Karolina?= <karolina.odbierajaca@example.net>
-Resent-Cc: =?utf-8?Q?Odbieraj=C4=85cy,_Daniel?= <daniel.odbierajacy@example.net>,
- =?UTF-8?Q?Odbieraj=C4=85ca,_Ewa?= <ewa.odbierajaca@example.net>
-Resent-Bcc: =?uTF-8?Q?Odbieraj=C4=85cy,_Franek?= <franek.odbierajacy@example.net>,
- =?utf-8?Q?Odbieraj=C4=85ca,_Gra=C5=BCyna?= <grazyna.odbierajaca@example.net>
+Resent-From: =?Utf-8?Q?"Nadaj=C4=85ca,_Alicja"?= <alicja.nadajaca@example.net>,
+ =?Utf-8?Q?"Nadaj=C4=85ca,_Alicja"?= <alicja.nadajaca@example.com>
+Resent-Sender: =?Utf-8?Q?"Nadaj=C4=85ca,_Alicja"?= <alicja.nadajaca@example.net>
+Resent-To: =?UTF-8?Q?"Odbieraj=C4=85cy,_Bob"?= <bob.odbierajacy@example.net>,
+ =?utF-8?q?"Odbieraj=C4=85ca,_Karolina"?= <karolina.odbierajaca@example.net>
+Resent-Cc: =?utf-8?Q?"Odbieraj=C4=85cy,_Daniel"?= <daniel.odbierajacy@example.net>,
+ =?UTF-8?Q?"Odbieraj=C4=85ca,_Ewa"?= <ewa.odbierajaca@example.net>
+Resent-Bcc: =?uTF-8?Q?"Odbieraj=C4=85cy,_Franek"?= <franek.odbierajacy@example.net>,
+ =?utf-8?Q?"Odbieraj=C4=85ca,_Gra=C5=BCyna"?= <grazyna.odbierajaca@example.net>
 Resent-Message-ID: <Message-Id-1@example.net>
 Content-Type: multipart/reLATED; CHARSeT="utf-8"; bouNDARY="RelatedBoundaryString"
 Content-Transfer-Encoding: QUOTED-PRintable

--- a/tests/test_polish_multipart_signed_iso-8859-2_over_base64.txt
+++ b/tests/test_polish_multipart_signed_iso-8859-2_over_base64.txt
@@ -1,14 +1,14 @@
 Date: Mon, 01 Apr 2019 07:55:00 +0200 (CEST)
-From: =?Iso-8859-2?b?TmFkYWqxY2EsIEFsaWNqYQ==?= <alicja.nadajaca@example.com>,
- =?Iso-8859-2?b?TmFkYWqxY2EsIEFsaWNqYQ==?= <alicja.nadajaca@example.net>
-Sender: =?Iso-8859-2?b?TmFkYWqxY2EsIEFsaWNqYQ==?= <alicja.nadajaca@example.com>
-Reply-To: =?Iso-8859-2?b?TmFkYWqxY2EsIEFsaWNqYQ==?= <alicja.nadajaca@example.net>
-To: =?iSo-8859-2?b?T2RiaWVyYWqxY3ksIEJvYg==?= <bob.odbierajacy@example.com>,
- =?ISO-8859-2?B?T2RiaWVyYWqxY2EsIEthcm9saW5h?= <karolina.odbierajaca@example.com>
-Cc: =?iSO-8859-2?b?T2RiaWVyYWqxY3ksIERhbmllbA==?= <daniel.odbierajacy@example.com>,
- =?iso-8859-2?b?T2RiaWVyYWqxY2EsIEV3YQ==?= <ewa.odbierajaca@example.com>
-Bcc: =?ISO-8859-2?b?T2RiaWVyYWqxY3ksIEZyYW5law==?= <franek.odbierajacy@example.com>,
- =?ISO-8859-2?B?T2RiaWVyYWqxY2EsIEdyYb95bmE=?= <grazyna.odbierajaca@example.com>
+From: =?Iso-8859-2?b?Ik5hZGFqsWNhLCBBbGljamEi?= <alicja.nadajaca@example.com>,
+ =?Iso-8859-2?b?Ik5hZGFqsWNhLCBBbGljamEi?= <alicja.nadajaca@example.net>
+Sender: =?Iso-8859-2?b?Ik5hZGFqsWNhLCBBbGljamEi?= <alicja.nadajaca@example.com>
+Reply-To: =?Iso-8859-2?b?Ik5hZGFqsWNhLCBBbGljamEi?= <alicja.nadajaca@example.net>
+To: =?iSo-8859-2?b?Ik9kYmllcmFqsWN5LCBCb2Ii?= <bob.odbierajacy@example.com>,
+ =?ISO-8859-2?B?Ik9kYmllcmFqsWNhLCBLYXJvbGluYSI=?= <karolina.odbierajaca@example.com>
+Cc: =?iSO-8859-2?b?Ik9kYmllcmFqsWN5LCBEYW5pZWwi?= <daniel.odbierajacy@example.com>,
+ =?iso-8859-2?b?Ik9kYmllcmFqsWNhLCBFd2Ei?= <ewa.odbierajaca@example.com>
+Bcc: =?ISO-8859-2?b?Ik9kYmllcmFqsWN5LCBGcmFuZWsi?= <franek.odbierajacy@example.com>,
+ =?ISO-8859-2?B?Ik9kYmllcmFqsWNhLCBHcmG/eW5hIg==?= <grazyna.odbierajaca@example.com>
 Subject: =?UTF-8?B?8J+Tpw==?= Signed Test
  =?ISO-8859-2?b?UG9sc2tpZSBwYW5ncmFteQ==?=
 In-Reply-To: <Message-Id-0@example.com>
@@ -17,15 +17,15 @@ Message-ID: <Message-Id-1@example.com>
 Comments: Message Header Comment
 Keywords: Keyword 1, Keyword 2
 Resent-Date: Mon, 01 Apr 2019 07:55:00 +0200 (CEST)
-Resent-From: =?Iso-8859-2?b?TmFkYWqxY2EsIEFsaWNqYQ==?= <alicja.nadajaca@example.net>,
- =?Iso-8859-2?b?TmFkYWqxY2EsIEFsaWNqYQ==?= <alicja.nadajaca@example.com>
-Resent-Sender: =?Iso-8859-2?b?TmFkYWqxY2EsIEFsaWNqYQ==?= <alicja.nadajaca@example.net>
-Resent-To: =?iSo-8859-2?b?T2RiaWVyYWqxY3ksIEJvYg==?= <bob.odbierajacy@example.net>,
- =?ISO-8859-2?B?T2RiaWVyYWqxY2EsIEthcm9saW5h?= <karolina.odbierajaca@example.net>
-Resent-Cc: =?iSO-8859-2?b?T2RiaWVyYWqxY3ksIERhbmllbA==?= <daniel.odbierajacy@example.net>,
- =?iso-8859-2?b?T2RiaWVyYWqxY2EsIEV3YQ==?= <ewa.odbierajaca@example.net>
-Resent-Bcc: =?ISO-8859-2?b?T2RiaWVyYWqxY3ksIEZyYW5law==?= <franek.odbierajacy@example.net>,
- =?ISO-8859-2?B?T2RiaWVyYWqxY2EsIEdyYb95bmE=?= <grazyna.odbierajaca@example.net>
+Resent-From: =?Iso-8859-2?b?Ik5hZGFqsWNhLCBBbGljamEi?= <alicja.nadajaca@example.net>,
+ =?Iso-8859-2?b?Ik5hZGFqsWNhLCBBbGljamEi?= <alicja.nadajaca@example.com>
+Resent-Sender: =?Iso-8859-2?b?Ik5hZGFqsWNhLCBBbGljamEi?= <alicja.nadajaca@example.net>
+Resent-To: =?iSo-8859-2?b?Ik9kYmllcmFqsWN5LCBCb2Ii?= <bob.odbierajacy@example.net>,
+ =?ISO-8859-2?B?Ik9kYmllcmFqsWNhLCBLYXJvbGluYSI=?= <karolina.odbierajaca@example.net>
+Resent-Cc: =?iSO-8859-2?b?Ik9kYmllcmFqsWN5LCBEYW5pZWwi?= <daniel.odbierajacy@example.net>,
+ =?iso-8859-2?b?Ik9kYmllcmFqsWNhLCBFd2Ei?= <ewa.odbierajaca@example.net>
+Resent-Bcc: =?ISO-8859-2?b?Ik9kYmllcmFqsWN5LCBGcmFuZWsi?= <franek.odbierajacy@example.net>,
+ =?ISO-8859-2?B?Ik9kYmllcmFqsWNhLCBHcmG/eW5hIg==?= <grazyna.odbierajaca@example.net>
 Resent-Message-ID: <Message-Id-1@example.net>
 Content-Type: MulTiparT/SIgneD;
               chaRSET="ISO-8859-2";

--- a/tests/test_polish_multipart_signed_iso-8859-2_over_quoted-printable.txt
+++ b/tests/test_polish_multipart_signed_iso-8859-2_over_quoted-printable.txt
@@ -1,14 +1,14 @@
 Date: Mon, 01 Apr 2019 07:55:00 +0200 (CEST)
-From: =?ISO-8859-2?q?Nadaj=B1ca,_Alicja?= <alicja.nadajaca@example.com>,
- =?ISO-8859-2?q?Nadaj=B1ca,_Alicja?= <alicja.nadajaca@example.net>
-Sender: =?ISO-8859-2?q?Nadaj=B1ca,_Alicja?= <alicja.nadajaca@example.com>
-Reply-To: =?ISO-8859-2?q?Nadaj=B1ca,_Alicja?= <alicja.nadajaca@example.net>
-To: =?Iso-8859-2?q?Odbieraj=B1cy,_Bob?= <bob.odbierajacy@example.com>,
- =?ISO-8859-2?Q?Odbieraj=B1ca,_Karolina?= <karolina.odbierajaca@example.com>
-Cc: =?iSo-8859-2?Q?Odbieraj=B1cy,_Daniel?= <daniel.odbierajacy@example.com>,
- =?Iso-8859-2?Q?Odbieraj=B1ca,_Ewa?= <ewa.odbierajaca@example.com>
-Bcc: =?iso-8859-2?q?Odbieraj=B1cy,_Franek?= <franek.odbierajacy@example.com>,
- =?ISO-8859-2?q?Odbieraj=B1ca,_Gra=BFyna?= <grazyna.odbierajaca@example.com>
+From: =?ISO-8859-2?q?"Nadaj=B1ca,_Alicja"?= <alicja.nadajaca@example.com>,
+ =?ISO-8859-2?q?"Nadaj=B1ca,_Alicja"?= <alicja.nadajaca@example.net>
+Sender: =?ISO-8859-2?q?"Nadaj=B1ca,_Alicja"?= <alicja.nadajaca@example.com>
+Reply-To: =?ISO-8859-2?q?"Nadaj=B1ca,_Alicja"?= <alicja.nadajaca@example.net>
+To: =?Iso-8859-2?q?"Odbieraj=B1cy,_Bob"?= <bob.odbierajacy@example.com>,
+ =?ISO-8859-2?Q?"Odbieraj=B1ca,_Karolina"?= <karolina.odbierajaca@example.com>
+Cc: =?iSo-8859-2?Q?"Odbieraj=B1cy,_Daniel"?= <daniel.odbierajacy@example.com>,
+ =?Iso-8859-2?Q?"Odbieraj=B1ca,_Ewa"?= <ewa.odbierajaca@example.com>
+Bcc: =?iso-8859-2?q?"Odbieraj=B1cy,_Franek"?= <franek.odbierajacy@example.com>,
+ =?ISO-8859-2?q?"Odbieraj=B1ca,_Gra=BFyna"?= <grazyna.odbierajaca@example.com>
 Subject: =?UTF-8?B?8J+Tpw==?= Signed Test
  =?iso-8859-2?Q?Polskie_pangramy?=
 In-Reply-To: <Message-Id-0@example.com>
@@ -17,15 +17,15 @@ Message-ID: <Message-Id-1@example.com>
 Comments: Message Header Comment
 Keywords: Keyword 1, Keyword 2
 Resent-Date: Mon, 01 Apr 2019 07:55:00 +0200 (CEST)
-Resent-From: =?ISO-8859-2?q?Nadaj=B1ca,_Alicja?= <alicja.nadajaca@example.net>,
- =?ISO-8859-2?q?Nadaj=B1ca,_Alicja?= <alicja.nadajaca@example.com>
-Resent-Sender: =?ISO-8859-2?q?Nadaj=B1ca,_Alicja?= <alicja.nadajaca@example.net>
-Resent-To: =?Iso-8859-2?q?Odbieraj=B1cy,_Bob?= <bob.odbierajacy@example.net>,
- =?ISO-8859-2?Q?Odbieraj=B1ca,_Karolina?= <karolina.odbierajaca@example.net>
-Resent-Cc: =?iSo-8859-2?Q?Odbieraj=B1cy,_Daniel?= <daniel.odbierajacy@example.net>,
- =?Iso-8859-2?Q?Odbieraj=B1ca,_Ewa?= <ewa.odbierajaca@example.net>
-Resent-Bcc: =?iso-8859-2?q?Odbieraj=B1cy,_Franek?= <franek.odbierajacy@example.net>,
- =?ISO-8859-2?q?Odbieraj=B1ca,_Gra=BFyna?= <grazyna.odbierajaca@example.net>
+Resent-From: =?ISO-8859-2?q?"Nadaj=B1ca,_Alicja"?= <alicja.nadajaca@example.net>,
+ =?ISO-8859-2?q?"Nadaj=B1ca,_Alicja"?= <alicja.nadajaca@example.com>
+Resent-Sender: =?ISO-8859-2?q?"Nadaj=B1ca,_Alicja"?= <alicja.nadajaca@example.net>
+Resent-To: =?Iso-8859-2?q?"Odbieraj=B1cy,_Bob"?= <bob.odbierajacy@example.net>,
+ =?ISO-8859-2?Q?"Odbieraj=B1ca,_Karolina"?= <karolina.odbierajaca@example.net>
+Resent-Cc: =?iSo-8859-2?Q?"Odbieraj=B1cy,_Daniel"?= <daniel.odbierajacy@example.net>,
+ =?Iso-8859-2?Q?"Odbieraj=B1ca,_Ewa"?= <ewa.odbierajaca@example.net>
+Resent-Bcc: =?iso-8859-2?q?"Odbieraj=B1cy,_Franek"?= <franek.odbierajacy@example.net>,
+ =?ISO-8859-2?q?"Odbieraj=B1ca,_Gra=BFyna"?= <grazyna.odbierajaca@example.net>
 Resent-Message-ID: <Message-Id-1@example.net>
 Content-Type: MUlTIpart/signed;
               cHarSET="iso-8859-2";

--- a/tests/test_polish_multipart_signed_utf-8_over_base64.txt
+++ b/tests/test_polish_multipart_signed_utf-8_over_base64.txt
@@ -1,14 +1,14 @@
 Date: Mon, 01 Apr 2019 07:55:00 +0200 (CEST)
-From: =?utf-8?b?TmFkYWrEhWNhLCBBbGljamE=?= <alicja.nadajaca@example.com>,
- =?utf-8?b?TmFkYWrEhWNhLCBBbGljamE=?= <alicja.nadajaca@example.net>
-Sender: =?utf-8?b?TmFkYWrEhWNhLCBBbGljamE=?= <alicja.nadajaca@example.com>
-Reply-To: =?utf-8?b?TmFkYWrEhWNhLCBBbGljamE=?= <alicja.nadajaca@example.net>
-To: =?uTF-8?b?T2RiaWVyYWrEhWN5LCBCb2I=?= <bob.odbierajacy@example.com>,
- =?UTF-8?B?T2RiaWVyYWrEhWNhLCBLYXJvbGluYQ==?= <karolina.odbierajaca@example.com>
-Cc: =?uTF-8?b?T2RiaWVyYWrEhWN5LCBEYW5pZWw=?= <daniel.odbierajacy@example.com>,
- =?UTf-8?B?T2RiaWVyYWrEhWNhLCBFd2E=?= <ewa.odbierajaca@example.com>
-Bcc: =?utf-8?b?T2RiaWVyYWrEhWN5LCBGcmFuZWs=?= <franek.odbierajacy@example.com>,
- =?uTf-8?B?T2RiaWVyYWrEhWNhLCBHcmHFvHluYQ==?= <grazyna.odbierajaca@example.com>
+From: =?utf-8?b?Ik5hZGFqxIVjYSwgQWxpY2phIg==?= <alicja.nadajaca@example.com>,
+ =?utf-8?b?Ik5hZGFqxIVjYSwgQWxpY2phIg==?= <alicja.nadajaca@example.net>
+Sender: =?utf-8?b?Ik5hZGFqxIVjYSwgQWxpY2phIg==?= <alicja.nadajaca@example.com>
+Reply-To: =?utf-8?b?Ik5hZGFqxIVjYSwgQWxpY2phIg==?= <alicja.nadajaca@example.net>
+To: =?uTF-8?b?Ik9kYmllcmFqxIVjeSwgQm9iIg==?= <bob.odbierajacy@example.com>,
+ =?UTF-8?B?Ik9kYmllcmFqxIVjYSwgS2Fyb2xpbmEi?= <karolina.odbierajaca@example.com>
+Cc: =?uTF-8?b?Ik9kYmllcmFqxIVjeSwgRGFuaWVsIg==?= <daniel.odbierajacy@example.com>,
+ =?UTf-8?B?Ik9kYmllcmFqxIVjYSwgRXdhIg==?= <ewa.odbierajaca@example.com>
+Bcc: =?utf-8?b?Ik9kYmllcmFqxIVjeSwgRnJhbmVrIg==?= <franek.odbierajacy@example.com>,
+ =?uTf-8?B?Ik9kYmllcmFqxIVjYSwgR3Jhxbx5bmEi?= <grazyna.odbierajaca@example.com>
 Subject: =?UTF-8?B?8J+Tpw==?= Signed Test
  =?utF-8?B?UG9sc2tpZSBwYW5ncmFteQ==?=
 In-Reply-To: <Message-Id-0@example.com>
@@ -17,15 +17,15 @@ Message-ID: <Message-Id-1@example.com>
 Comments: Message Header Comment
 Keywords: Keyword 1, Keyword 2
 Resent-Date: Mon, 01 Apr 2019 07:55:00 +0200 (CEST)
-Resent-From: =?utf-8?b?TmFkYWrEhWNhLCBBbGljamE=?= <alicja.nadajaca@example.net>,
- =?utf-8?b?TmFkYWrEhWNhLCBBbGljamE=?= <alicja.nadajaca@example.com>
-Resent-Sender: =?utf-8?b?TmFkYWrEhWNhLCBBbGljamE=?= <alicja.nadajaca@example.net>
-Resent-To: =?uTF-8?b?T2RiaWVyYWrEhWN5LCBCb2I=?= <bob.odbierajacy@example.net>,
- =?UTF-8?B?T2RiaWVyYWrEhWNhLCBLYXJvbGluYQ==?= <karolina.odbierajaca@example.net>
-Resent-Cc: =?uTF-8?b?T2RiaWVyYWrEhWN5LCBEYW5pZWw=?= <daniel.odbierajacy@example.net>,
- =?UTf-8?B?T2RiaWVyYWrEhWNhLCBFd2E=?= <ewa.odbierajaca@example.net>
-Resent-Bcc: =?utf-8?b?T2RiaWVyYWrEhWN5LCBGcmFuZWs=?= <franek.odbierajacy@example.net>,
- =?uTf-8?B?T2RiaWVyYWrEhWNhLCBHcmHFvHluYQ==?= <grazyna.odbierajaca@example.net>
+Resent-From: =?utf-8?b?Ik5hZGFqxIVjYSwgQWxpY2phIg==?= <alicja.nadajaca@example.net>,
+ =?utf-8?b?Ik5hZGFqxIVjYSwgQWxpY2phIg==?= <alicja.nadajaca@example.com>
+Resent-Sender: =?utf-8?b?Ik5hZGFqxIVjYSwgQWxpY2phIg==?= <alicja.nadajaca@example.net>
+Resent-To: =?uTF-8?b?Ik9kYmllcmFqxIVjeSwgQm9iIg==?= <bob.odbierajacy@example.net>,
+ =?UTF-8?B?Ik9kYmllcmFqxIVjYSwgS2Fyb2xpbmEi?= <karolina.odbierajaca@example.net>
+Resent-Cc: =?uTF-8?b?Ik9kYmllcmFqxIVjeSwgRGFuaWVsIg==?= <daniel.odbierajacy@example.net>,
+ =?UTf-8?B?Ik9kYmllcmFqxIVjYSwgRXdhIg==?= <ewa.odbierajaca@example.net>
+Resent-Bcc: =?utf-8?b?Ik9kYmllcmFqxIVjeSwgRnJhbmVrIg==?= <franek.odbierajacy@example.net>,
+ =?uTf-8?B?Ik9kYmllcmFqxIVjYSwgR3Jhxbx5bmEi?= <grazyna.odbierajaca@example.net>
 Resent-Message-ID: <Message-Id-1@example.net>
 Content-Type: multiparT/sIGNED;
               CHARSET="UTF-8";

--- a/tests/test_polish_multipart_signed_utf-8_over_quoted-printable.txt
+++ b/tests/test_polish_multipart_signed_utf-8_over_quoted-printable.txt
@@ -1,14 +1,14 @@
 Date: Mon, 01 Apr 2019 07:55:00 +0200 (CEST)
-From: =?utF-8?q?Nadaj=C4=85ca,_Alicja?= <alicja.nadajaca@example.com>,
- =?utF-8?q?Nadaj=C4=85ca,_Alicja?= <alicja.nadajaca@example.net>
-Sender: =?utF-8?q?Nadaj=C4=85ca,_Alicja?= <alicja.nadajaca@example.com>
-Reply-To: =?utF-8?q?Nadaj=C4=85ca,_Alicja?= <alicja.nadajaca@example.net>
-To: =?UTF-8?Q?Odbieraj=C4=85cy,_Bob?= <bob.odbierajacy@example.com>,
- =?UTf-8?Q?Odbieraj=C4=85ca,_Karolina?= <karolina.odbierajaca@example.com>
-Cc: =?utf-8?q?Odbieraj=C4=85cy,_Daniel?= <daniel.odbierajacy@example.com>,
- =?Utf-8?Q?Odbieraj=C4=85ca,_Ewa?= <ewa.odbierajaca@example.com>
-Bcc: =?UTF-8?Q?Odbieraj=C4=85cy,_Franek?= <franek.odbierajacy@example.com>,
- =?UTF-8?q?Odbieraj=C4=85ca,_Gra=C5=BCyna?= <grazyna.odbierajaca@example.com>
+From: =?utF-8?q?"Nadaj=C4=85ca,_Alicja"?= <alicja.nadajaca@example.com>,
+ =?utF-8?q?"Nadaj=C4=85ca,_Alicja"?= <alicja.nadajaca@example.net>
+Sender: =?utF-8?q?"Nadaj=C4=85ca,_Alicja"?= <alicja.nadajaca@example.com>
+Reply-To: =?utF-8?q?"Nadaj=C4=85ca,_Alicja"?= <alicja.nadajaca@example.net>
+To: =?UTF-8?Q?"Odbieraj=C4=85cy,_Bob"?= <bob.odbierajacy@example.com>,
+ =?UTf-8?Q?"Odbieraj=C4=85ca,_Karolina"?= <karolina.odbierajaca@example.com>
+Cc: =?utf-8?q?"Odbieraj=C4=85cy,_Daniel"?= <daniel.odbierajacy@example.com>,
+ =?Utf-8?Q?"Odbieraj=C4=85ca,_Ewa"?= <ewa.odbierajaca@example.com>
+Bcc: =?UTF-8?Q?"Odbieraj=C4=85cy,_Franek"?= <franek.odbierajacy@example.com>,
+ =?UTF-8?q?"Odbieraj=C4=85ca,_Gra=C5=BCyna"?= <grazyna.odbierajaca@example.com>
 Subject: =?UTF-8?B?8J+Tpw==?= Signed Test
  =?UTF-8?Q?Polskie_pangramy?=
 In-Reply-To: <Message-Id-0@example.com>
@@ -17,15 +17,15 @@ Message-ID: <Message-Id-1@example.com>
 Comments: Message Header Comment
 Keywords: Keyword 1, Keyword 2
 Resent-Date: Mon, 01 Apr 2019 07:55:00 +0200 (CEST)
-Resent-From: =?utF-8?q?Nadaj=C4=85ca,_Alicja?= <alicja.nadajaca@example.net>,
- =?utF-8?q?Nadaj=C4=85ca,_Alicja?= <alicja.nadajaca@example.com>
-Resent-Sender: =?utF-8?q?Nadaj=C4=85ca,_Alicja?= <alicja.nadajaca@example.net>
-Resent-To: =?UTF-8?Q?Odbieraj=C4=85cy,_Bob?= <bob.odbierajacy@example.net>,
- =?UTf-8?Q?Odbieraj=C4=85ca,_Karolina?= <karolina.odbierajaca@example.net>
-Resent-Cc: =?utf-8?q?Odbieraj=C4=85cy,_Daniel?= <daniel.odbierajacy@example.net>,
- =?Utf-8?Q?Odbieraj=C4=85ca,_Ewa?= <ewa.odbierajaca@example.net>
-Resent-Bcc: =?UTF-8?Q?Odbieraj=C4=85cy,_Franek?= <franek.odbierajacy@example.net>,
- =?UTF-8?q?Odbieraj=C4=85ca,_Gra=C5=BCyna?= <grazyna.odbierajaca@example.net>
+Resent-From: =?utF-8?q?"Nadaj=C4=85ca,_Alicja"?= <alicja.nadajaca@example.net>,
+ =?utF-8?q?"Nadaj=C4=85ca,_Alicja"?= <alicja.nadajaca@example.com>
+Resent-Sender: =?utF-8?q?"Nadaj=C4=85ca,_Alicja"?= <alicja.nadajaca@example.net>
+Resent-To: =?UTF-8?Q?"Odbieraj=C4=85cy,_Bob"?= <bob.odbierajacy@example.net>,
+ =?UTf-8?Q?"Odbieraj=C4=85ca,_Karolina"?= <karolina.odbierajaca@example.net>
+Resent-Cc: =?utf-8?q?"Odbieraj=C4=85cy,_Daniel"?= <daniel.odbierajacy@example.net>,
+ =?Utf-8?Q?"Odbieraj=C4=85ca,_Ewa"?= <ewa.odbierajaca@example.net>
+Resent-Bcc: =?UTF-8?Q?"Odbieraj=C4=85cy,_Franek"?= <franek.odbierajacy@example.net>,
+ =?UTF-8?q?"Odbieraj=C4=85ca,_Gra=C5=BCyna"?= <grazyna.odbierajaca@example.net>
 Resent-Message-ID: <Message-Id-1@example.net>
 Content-Type: multipaRt/SiGned;
               charset="utf-8";

--- a/tests/test_polish_plaintext_iso-8859-2_over_base64.txt
+++ b/tests/test_polish_plaintext_iso-8859-2_over_base64.txt
@@ -1,14 +1,14 @@
 Date: Mon, 01 Apr 2019 07:55:00 +0200 (CEST)
-From: =?ISo-8859-2?B?TmFkYWqxY2EsIEFsaWNqYQ==?= <alicja.nadajaca@example.com>,
- =?ISo-8859-2?B?TmFkYWqxY2EsIEFsaWNqYQ==?= <alicja.nadajaca@example.net>
-Sender: =?ISo-8859-2?B?TmFkYWqxY2EsIEFsaWNqYQ==?= <alicja.nadajaca@example.com>
-Reply-To: =?ISo-8859-2?B?TmFkYWqxY2EsIEFsaWNqYQ==?= <alicja.nadajaca@example.net>
-To: =?iSo-8859-2?b?T2RiaWVyYWqxY3ksIEJvYg==?= <bob.odbierajacy@example.com>,
- =?iso-8859-2?B?T2RiaWVyYWqxY2EsIEthcm9saW5h?= <karolina.odbierajaca@example.com>
-Cc: =?IsO-8859-2?B?T2RiaWVyYWqxY3ksIERhbmllbA==?= <daniel.odbierajacy@example.com>,
- =?iso-8859-2?B?T2RiaWVyYWqxY2EsIEV3YQ==?= <ewa.odbierajaca@example.com>
-Bcc: =?Iso-8859-2?b?T2RiaWVyYWqxY3ksIEZyYW5law==?= <franek.odbierajacy@example.com>,
- =?iso-8859-2?B?T2RiaWVyYWqxY2EsIEdyYb95bmE=?= <grazyna.odbierajaca@example.com>
+From: =?ISo-8859-2?B?Ik5hZGFqsWNhLCBBbGljamEi?= <alicja.nadajaca@example.com>,
+ =?ISo-8859-2?B?Ik5hZGFqsWNhLCBBbGljamEi?= <alicja.nadajaca@example.net>
+Sender: =?ISo-8859-2?B?Ik5hZGFqsWNhLCBBbGljamEi?= <alicja.nadajaca@example.com>
+Reply-To: =?ISo-8859-2?B?Ik5hZGFqsWNhLCBBbGljamEi?= <alicja.nadajaca@example.net>
+To: =?iSo-8859-2?b?Ik9kYmllcmFqsWN5LCBCb2Ii?= <bob.odbierajacy@example.com>,
+ =?iso-8859-2?B?Ik9kYmllcmFqsWNhLCBLYXJvbGluYSI=?= <karolina.odbierajaca@example.com>
+Cc: =?IsO-8859-2?B?Ik9kYmllcmFqsWN5LCBEYW5pZWwi?= <daniel.odbierajacy@example.com>,
+ =?iso-8859-2?B?Ik9kYmllcmFqsWNhLCBFd2Ei?= <ewa.odbierajaca@example.com>
+Bcc: =?Iso-8859-2?b?Ik9kYmllcmFqsWN5LCBGcmFuZWsi?= <franek.odbierajacy@example.com>,
+ =?iso-8859-2?B?Ik9kYmllcmFqsWNhLCBHcmG/eW5hIg==?= <grazyna.odbierajaca@example.com>
 Subject: =?UTF-8?B?8J+Tpw==?= Test
  =?IsO-8859-2?b?UG9sc2tpZSBwYW5ncmFteQ==?=
 In-Reply-To: <Message-Id-0@example.com>
@@ -17,15 +17,15 @@ Message-ID: <Message-Id-1@example.com>
 Comments: Message Header Comment
 Keywords: Keyword 1, Keyword 2
 Resent-Date: Mon, 01 Apr 2019 07:55:00 +0200 (CEST)
-Resent-From: =?ISo-8859-2?B?TmFkYWqxY2EsIEFsaWNqYQ==?= <alicja.nadajaca@example.net>,
- =?ISo-8859-2?B?TmFkYWqxY2EsIEFsaWNqYQ==?= <alicja.nadajaca@example.com>
-Resent-Sender: =?ISo-8859-2?B?TmFkYWqxY2EsIEFsaWNqYQ==?= <alicja.nadajaca@example.net>
-Resent-To: =?iSo-8859-2?b?T2RiaWVyYWqxY3ksIEJvYg==?= <bob.odbierajacy@example.net>,
- =?iso-8859-2?B?T2RiaWVyYWqxY2EsIEthcm9saW5h?= <karolina.odbierajaca@example.net>
-Resent-Cc: =?IsO-8859-2?B?T2RiaWVyYWqxY3ksIERhbmllbA==?= <daniel.odbierajacy@example.net>,
- =?iso-8859-2?B?T2RiaWVyYWqxY2EsIEV3YQ==?= <ewa.odbierajaca@example.net>
-Resent-Bcc: =?Iso-8859-2?b?T2RiaWVyYWqxY3ksIEZyYW5law==?= <franek.odbierajacy@example.net>,
- =?iso-8859-2?B?T2RiaWVyYWqxY2EsIEdyYb95bmE=?= <grazyna.odbierajaca@example.net>
+Resent-From: =?ISo-8859-2?B?Ik5hZGFqsWNhLCBBbGljamEi?= <alicja.nadajaca@example.net>,
+ =?ISo-8859-2?B?Ik5hZGFqsWNhLCBBbGljamEi?= <alicja.nadajaca@example.com>
+Resent-Sender: =?ISo-8859-2?B?Ik5hZGFqsWNhLCBBbGljamEi?= <alicja.nadajaca@example.net>
+Resent-To: =?iSo-8859-2?b?Ik9kYmllcmFqsWN5LCBCb2Ii?= <bob.odbierajacy@example.net>,
+ =?iso-8859-2?B?Ik9kYmllcmFqsWNhLCBLYXJvbGluYSI=?= <karolina.odbierajaca@example.net>
+Resent-Cc: =?IsO-8859-2?B?Ik9kYmllcmFqsWN5LCBEYW5pZWwi?= <daniel.odbierajacy@example.net>,
+ =?iso-8859-2?B?Ik9kYmllcmFqsWNhLCBFd2Ei?= <ewa.odbierajaca@example.net>
+Resent-Bcc: =?Iso-8859-2?b?Ik9kYmllcmFqsWN5LCBGcmFuZWsi?= <franek.odbierajacy@example.net>,
+ =?iso-8859-2?B?Ik9kYmllcmFqsWNhLCBHcmG/eW5hIg==?= <grazyna.odbierajaca@example.net>
 Resent-Message-ID: <Message-Id-1@example.net>
 Content-Type: TEXT/pLain; charsET=IsO-8859-2
 Content-Transfer-Encoding: bAsE64

--- a/tests/test_polish_plaintext_iso-8859-2_over_quoted-printable.txt
+++ b/tests/test_polish_plaintext_iso-8859-2_over_quoted-printable.txt
@@ -1,14 +1,14 @@
 Date: Mon, 01 Apr 2019 07:55:00 +0200 (CEST)
-From: =?ISO-8859-2?q?Nadaj=B1ca,_Alicja?= <alicja.nadajaca@example.com>,
- =?ISO-8859-2?q?Nadaj=B1ca,_Alicja?= <alicja.nadajaca@example.net>
-Sender: =?ISO-8859-2?q?Nadaj=B1ca,_Alicja?= <alicja.nadajaca@example.com>
-Reply-To: =?ISO-8859-2?q?Nadaj=B1ca,_Alicja?= <alicja.nadajaca@example.net>
-To: =?iso-8859-2?q?Odbieraj=B1cy,_Bob?= <bob.odbierajacy@example.com>,
- =?ISO-8859-2?Q?Odbieraj=B1ca,_Karolina?= <karolina.odbierajaca@example.com>
-Cc: =?ISO-8859-2?q?Odbieraj=B1cy,_Daniel?= <daniel.odbierajacy@example.com>,
- =?iso-8859-2?Q?Odbieraj=B1ca,_Ewa?= <ewa.odbierajaca@example.com>
-Bcc: =?iso-8859-2?Q?Odbieraj=B1cy,_Franek?= <franek.odbierajacy@example.com>,
- =?Iso-8859-2?q?Odbieraj=B1ca,_Gra=BFyna?= <grazyna.odbierajaca@example.com>
+From: =?ISO-8859-2?q?"Nadaj=B1ca,_Alicja"?= <alicja.nadajaca@example.com>,
+ =?ISO-8859-2?q?"Nadaj=B1ca,_Alicja"?= <alicja.nadajaca@example.net>
+Sender: =?ISO-8859-2?q?"Nadaj=B1ca,_Alicja"?= <alicja.nadajaca@example.com>
+Reply-To: =?ISO-8859-2?q?"Nadaj=B1ca,_Alicja"?= <alicja.nadajaca@example.net>
+To: =?iso-8859-2?q?"Odbieraj=B1cy,_Bob"?= <bob.odbierajacy@example.com>,
+ =?ISO-8859-2?Q?"Odbieraj=B1ca,_Karolina"?= <karolina.odbierajaca@example.com>
+Cc: =?ISO-8859-2?q?"Odbieraj=B1cy,_Daniel"?= <daniel.odbierajacy@example.com>,
+ =?iso-8859-2?Q?"Odbieraj=B1ca,_Ewa"?= <ewa.odbierajaca@example.com>
+Bcc: =?iso-8859-2?Q?"Odbieraj=B1cy,_Franek"?= <franek.odbierajacy@example.com>,
+ =?Iso-8859-2?q?"Odbieraj=B1ca,_Gra=BFyna"?= <grazyna.odbierajaca@example.com>
 Subject: =?UTF-8?B?8J+Tpw==?= Test
  =?iso-8859-2?Q?Polskie_pangramy?=
 In-Reply-To: <Message-Id-0@example.com>
@@ -17,15 +17,15 @@ Message-ID: <Message-Id-1@example.com>
 Comments: Message Header Comment
 Keywords: Keyword 1, Keyword 2
 Resent-Date: Mon, 01 Apr 2019 07:55:00 +0200 (CEST)
-Resent-From: =?ISO-8859-2?q?Nadaj=B1ca,_Alicja?= <alicja.nadajaca@example.net>,
- =?ISO-8859-2?q?Nadaj=B1ca,_Alicja?= <alicja.nadajaca@example.com>
-Resent-Sender: =?ISO-8859-2?q?Nadaj=B1ca,_Alicja?= <alicja.nadajaca@example.net>
-Resent-To: =?iso-8859-2?q?Odbieraj=B1cy,_Bob?= <bob.odbierajacy@example.net>,
- =?ISO-8859-2?Q?Odbieraj=B1ca,_Karolina?= <karolina.odbierajaca@example.net>
-Resent-Cc: =?ISO-8859-2?q?Odbieraj=B1cy,_Daniel?= <daniel.odbierajacy@example.net>,
- =?iso-8859-2?Q?Odbieraj=B1ca,_Ewa?= <ewa.odbierajaca@example.net>
-Resent-Bcc: =?iso-8859-2?Q?Odbieraj=B1cy,_Franek?= <franek.odbierajacy@example.net>,
- =?Iso-8859-2?q?Odbieraj=B1ca,_Gra=BFyna?= <grazyna.odbierajaca@example.net>
+Resent-From: =?ISO-8859-2?q?"Nadaj=B1ca,_Alicja"?= <alicja.nadajaca@example.net>,
+ =?ISO-8859-2?q?"Nadaj=B1ca,_Alicja"?= <alicja.nadajaca@example.com>
+Resent-Sender: =?ISO-8859-2?q?"Nadaj=B1ca,_Alicja"?= <alicja.nadajaca@example.net>
+Resent-To: =?iso-8859-2?q?"Odbieraj=B1cy,_Bob"?= <bob.odbierajacy@example.net>,
+ =?ISO-8859-2?Q?"Odbieraj=B1ca,_Karolina"?= <karolina.odbierajaca@example.net>
+Resent-Cc: =?ISO-8859-2?q?"Odbieraj=B1cy,_Daniel"?= <daniel.odbierajacy@example.net>,
+ =?iso-8859-2?Q?"Odbieraj=B1ca,_Ewa"?= <ewa.odbierajaca@example.net>
+Resent-Bcc: =?iso-8859-2?Q?"Odbieraj=B1cy,_Franek"?= <franek.odbierajacy@example.net>,
+ =?Iso-8859-2?q?"Odbieraj=B1ca,_Gra=BFyna"?= <grazyna.odbierajaca@example.net>
 Resent-Message-ID: <Message-Id-1@example.net>
 Content-Type: texT/pLain; charset=iso-8859-2
 Content-Transfer-Encoding: QUOTED-PrIntAbLE

--- a/tests/test_polish_plaintext_utf-8_over_base64.txt
+++ b/tests/test_polish_plaintext_utf-8_over_base64.txt
@@ -1,14 +1,14 @@
 Date: Mon, 01 Apr 2019 07:55:00 +0200 (CEST)
-From: =?utf-8?b?TmFkYWrEhWNhLCBBbGljamE=?= <alicja.nadajaca@example.com>,
- =?utf-8?b?TmFkYWrEhWNhLCBBbGljamE=?= <alicja.nadajaca@example.net>
-Sender: =?utf-8?b?TmFkYWrEhWNhLCBBbGljamE=?= <alicja.nadajaca@example.com>
-Reply-To: =?utf-8?b?TmFkYWrEhWNhLCBBbGljamE=?= <alicja.nadajaca@example.net>
-To: =?utf-8?b?T2RiaWVyYWrEhWN5LCBCb2I=?= <bob.odbierajacy@example.com>,
- =?utf-8?b?T2RiaWVyYWrEhWNhLCBLYXJvbGluYQ==?= <karolina.odbierajaca@example.com>
-Cc: =?utf-8?b?T2RiaWVyYWrEhWN5LCBEYW5pZWw=?= <daniel.odbierajacy@example.com>,
- =?uTf-8?b?T2RiaWVyYWrEhWNhLCBFd2E=?= <ewa.odbierajaca@example.com>
-Bcc: =?utF-8?b?T2RiaWVyYWrEhWN5LCBGcmFuZWs=?= <franek.odbierajacy@example.com>,
- =?utf-8?b?T2RiaWVyYWrEhWNhLCBHcmHFvHluYQ==?= <grazyna.odbierajaca@example.com>
+From: =?utf-8?b?Ik5hZGFqxIVjYSwgQWxpY2phIg==?= <alicja.nadajaca@example.com>,
+ =?utf-8?b?Ik5hZGFqxIVjYSwgQWxpY2phIg==?= <alicja.nadajaca@example.net>
+Sender: =?utf-8?b?Ik5hZGFqxIVjYSwgQWxpY2phIg==?= <alicja.nadajaca@example.com>
+Reply-To: =?utf-8?b?Ik5hZGFqxIVjYSwgQWxpY2phIg==?= <alicja.nadajaca@example.net>
+To: =?utf-8?b?Ik9kYmllcmFqxIVjeSwgQm9iIg==?= <bob.odbierajacy@example.com>,
+ =?utf-8?b?Ik9kYmllcmFqxIVjYSwgS2Fyb2xpbmEi?= <karolina.odbierajaca@example.com>
+Cc: =?utf-8?b?Ik9kYmllcmFqxIVjeSwgRGFuaWVsIg==?= <daniel.odbierajacy@example.com>,
+ =?uTf-8?b?Ik9kYmllcmFqxIVjYSwgRXdhIg==?= <ewa.odbierajaca@example.com>
+Bcc: =?utF-8?b?Ik9kYmllcmFqxIVjeSwgRnJhbmVrIg==?= <franek.odbierajacy@example.com>,
+ =?utf-8?b?Ik9kYmllcmFqxIVjYSwgR3Jhxbx5bmEi?= <grazyna.odbierajaca@example.com>
 Subject: =?UTF-8?B?8J+Tpw==?= Test
  =?utf-8?B?UG9sc2tpZSBwYW5ncmFteQ==?=
 In-Reply-To: <Message-Id-0@example.com>
@@ -17,15 +17,15 @@ Message-ID: <Message-Id-1@example.com>
 Comments: Message Header Comment
 Keywords: Keyword 1, Keyword 2
 Resent-Date: Mon, 01 Apr 2019 07:55:00 +0200 (CEST)
-Resent-From: =?utf-8?b?TmFkYWrEhWNhLCBBbGljamE=?= <alicja.nadajaca@example.net>,
- =?utf-8?b?TmFkYWrEhWNhLCBBbGljamE=?= <alicja.nadajaca@example.com>
-Resent-Sender: =?utf-8?b?TmFkYWrEhWNhLCBBbGljamE=?= <alicja.nadajaca@example.net>
-Resent-To: =?utf-8?b?T2RiaWVyYWrEhWN5LCBCb2I=?= <bob.odbierajacy@example.net>,
- =?utf-8?b?T2RiaWVyYWrEhWNhLCBLYXJvbGluYQ==?= <karolina.odbierajaca@example.net>
-Resent-Cc: =?utf-8?b?T2RiaWVyYWrEhWN5LCBEYW5pZWw=?= <daniel.odbierajacy@example.net>,
- =?uTf-8?b?T2RiaWVyYWrEhWNhLCBFd2E=?= <ewa.odbierajaca@example.net>
-Resent-Bcc: =?utF-8?b?T2RiaWVyYWrEhWN5LCBGcmFuZWs=?= <franek.odbierajacy@example.net>,
- =?utf-8?b?T2RiaWVyYWrEhWNhLCBHcmHFvHluYQ==?= <grazyna.odbierajaca@example.net>
+Resent-From: =?utf-8?b?Ik5hZGFqxIVjYSwgQWxpY2phIg==?= <alicja.nadajaca@example.net>,
+ =?utf-8?b?Ik5hZGFqxIVjYSwgQWxpY2phIg==?= <alicja.nadajaca@example.com>
+Resent-Sender: =?utf-8?b?Ik5hZGFqxIVjYSwgQWxpY2phIg==?= <alicja.nadajaca@example.net>
+Resent-To: =?utf-8?b?Ik9kYmllcmFqxIVjeSwgQm9iIg==?= <bob.odbierajacy@example.net>,
+ =?utf-8?b?Ik9kYmllcmFqxIVjYSwgS2Fyb2xpbmEi?= <karolina.odbierajaca@example.net>
+Resent-Cc: =?utf-8?b?Ik9kYmllcmFqxIVjeSwgRGFuaWVsIg==?= <daniel.odbierajacy@example.net>,
+ =?uTf-8?b?Ik9kYmllcmFqxIVjYSwgRXdhIg==?= <ewa.odbierajaca@example.net>
+Resent-Bcc: =?utF-8?b?Ik9kYmllcmFqxIVjeSwgRnJhbmVrIg==?= <franek.odbierajacy@example.net>,
+ =?utf-8?b?Ik9kYmllcmFqxIVjYSwgR3Jhxbx5bmEi?= <grazyna.odbierajaca@example.net>
 Resent-Message-ID: <Message-Id-1@example.net>
 Content-Type: text/plAIn; cHARSET=UTF-8
 Content-Transfer-Encoding: base64

--- a/tests/test_polish_plaintext_utf-8_over_quoted-printable.txt
+++ b/tests/test_polish_plaintext_utf-8_over_quoted-printable.txt
@@ -1,14 +1,14 @@
 Date: Mon, 01 Apr 2019 07:55:00 +0200 (CEST)
-From: =?utF-8?q?Nadaj=C4=85ca,_Alicja?= <alicja.nadajaca@example.com>,
- =?utF-8?q?Nadaj=C4=85ca,_Alicja?= <alicja.nadajaca@example.net>
-Sender: =?utF-8?q?Nadaj=C4=85ca,_Alicja?= <alicja.nadajaca@example.com>
-Reply-To: =?utF-8?q?Nadaj=C4=85ca,_Alicja?= <alicja.nadajaca@example.net>
-To: =?UTF-8?Q?Odbieraj=C4=85cy,_Bob?= <bob.odbierajacy@example.com>,
- =?Utf-8?Q?Odbieraj=C4=85ca,_Karolina?= <karolina.odbierajaca@example.com>
-Cc: =?uTF-8?q?Odbieraj=C4=85cy,_Daniel?= <daniel.odbierajacy@example.com>,
- =?uTF-8?Q?Odbieraj=C4=85ca,_Ewa?= <ewa.odbierajaca@example.com>
-Bcc: =?UtF-8?Q?Odbieraj=C4=85cy,_Franek?= <franek.odbierajacy@example.com>,
- =?uTF-8?q?Odbieraj=C4=85ca,_Gra=C5=BCyna?= <grazyna.odbierajaca@example.com>
+From: =?utF-8?q?"Nadaj=C4=85ca,_Alicja"?= <alicja.nadajaca@example.com>,
+ =?utF-8?q?"Nadaj=C4=85ca,_Alicja"?= <alicja.nadajaca@example.net>
+Sender: =?utF-8?q?"Nadaj=C4=85ca,_Alicja"?= <alicja.nadajaca@example.com>
+Reply-To: =?utF-8?q?"Nadaj=C4=85ca,_Alicja"?= <alicja.nadajaca@example.net>
+To: =?UTF-8?Q?"Odbieraj=C4=85cy,_Bob"?= <bob.odbierajacy@example.com>,
+ =?Utf-8?Q?"Odbieraj=C4=85ca,_Karolina"?= <karolina.odbierajaca@example.com>
+Cc: =?uTF-8?q?"Odbieraj=C4=85cy,_Daniel"?= <daniel.odbierajacy@example.com>,
+ =?uTF-8?Q?"Odbieraj=C4=85ca,_Ewa"?= <ewa.odbierajaca@example.com>
+Bcc: =?UtF-8?Q?"Odbieraj=C4=85cy,_Franek"?= <franek.odbierajacy@example.com>,
+ =?uTF-8?q?"Odbieraj=C4=85ca,_Gra=C5=BCyna"?= <grazyna.odbierajaca@example.com>
 Subject: =?UTF-8?B?8J+Tpw==?= Test
  =?UTF-8?q?Polskie_pangramy?=
 In-Reply-To: <Message-Id-0@example.com>
@@ -17,15 +17,15 @@ Message-ID: <Message-Id-1@example.com>
 Comments: Message Header Comment
 Keywords: Keyword 1, Keyword 2
 Resent-Date: Mon, 01 Apr 2019 07:55:00 +0200 (CEST)
-Resent-From: =?utF-8?q?Nadaj=C4=85ca,_Alicja?= <alicja.nadajaca@example.net>,
- =?utF-8?q?Nadaj=C4=85ca,_Alicja?= <alicja.nadajaca@example.com>
-Resent-Sender: =?utF-8?q?Nadaj=C4=85ca,_Alicja?= <alicja.nadajaca@example.net>
-Resent-To: =?UTF-8?Q?Odbieraj=C4=85cy,_Bob?= <bob.odbierajacy@example.net>,
- =?Utf-8?Q?Odbieraj=C4=85ca,_Karolina?= <karolina.odbierajaca@example.net>
-Resent-Cc: =?uTF-8?q?Odbieraj=C4=85cy,_Daniel?= <daniel.odbierajacy@example.net>,
- =?uTF-8?Q?Odbieraj=C4=85ca,_Ewa?= <ewa.odbierajaca@example.net>
-Resent-Bcc: =?UtF-8?Q?Odbieraj=C4=85cy,_Franek?= <franek.odbierajacy@example.net>,
- =?uTF-8?q?Odbieraj=C4=85ca,_Gra=C5=BCyna?= <grazyna.odbierajaca@example.net>
+Resent-From: =?utF-8?q?"Nadaj=C4=85ca,_Alicja"?= <alicja.nadajaca@example.net>,
+ =?utF-8?q?"Nadaj=C4=85ca,_Alicja"?= <alicja.nadajaca@example.com>
+Resent-Sender: =?utF-8?q?"Nadaj=C4=85ca,_Alicja"?= <alicja.nadajaca@example.net>
+Resent-To: =?UTF-8?Q?"Odbieraj=C4=85cy,_Bob"?= <bob.odbierajacy@example.net>,
+ =?Utf-8?Q?"Odbieraj=C4=85ca,_Karolina"?= <karolina.odbierajaca@example.net>
+Resent-Cc: =?uTF-8?q?"Odbieraj=C4=85cy,_Daniel"?= <daniel.odbierajacy@example.net>,
+ =?uTF-8?Q?"Odbieraj=C4=85ca,_Ewa"?= <ewa.odbierajaca@example.net>
+Resent-Bcc: =?UtF-8?Q?"Odbieraj=C4=85cy,_Franek"?= <franek.odbierajacy@example.net>,
+ =?uTF-8?q?"Odbieraj=C4=85ca,_Gra=C5=BCyna"?= <grazyna.odbierajaca@example.net>
 Resent-Message-ID: <Message-Id-1@example.net>
 Content-Type: TExT/PLAIN; CHARSET=UTF-8
 Content-Transfer-Encoding: QuOted-prInTaBLe


### PR DESCRIPTION
In preparation for various (terribly late, I must admit) updates, this PR fixes a mistake in test cases, where commas in addresses were not quoted following RFC5322.