### PR TITLE
Email parsing failure for malformed Content-Disposition header

### DIFF
--- a/letters.go
+++ b/letters.go
@@ -30,6 +30,7 @@ type EmailParser struct {
 	bodyFilter     EmailBodyFilter
 	fileFilter     EmailFileFilter
 	headersParsers HeadersParsers
+	bodyParsers    BodyParsers
 }
 
 type EmailParserOption func(*EmailParser)
@@ -62,11 +63,20 @@ func DefaultHeadersParsers() HeadersParsers {
 	}
 }
 
+func DefaultBodyParsers() BodyParsers {
+	return BodyParsers{
+		ContentType:             ParseContentTypeHeader,
+		ContentTransferEncoding: ParseContentTransferEncoding,
+		ContentDisposition:      ParseContentDisposition,
+	}
+}
+
 func NewEmailParser(options ...EmailParserOption) *EmailParser {
 	ep := &EmailParser{
 		bodyFilter:     AllBodies,
 		fileFilter:     AllFiles,
 		headersParsers: DefaultHeadersParsers(),
+		bodyParsers:    DefaultBodyParsers(),
 	}
 
 	for _, option := range options {

--- a/letters_test.go
+++ b/letters_test.go
@@ -2,6 +2,7 @@ package letters_test
 
 import (
 	"fmt"
+	"mime"
 	"net/mail"
 	"os"
 	"reflect"
@@ -138,6 +139,166 @@ func TestParseEmailEnglishNoTextContent(t *testing.T) {
 			name:        "DefaultParser",
 			filepath:    "tests/test_english_no_text_content.txt",
 			emailParser: letters.NewEmailParser(),
+			expectedEmail: letters.Email{
+				Headers: letters.Headers{
+					Date:    expectedDate,
+					Subject: "Test No Text Content, Attachment Only",
+					ReplyTo: []*mail.Address{
+						{
+							Name:    "Alice Sender",
+							Address: "alice.sender@example.net",
+						},
+					},
+					Sender: &mail.Address{
+						Name:    "Alice Sender",
+						Address: "alice.sender@example.com",
+					},
+					From: []*mail.Address{
+						{
+							Name:    "Alice Sender",
+							Address: "alice.sender@example.com",
+						},
+						{
+							Name:    "Alice Sender",
+							Address: "alice.sender@example.net",
+						},
+					},
+					To: []*mail.Address{
+						{
+							Name:    "Bob Recipient",
+							Address: "bob.recipient@example.com",
+						},
+						{
+							Name:    "Carol Recipient",
+							Address: "carol.recipient@example.com",
+						},
+					},
+					Cc: []*mail.Address{
+						{
+							Name:    "Dan Recipient",
+							Address: "dan.recipient@example.com",
+						},
+						{
+							Name:    "Eve Recipient",
+							Address: "eve.recipient@example.com",
+						},
+					},
+					Bcc: []*mail.Address{
+						{
+							Name:    "Frank Recipient",
+							Address: "frank.recipient@example.com",
+						},
+						{
+							Name:    "Grace Recipient",
+							Address: "grace.recipient@example.com",
+						},
+					},
+					MessageID: "Message-Id-1@example.com",
+					ContentType: letters.ContentTypeHeader{
+						ContentType: "application/pdf",
+						Params: map[string]string{
+							"name": "attached-pdf-name.pdf",
+						},
+					},
+					ContentDisposition: letters.ContentDispositionHeader{
+						ContentDisposition: letters.ContentDispositionAttachment,
+						Params: map[string]string{
+							"filename": "attached-pdf-filename.pdf",
+						},
+					},
+					ExtraHeaders: map[string][]string{
+						"X-Clacks-Overhead": {"GNU Terry Pratchett"},
+						"X-Script/function/\t !\"#$%&'()*+,-./;<=>?@[\\]^_`{|}~": {
+							"TEST VALUE 1\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+							"TEST VALUE 2\t !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_` abcdefghijklmnopqrstuvwxyz{|}~",
+						},
+					},
+				},
+				Text:         "",
+				EnrichedText: "",
+				HTML:         "",
+				AttachedFiles: []letters.AttachedFile{
+					{
+						ContentType: letters.ContentTypeHeader{
+							ContentType: "application/pdf",
+							Params: map[string]string{
+								"name": "attached-pdf-name.pdf",
+							},
+						},
+						ContentDisposition: letters.ContentDispositionHeader{
+							ContentDisposition: letters.ContentDispositionAttachment,
+							Params: map[string]string{
+								"filename": "attached-pdf-filename.pdf",
+							},
+						},
+						Data: []byte{
+							37, 80, 68, 70, 45, 49, 46, 13, 116, 114, 97, 105, 108, 101, 114, 60, 60,
+							47, 82, 111, 111, 116, 60, 60, 47, 80, 97, 103, 101, 115, 60, 60, 47, 75, 105, 100, 115, 91, 60,
+							60, 47, 77, 101, 100, 105, 97, 66, 111, 120, 91, 48, 32, 48, 32, 51, 32, 51, 93, 62, 62, 93, 62,
+							62, 62, 62, 62, 62,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	testEmailCases(t, tcs)
+}
+
+func TestParseEmailEnglishInvalidTextContent(t *testing.T) {
+	t.Parallel()
+
+	tz, _ := time.LoadLocation("Europe/London")
+	expectedDate, _ := time.Parse(
+		time.RFC1123Z+" (MST)",
+		time.Date(2019, time.April, 1, 7, 55, 0, 0, tz).
+			Format(time.RFC1123Z+" (MST)"),
+	)
+
+	var cdMap = map[string]letters.ContentDisposition{
+		"attachment":  letters.ContentDispositionAttachment,
+		"attachments": letters.ContentDispositionAttachment,
+		"inline":      letters.ContentDispositionInline,
+	}
+
+	customContentDispositionParser := func(s string) (letters.ContentDispositionHeader, error) {
+		var cdh letters.ContentDispositionHeader
+
+		label, params, err := mime.ParseMediaType(s)
+		if label == "" {
+			return cdh, nil
+		}
+		if err != nil {
+			return cdh, fmt.Errorf(
+				"letters.parsers.parseContentDisposition: "+
+					"cannot parse Content-Disposition %q: %w",
+				s,
+				err,
+			)
+		}
+
+		cd, ok := cdMap[label]
+		if !ok {
+			return cdh, fmt.Errorf(
+				"letters.parsers.parseContentDisposition: "+
+					"unknown Content-Disposition %q",
+				label,
+			)
+		}
+		return letters.ContentDispositionHeader{
+			ContentDisposition: cd,
+			Params:             params,
+		}, nil
+	}
+
+	tcs := []emailTestCase{
+		{
+			name:     "DefaultParser",
+			filepath: "tests/test_english_no_text_invalid_content.txt",
+			emailParser: letters.NewEmailParser(
+				letters.WithContentDispositionHeaderParser(customContentDispositionParser),
+			),
 			expectedEmail: letters.Email{
 				Headers: letters.Headers{
 					Date:    expectedDate,

--- a/options.go
+++ b/options.go
@@ -16,6 +16,7 @@ type (
 	parseCommaSeparatedMessageIdHeaderFn func(string) []MessageId
 	parseContentDispositionHeaderFn      func(string) (ContentDispositionHeader, error)
 	parseContentTypeHeaderFn             func(string) (ContentTypeHeader, error)
+	parseContentTransferEncodingHeaderFn func(string) (ContentTransferEncoding, error)
 )
 
 type HeadersParsers struct {
@@ -42,6 +43,12 @@ type HeadersParsers struct {
 	ContentType        parseContentTypeHeaderFn
 	ContentDisposition parseContentDispositionHeaderFn
 	ExtraHeaders       map[string]parseStringHeaderFn
+}
+
+type BodyParsers struct {
+	ContentType             parseContentTypeHeaderFn
+	ContentTransferEncoding parseContentTransferEncodingHeaderFn
+	ContentDisposition      parseContentDispositionHeaderFn
 }
 
 func WithDateHeaderParser(
@@ -240,5 +247,35 @@ func WithExtraHeaderParser(
 func WithHeadersParsers(headersParsers HeadersParsers) EmailParserOption {
 	return func(ep *EmailParser) {
 		ep.headersParsers = headersParsers
+	}
+}
+
+func WithContentTypeBodyParser(
+	contentTypeBodyParserFn parseContentTypeHeaderFn,
+) EmailParserOption {
+	return func(ep *EmailParser) {
+		ep.bodyParsers.ContentType = contentTypeBodyParserFn
+	}
+}
+
+func WithContentDispositionBodyParser(
+	contentDispositionBodyParserFn parseContentDispositionHeaderFn,
+) EmailParserOption {
+	return func(ep *EmailParser) {
+		ep.bodyParsers.ContentDisposition = contentDispositionBodyParserFn
+	}
+}
+
+func WithContentTransferEncodingBodyParser(
+	contentTransferEncodingBodyParserFn parseContentTransferEncodingHeaderFn,
+) EmailParserOption {
+	return func(ep *EmailParser) {
+		ep.bodyParsers.ContentTransferEncoding = contentTransferEncodingBodyParserFn
+	}
+}
+
+func WithBodyParsers(bodyParsers BodyParsers) EmailParserOption {
+	return func(ep *EmailParser) {
+		ep.bodyParsers = bodyParsers
 	}
 }

--- a/parsers.go
+++ b/parsers.go
@@ -742,7 +742,7 @@ func (ep *EmailParser) parsePart(
 			)
 		}
 
-		partContentType, err := ParseContentTypeHeader(
+		partContentType, err := ep.bodyParsers.ContentType(
 			part.Header.Get("Content-Type"),
 		)
 		if err != nil {
@@ -759,7 +759,7 @@ func (ep *EmailParser) parsePart(
 		}
 
 		enc, _ := charset.Lookup(charsetLabel)
-		cte, err := ParseContentTransferEncoding(
+		cte, err := ep.bodyParsers.ContentTransferEncoding(
 			part.Header.Get("Content-Transfer-Encoding"),
 		)
 		if err != nil {
@@ -770,7 +770,7 @@ func (ep *EmailParser) parsePart(
 			)
 		}
 
-		cdh, err := ParseContentDisposition(
+		cdh, err := ep.bodyParsers.ContentDisposition(
 			part.Header.Get("Content-Disposition"),
 		)
 		if err != nil {

--- a/tests/test_english_no_text_invalid_content.txt
+++ b/tests/test_english_no_text_invalid_content.txt
@@ -1,0 +1,26 @@
+Date: Mon, 01 Apr 2019 07:55:00 +0100 (BST)
+From: =?uTf-8?b?QWxpY2UgU2VuZGVy?= <alice.sender@example.com>,
+ =?uTf-8?b?QWxpY2UgU2VuZGVy?= <alice.sender@example.net>
+Sender: =?uTf-8?b?QWxpY2UgU2VuZGVy?= <alice.sender@example.com>
+Reply-To: =?uTf-8?b?QWxpY2UgU2VuZGVy?= <alice.sender@example.net>
+To: =?utf-8?b?Qm9iIFJlY2lwaWVudA==?= <bob.recipient@example.com>,
+ =?UTF-8?B?Q2Fyb2wgUmVjaXBpZW50?= <carol.recipient@example.com>
+Cc: =?Utf-8?B?RGFuIFJlY2lwaWVudA==?= <dan.recipient@example.com>,
+ =?uTF-8?b?RXZlIFJlY2lwaWVudA==?= <eve.recipient@example.com>
+Bcc: =?utf-8?b?RnJhbmsgUmVjaXBpZW50?= <frank.recipient@example.com>,
+ =?Utf-8?B?R3JhY2UgUmVjaXBpZW50?= <grace.recipient@example.com>
+Message-ID: <Message-Id-1@example.com>
+Subject: Test No Text Content, Attachment Only
+Content-Type: applicaTION/PDF; NAME="attached-pdf-name.pdf"
+Content-Disposition: AttachmenTs; FILENAMe="attached-pdf-filename.pdf"
+Content-Transfer-Encoding: BASE64
+X-Clacks-Overhead: GNU Terry Pratchett
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 1	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
+X-Script/function/	 !"#$%&'()*+,-./;<=>?@[\]^_`{|}~: TEST
+ VALUE 2	 !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`
+ abcdefghijklmnopqrstuvwxyz{|}~
+
+JVBERi0xLg10cmFpbGVyPDwvUm9vdDw8L1BhZ2VzPDwvS2lkc1s8PC9NZWRpYUJveFswIDAgMyAz
+XT4+XT4+Pj4+Pg==


### PR DESCRIPTION
## Describe your changes

Add support for certain incoming emails due to invalid header format: `Content-Disposition: attachments`.

This is done by altering `ep.parsePart(...)` function by making the `ContentType`, `ContentTransferEncoding`, and `ContentDisposition` customisable, similar to what have been done before to the `ParseHeaders` function.

Let me know if there's some additional changes needed, like documentation in `README.md`