### PR TITLE
Patch 2

### DIFF
--- a/parsers.go
+++ b/parsers.go
@@ -121,17 +121,7 @@ func ParseAddressListHeader(
 		return addresses, nil
 	}
 
-	decodedHeader, err := decodeHeader(normalizedS)
-	if err != nil {
-		return addresses, fmt.Errorf(
-			"letters.parsers.parseAddressListHeader: "+
-				"cannot decode address list header %q: %w",
-			s,
-			err,
-		)
-	}
-
-	addresses, err = mail.ParseAddressList(decodedHeader)
+	addresses, err := mail.ParseAddressList(normalizedS)
 	if err != nil {
 		return addresses, fmt.Errorf(
 			"letters.parsers.parseAddressListHeader: "+
@@ -139,6 +129,16 @@ func ParseAddressListHeader(
 			s,
 			err,
 		)
+	}
+
+	for _, addr := range addresses {
+		if addr.Name != "" {
+			decoded, err := decodeHeader(addr.Name)
+			if err == nil {
+				addr.Name = decoded
+			}
+			// If decode fails, just leave the original name as-is
+		}
 	}
 
 	return addresses, nil

--- a/parsers.go
+++ b/parsers.go
@@ -82,7 +82,7 @@ func ParseAddressHeader(
 		return address, nil
 	}
 
-	address, err = mail.ParseAddress(decodedHeader)
+	address, err = mail.ParseAddress(normalizedS)
 	if err != nil {
 		return address, fmt.Errorf(
 			"letters.parsers.parseAddressHeader: "+

--- a/parsers.go
+++ b/parsers.go
@@ -82,16 +82,6 @@ func ParseAddressHeader(
 		return address, nil
 	}
 
-	decodedHeader, err := decodeHeader(normalizedS)
-	if err != nil {
-		return address, fmt.Errorf(
-			"letters.parsers.parseAddressHeader: "+
-				"cannot decode address header %q: %w",
-			s,
-			err,
-		)
-	}
-
 	address, err = mail.ParseAddress(decodedHeader)
 	if err != nil {
 		return address, fmt.Errorf(
@@ -100,6 +90,14 @@ func ParseAddressHeader(
 			s,
 			err,
 		)
+	}
+
+	if address.Name != "" {
+		decoded, err := decodeHeader(address.Name)
+		if err == nil {
+			address.Name = decoded
+		}
+		// Optional: log decode failure but keep original name
 	}
 
 	return address, nil


### PR DESCRIPTION
I just started using this library to parse hundreds of thousands of emails from real world. I get a TON of errors of this type:

cannot parse address list header "=?UTF-8?Q?sales=40somedomain=2Ecom?= <sales@somedomain.com>": mail: expected comma

I see that we can override individual header parsers, so I guess that's how I can fix this. Still, it would be nice to have this work properly. The problem is if the "name" on an address contains anything funny that isn't quoted after decoding. I believe the standard here is that only the name (and not email) of a mail.Address should ever ben encoded, so this is how it should be done anyway, is that your understanding?