### PR TITLE
tests: switch to using go-cmp.Equal instead of reflect.DeepEqual

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,3 +6,5 @@ require (
 	golang.org/x/net v0.33.0
 	golang.org/x/text v0.21.0
 )
+
+require github.com/google/go-cmp v0.6.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,4 @@
+github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=

--- a/letters_test.go
+++ b/letters_test.go
@@ -3,9 +3,10 @@ package letters
 import (
 	"net/mail"
 	"os"
-	"reflect"
 	"testing"
 	"time"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 func testEmailHeadersFromFile(t *testing.T, fp string, expectedEmailHeaders Headers) {
@@ -27,10 +28,8 @@ func testEmailHeadersFromFile(t *testing.T, fp string, expectedEmailHeaders Head
 		return
 	}
 
-	if !reflect.DeepEqual(parsedEmailHeaders, expectedEmailHeaders) {
-		t.Errorf("email headers are not equal")
-		t.Errorf("Got %#v", parsedEmailHeaders)
-		t.Errorf("Want %#v", expectedEmailHeaders)
+	if got, want := parsedEmailHeaders, expectedEmailHeaders; !cmp.Equal(got, want) {
+		t.Errorf("email headers are not equal\n%s", cmp.Diff(got, want))
 	}
 }
 
@@ -47,10 +46,8 @@ func testEmailFromFile(t *testing.T, fp string, expectedEmail Email) {
 		return
 	}
 
-	if !reflect.DeepEqual(parsedEmail, expectedEmail) {
-		t.Errorf("emails are not equal")
-		t.Errorf("Got %#v", parsedEmail)
-		t.Errorf("Want %#v", expectedEmail)
+	if got, want := parsedEmail, expectedEmail; !cmp.Equal(got, want) {
+		t.Errorf("emails are not equal\n%s", cmp.Diff(got, want))
 	}
 }
 


### PR DESCRIPTION
Hi @mnako 

This is a suggestion to use go-cmp for easier comparison of failing test cases.

---

go-cmp provides convenient diffing of compound data types, for example (for a contrived case):

```
=== RUN   TestParseEmailHeadersEnglishPlaintextAsciiOver7bit
    letters_test.go:32: email headers are not equal
          letters.Headers{
        - 	Date:   s"2019-04-01 07:55:00 +0100 BST",
        + 	Date:   s"2091-04-01 07:55:00 +0100 BST",
          	Sender: &{Name: "Alice Sender", Address: "alice.sender@example.com"},
          	From:   {&{Name: "Alice Sender", Address: "alice.sender@example.com"}, &{Name: "Alice Sender", Address: "alice.sender@example.net"}},
          	... // 5 identical fields
          	InReplyTo:  {"Message-Id-0@example.com"},
          	References: {"Message-Id-0@example.com"},
        - 	Subject:    "📧 Test English Pangrams",
        + 	Subject:    "Test English Pangrams",
          	Comments:   "Message Header Comment",
          	Keywords:   {"Keyword 1", "Keyword 2"},
          	... // 10 identical fields
          }
--- FAIL: TestParseEmailHeadersEnglishPlaintextAsciiOver7bit (0.00s)
FAIL
FAIL	github.com/mnako/letters	0.006s
FAIL
```