### PR TITLE
Drop support for Go 1.18–1.22; bump Go requirement to 1.23

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,8 +16,6 @@ jobs:
       fail-fast: false
       matrix:
         go-version:
-          - "1.21"
-          - "1.22"
           - "1.23"
           - "1.24"
           - "1.25"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,9 +16,6 @@ jobs:
       fail-fast: false
       matrix:
         go-version:
-          - "1.18"
-          - "1.19"
-          - "1.20"
           - "1.21"
           - "1.22"
           - "1.23"

--- a/README.md
+++ b/README.md
@@ -254,7 +254,7 @@ headers.Headers.From
 
 > [!TIP] 
 > The `letters.ParseEmail()` and `letters.ParseEmailHeaders()` helpers
-> exist for developers' convenience and are a good entrypoint to get started
+> exist for developers’ convenience and are a good entrypoint to get started
 > quickly. However, if you find yourself in need of customising the parser to,
 > i.a. parse non-compliant headers or conditionally parse only some parts of the
 > email, we recommend following the [Advanced Usage](#advanced-usage) section
@@ -332,7 +332,7 @@ More interestingly, bodies and files can be skipped conditionally: bodies can be
 skipped based on the Content-Type header of the part, and files can be skipped
 based on the Content-Type and the Content-Disposition headers of the part.
 
-For example, to only parse files with a filename that ends with ".jpg," you can
+For example, to only parse files with a filename that ends with `.jpg`, you can
 pass a custom File Filter that checks the `name` Param of the Content-Type
 header:
 
@@ -523,3 +523,10 @@ Feature-complete and tests passing.
 
 Currently, gathering feedback and refactoring code before releasing v1.0.0.
 Fields and API are still subject to change.
+
+# Release Policy
+
+We follow [Go’s Release Policy](https://go.dev/doc/devel/release#policy) 
+and commit to supporting at least the two most recent major versions of Go.
+
+Letter v0.2.7 supports Go versions 1.23 through 1.25.

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/mnako/letters
 
-go 1.18
+go 1.21
 
 require (
 	golang.org/x/net v0.35.0

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,6 @@ module github.com/mnako/letters
 go 1.21
 
 require (
-	golang.org/x/net v0.35.0
-	golang.org/x/text v0.22.0
+	golang.org/x/net v0.38.0
+	golang.org/x/text v0.23.0
 )

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/mnako/letters
 
-go 1.21
+go 1.23.0
 
 require (
 	golang.org/x/net v0.38.0

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,4 @@
-golang.org/x/net v0.35.0 h1:T5GQRQb2y08kTAByq9L4/bz8cipCdA8FbRTXewonqY8=
-golang.org/x/net v0.35.0/go.mod h1:EglIi67kWsHKlRzzVMUD93VMSWGFOMSZgxFjparz1Qk=
-golang.org/x/text v0.22.0 h1:bofq7m3/HAFvbF51jz3Q9wLg3jkvSPuiZu/pD1XwgtM=
-golang.org/x/text v0.22.0/go.mod h1:YRoo4H8PVmsu+E3Ou7cqLVH8oXWIHVoX0jqUWALQhfY=
+golang.org/x/net v0.38.0 h1:vRMAPTMaeGqVhG5QyLJHqNDwecKTomGeqbnfZyKlBI8=
+golang.org/x/net v0.38.0/go.mod h1:ivrbrMbzFq5J41QOQh0siUuly180yBYtLp+CKbEaFx8=
+golang.org/x/text v0.23.0 h1:D71I7dUrlY+VX0gQShAThNGHFxZ13dGLBHQLVl1mJlY=
+golang.org/x/text v0.23.0/go.mod h1:/BLNzu4aZCJ1+kcD0DNRotWKage4q2rGVAg4o22unh4=


### PR DESCRIPTION
This pull request updates the Go language version used in the project, both in the workflow configuration and the module definition. The main goal is to drop support for older Go versions and standardize on newer, currently supported versions to close security vulnerabilities in GHSA-vvgc-356p-c3xw and GHSA-qxp5-gwg8-xv66 in `x/net`.

Go version updates:

* [`.github/workflows/test.yml`](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L19-L21): Removed Go 1.18, 1.19, 1.20, 1.21, and 1.22 from the test matrix.
* [`go.mod`](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6L3-R3): Updated the minimum required Go version from 1.18 to 1.23.0.