### PR TITLE
Export `letters.ParseHeaders()` so that a message can be parsed into `letters.Headers` only

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,23 @@ email.Text
 // "色は匂えど散りぬるを..."
 ```
 
+If you only want to parse email headers, you can use `letters.ParseHeaders`:
+
+```go
+msg, err := mail.ReadMessage(r)
+if err != nil {
+    log.Fatal(err)
+}
+
+emailHeaders, err := letters.ParseHeaders(msg.Header)
+if err != nil {
+    log.Fatal(err)
+}
+
+emailHeaders.To[0].Address
+// "bob.recipient@example.com"
+```
+
 ## Current Scope and Features
 
 * Parsing plaintext emails and recursively traversing multipart

--- a/letters.go
+++ b/letters.go
@@ -17,7 +17,7 @@ func ParseEmail(r io.Reader) (Email, error) {
 		return email, fmt.Errorf("letters.ParseEmail: cannot read message: %w", err)
 	}
 
-	headers, err := parseHeaders(msg.Header)
+	headers, err := ParseHeaders(msg.Header)
 	if err != nil {
 		return email, fmt.Errorf("letters.ParseEmail: cannot parse headers: %w", err)
 	}

--- a/letters_test.go
+++ b/letters_test.go
@@ -8,6 +8,32 @@ import (
 	"time"
 )
 
+func testEmailHeadersFromFile(t *testing.T, fp string, expectedEmailHeaders Headers) {
+	rawEmail, err := os.Open(fp)
+	if err != nil {
+		t.Errorf("error while reading email from file: %s", err)
+		return
+	}
+
+	msg, err := mail.ReadMessage(rawEmail)
+	if err != nil {
+		t.Errorf("error while reading message from file: %s", err)
+		return
+	}
+
+	parsedEmailHeaders, err := ParseHeaders(msg.Header)
+	if err != nil {
+		t.Errorf("error while parsing email headers: %s", err)
+		return
+	}
+
+	if !reflect.DeepEqual(parsedEmailHeaders, expectedEmailHeaders) {
+		t.Errorf("email headers are not equal")
+		t.Errorf("Got %#v", parsedEmailHeaders)
+		t.Errorf("Want %#v", expectedEmailHeaders)
+	}
+}
+
 func testEmailFromFile(t *testing.T, fp string, expectedEmail Email) {
 	rawEmail, err := os.Open(fp)
 	if err != nil {
@@ -153,6 +179,88 @@ func TestParseEmailEnglishNoTextContent(t *testing.T) {
 	}
 
 	testEmailFromFile(t, fp, expectedEmail)
+}
+
+func TestParseEmailHeadersEnglishPlaintextAsciiOver7bit(t *testing.T) {
+	fp := "tests/test_english_plaintext_ascii_over_7bit.txt"
+	tz, _ := time.LoadLocation("Europe/London")
+	expectedDate, _ := time.Parse(
+		time.RFC1123Z+" (MST)",
+		time.Date(2019, time.April, 1, 7, 55, 0, 0, tz).Format(time.RFC1123Z+" (MST)"))
+	expectedEmailHeaders := Headers{
+		Date:    expectedDate,
+		Subject: "📧 Test English Pangrams",
+		ReplyTo: []*mail.Address{
+			{
+				Name:    "Alice Sender",
+				Address: "alice.sender@example.net",
+			},
+		},
+		Sender: &mail.Address{
+			Name:    "Alice Sender",
+			Address: "alice.sender@example.com",
+		},
+		From: []*mail.Address{
+			{
+				Name:    "Alice Sender",
+				Address: "alice.sender@example.com",
+			},
+			{
+				Name:    "Alice Sender",
+				Address: "alice.sender@example.net",
+			},
+		},
+		To: []*mail.Address{
+			{
+				Name:    "Bob Recipient",
+				Address: "bob.recipient@example.com",
+			},
+			{
+				Name:    "Carol Recipient",
+				Address: "carol.recipient@example.com",
+			},
+		},
+		Cc: []*mail.Address{
+			{
+				Name:    "Dan Recipient",
+				Address: "dan.recipient@example.com",
+			},
+			{
+				Name:    "Eve Recipient",
+				Address: "eve.recipient@example.com",
+			},
+		},
+		Bcc: []*mail.Address{
+			{
+				Name:    "Frank Recipient",
+				Address: "frank.recipient@example.com",
+			},
+			{
+				Name:    "Grace Recipient",
+				Address: "grace.recipient@example.com",
+			},
+		},
+		MessageID:  "Message-Id-1@example.com",
+		InReplyTo:  []MessageId{"Message-Id-0@example.com"},
+		References: []MessageId{"Message-Id-0@example.com"},
+		Comments:   "Message Header Comment",
+		Keywords:   []string{"Keyword 1", "Keyword 2"},
+		ContentType: ContentTypeHeader{
+			ContentType: "text/plain",
+			Params: map[string]string{
+				"charset": "ascii",
+			},
+		},
+		ExtraHeaders: map[string][]string{
+			"X-Clacks-Overhead": {"GNU Terry Pratchett"},
+			"X-Script/function/\t !\"#$%&'()*+,-./;<=>?@[\\]^_`{|}~": {
+				"TEST VALUE 1\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+				"TEST VALUE 2\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+			},
+		},
+	}
+
+	testEmailHeadersFromFile(t, fp, expectedEmailHeaders)
 }
 
 func TestParseEmailEnglishPlaintextAsciiOver7bit(t *testing.T) {

--- a/parsers.go
+++ b/parsers.go
@@ -223,11 +223,11 @@ func parseContentTypeHeader(s string) (ContentTypeHeader, error) {
 	}, nil
 }
 
