### PR TITLE
Chore: Lint YAML files

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,10 +1,11 @@
+---
 version: 2
 updates:
   - package-ecosystem: gomod
-    directory: "/"
+    directory: /
     schedule:
       interval: daily
-  - package-ecosystem: "github-actions"
-    directory: "/"
+  - package-ecosystem: github-actions
+    directory: /
     schedule:
       interval: daily

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,21 +1,19 @@
-name: "Create Release from Tag"
-
-on:
+---
+name: Create Release from Tag
+"on":
   push:
     tags:
       - v*
-
 jobs:
   build:
-    name: "Create Release"
+    name: Create Release
     runs-on: ubuntu-latest
     steps:
-      - name: "Checkout"
-        uses: actions/checkout@v4
-
-      - name: "Create Release"
+      - name: Checkout
+        uses: actions/checkout@v4.1.7
+      - name: Create Release
         id: create_release
-        uses: actions/create-release@v1
+        uses: actions/create-release@v1.1.4
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,25 +1,29 @@
-name: "Test"
-
-on:
+---
+name: Test
+"on":
   push:
     tags:
       - v*
     branches:
       - main
-  pull_request:
-
+  pull_request: null
 jobs:
   test:
-    name: "Test"
+    name: Test
     timeout-minutes: 15
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: ["1.18", "1.19", "1.20", "1.21"]
+        go-version:
+          - "1.18"
+          - "1.19"
+          - "1.20"
+          - "1.21"
+          - "1.22"
     steps:
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v5.0.1
         with:
           go-version: ${{ matrix.go-version }}
-      - uses: actions/checkout@v4
-      - uses: golangci/golangci-lint-action@v4
+      - uses: actions/checkout@v4.1.7
+      - uses: golangci/golangci-lint-action@v6.0.1
       - run: make test


### PR DESCRIPTION
Some more house cleaning before addressing the important issues, like parsing only mail headers.

The most important part of this PR is testing against Go 1.22.

* Lint YAML files.
* Pin exact versions of GitHub Actions.
* Add Go 1.22 to the testing matrix.