### PR TITLE
Add Go version 1.26 to test matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,6 +18,7 @@ jobs:
         go-version:
           - "1.24"
           - "1.25"
+          - "1.26"
     steps:
       - name: Setup Go
         uses: actions/setup-go@v6.2.0


### PR DESCRIPTION
This pull request makes a small update to the test workflow configuration, adding support for Go version 1.26 in the matrix of versions used for testing.