-func parseHeaders(header mail.Header) (Headers, error) {
+func ParseHeaders(header mail.Header) (Headers, error) {
 	contentType, err := parseContentTypeHeader(header.Get("Content-Type"))
 	if err != nil {
 		return Headers{}, fmt.Errorf(
-			"letters.parsers.parseHeaders: cannot parse Content-Type: %w",
+			"letters.parsers.ParseHeaders: cannot parse Content-Type: %w",
 			err)
 	}
 
@@ -249,77 +249,77 @@ func parseHeaders(header mail.Header) (Headers, error) {
 	sender, err := parseAddressHeader(header, "Sender")
 	if err != nil {
 		return Headers{}, fmt.Errorf(
-			"letters.parsers.parseHeaders: cannot parse Sender header: %w",
+			"letters.parsers.ParseHeaders: cannot parse Sender header: %w",
 			err)
 	}
 
 	from, err := parseAddressListHeader(header, "From")
 	if err != nil {
 		return Headers{}, fmt.Errorf(
-			"letters.parsers.parseHeaders: cannot parse From header: %w",
+			"letters.parsers.ParseHeaders: cannot parse From header: %w",
 			err)
 	}
 
 	replyTo, err := parseAddressListHeader(header, "Reply-To")
 	if err != nil {
 		return Headers{}, fmt.Errorf(
-			"letters.parsers.parseHeaders: cannot parse Reply-To header: %w",
+			"letters.parsers.ParseHeaders: cannot parse Reply-To header: %w",
 			err)
 	}
 
 	to, err := parseAddressListHeader(header, "To")
 	if err != nil {
 		return Headers{}, fmt.Errorf(
-			"letters.parsers.parseHeaders: cannot parse To header: %w",
+			"letters.parsers.ParseHeaders: cannot parse To header: %w",
 			err)
 	}
 
 	cc, err := parseAddressListHeader(header, "Cc")
 	if err != nil {
 		return Headers{}, fmt.Errorf(
-			"letters.parsers.parseHeaders: cannot parse Cc header: %w",
+			"letters.parsers.ParseHeaders: cannot parse Cc header: %w",
 			err)
 	}
 
 	bcc, err := parseAddressListHeader(header, "Bcc")
 	if err != nil {
 		return Headers{}, fmt.Errorf(
-			"letters.parsers.parseHeaders: cannot parse Bcc header: %w",
+			"letters.parsers.ParseHeaders: cannot parse Bcc header: %w",
 			err)
 	}
 
 	resentFrom, err := parseAddressListHeader(header, "Resent-From")
 	if err != nil {
 		return Headers{}, fmt.Errorf(
-			"letters.parsers.parseHeaders: cannot parse Resent-From header: %w",
+			"letters.parsers.ParseHeaders: cannot parse Resent-From header: %w",
 			err)
 	}
 
 	resentSender, err := parseAddressHeader(header, "Resent-Sender")
 	if err != nil {
 		return Headers{}, fmt.Errorf(
-			"letters.parsers.parseHeaders: cannot parse Resent-Sender header: %w",
+			"letters.parsers.ParseHeaders: cannot parse Resent-Sender header: %w",
 			err)
 	}
 
 	resentTo, err := parseAddressListHeader(header, "Resent-To")
 	if err != nil {
 		return Headers{}, fmt.Errorf(
-			"letters.parsers.parseHeaders: cannot parse Resent-To header: %w",
+			"letters.parsers.ParseHeaders: cannot parse Resent-To header: %w",
 			err)
 	}
 
 	resentCc, err := parseAddressListHeader(header, "Resent-Cc")
 	if err != nil {
 		return Headers{}, fmt.Errorf(
-			"letters.parsers.parseHeaders: cannot parse Resent-Cc header: %w",
+			"letters.parsers.ParseHeaders: cannot parse Resent-Cc header: %w",
 			err)
 	}
 
 	resentBcc, err := parseAddressListHeader(header, "Resent-Bcc")
 	if err != nil {
 		return Headers{}, fmt.Errorf(
-			"letters.parsers.parseHeaders: cannot parse Resent-Bcc header: %w",
+			"letters.parsers.ParseHeaders: cannot parse Resent-Bcc header: %w",
 			err)
 	}
 


### PR DESCRIPTION
In https://github.com/mnako/letters/pull/72 @rorycl makes a good point for parsing email headers only: the email bodies might be malformed or the user might be interested in headers only.

I do not think, however, that a string arg `letters.ParseEmail(r, "HeadersOnly")` is the best way to implement this feature. I believe that this should be at least a config struct for future maintainability, but for the time being there is a simpler solution: export the `ParseHeaders()` identifier so that users can use it directly.

This PR renames `letters.parseHeaders()` to `letters.ParseHeaders()`, adds a test, and updates README.md with an example.

One point that might merit discussion, is whether the now public `ParseHeaders()` should not accept the same parameters as `ParseEmail` so that the user is not responsible for reading the message using `mail.ReadMessage()` and passing `msg.Header` to `ParseHeaders()`.