### PR TITLE
Fix/golangci lint 1.61 warnings: Fix SA1019: "io/ioutil" has been deprecated since Go 1.19 in favour of "io"

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,4 +26,6 @@ jobs:
           go-version: ${{ matrix.go-version }}
       - uses: actions/checkout@v4.1.7
       - uses: golangci/golangci-lint-action@v6.0.1
+        with:
+          version: v1.61.0
       - run: make test

--- a/decoders.go
+++ b/decoders.go
@@ -5,7 +5,6 @@ import (
 	"encoding/base64"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"mime"
 	"mime/multipart"
 	"mime/quotedprintable"
@@ -47,7 +46,7 @@ func decodeContent(
 	cte ContentTransferEncoding,
 ) (io.Reader, error) {
 	var contentReader io.Reader
-	contentBytes, err := ioutil.ReadAll(content)
+	contentBytes, err := io.ReadAll(content)
 	if err != nil && err != io.ErrUnexpectedEOF {
 		return nil, fmt.Errorf(
 			"letters.decoders.decodeContent: cannot decode content: %w",
@@ -57,10 +56,10 @@ func decodeContent(
 	switch cte {
 	case cteBase64:
 		decoded := base64.NewDecoder(base64.StdEncoding, bytes.NewReader(contentBytes))
-		b, err := ioutil.ReadAll(decoded)
+		b, err := io.ReadAll(decoded)
 		if err == io.ErrUnexpectedEOF {
 			decoded = base64.NewDecoder(base64.RawStdEncoding, bytes.NewReader(contentBytes))
-			b, err = ioutil.ReadAll(decoded)
+			b, err = io.ReadAll(decoded)
 			if err != nil {
 				return nil, fmt.Errorf(
 					"letters.decoders.decodeContent: cannot decode raw-std-base64-encoded content: %w",
@@ -74,7 +73,7 @@ func decodeContent(
 		contentReader = bytes.NewReader(b)
 	case cteQuotedPrintable:
 		decoded := quotedprintable.NewReader(bytes.NewReader(contentBytes))
-		b, err := ioutil.ReadAll(decoded)
+		b, err := io.ReadAll(decoded)
 		if err != nil {
 			return nil, fmt.Errorf(
 				"letters.decoders.decodeContent: cannot decode quoted-printable-encoded content: %w",
@@ -113,7 +112,7 @@ func decodeInlineFile(part *multipart.Part, cte ContentTransferEncoding) (Inline
 	}
 
 	ifl.ContentID = strings.Trim(cid, "<>")
-	ifl.Data, err = ioutil.ReadAll(decoded)
+	ifl.Data, err = io.ReadAll(decoded)
 	if err != nil {
 		return ifl, fmt.Errorf(
 			"letters.decoders.decodeInlineFile: cannot read inline attachment data: %w",
@@ -149,7 +148,7 @@ func decodeAttachmentFileFromBody(body io.Reader, headers Headers, cte ContentTr
 
 	afl.ContentType = headers.ContentType
 	afl.ContentDisposition = headers.ContentDisposition
-	afl.Data, err = ioutil.ReadAll(decoded)
+	afl.Data, err = io.ReadAll(decoded)
 	if err != nil {
 		return afl, fmt.Errorf(
 			"letters.decoders.decodeAttachmentFileFromBody: cannot read attached file data: %w",
@@ -183,7 +182,7 @@ func decodeAttachedFileFromPart(part *multipart.Part, cte ContentTransferEncodin
 			err)
 	}
 
-	afl.Data, err = ioutil.ReadAll(decoded)
+	afl.Data, err = io.ReadAll(decoded)
 	if err != nil {
 		return afl, fmt.Errorf(
 			"letters.decoders.decodeAttachedFileFromPart: cannot read attached file data: %w",

--- a/parsers.go
+++ b/parsers.go
@@ -3,7 +3,6 @@ package letters
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"mime"
 	"mime/multipart"
 	"net/mail"
@@ -358,7 +357,7 @@ func parseText(t io.Reader, e encoding.Encoding, cte ContentTransferEncoding) (s
 			err)
 	}
 
-	textBody, err := ioutil.ReadAll(reader)
+	textBody, err := io.ReadAll(reader)
 	if err != nil {
 		return "", fmt.Errorf(
 			"letters.parsers.parseText: cannot read plain text content: %w",


### PR DESCRIPTION
# Changes

1. [Pin golangci-lint to v1.61.0 in test workflow](https://github.com/mnako/letters/commit/c3f63c9c26e8534a20fe8de2c5c32584b28f97c3)
2. [Fix SA1019: `io/ioutil` has been deprecated since Go 1.19 in favour of `io`](https://github.com/mnako/letters/commit/4ce9c4d1f53179d1406cfcf9d025dc2cf43f4816)
