### PR TITLE
Test against go 1.25, do not fail early to catch failing versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,6 +13,7 @@ jobs:
     timeout-minutes: 15
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         go-version:
           - "1.18"
@@ -22,6 +23,7 @@ jobs:
           - "1.22"
           - "1.23"
           - "1.24"
+          - "1.25"
     steps:
       - name: Setup Go
         uses: actions/setup-go@v5.5.0


### PR DESCRIPTION
This pull request updates the test workflow configuration to improve CI reliability and expand Go version coverage.

Workflow improvements:

* Disabled the `fail-fast` option in the test job matrix to ensure all test jobs run to completion, even if one fails.

Go version support:

* Added Go 1.25 to the matrix of tested Go versions in the CI workflow.