### PR TITLE
Update README and code comments for v0.3.0 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ inline and attached files.
 Install Letters:
 
 ```sh
-go get github.com/mnako/letters@v0.2.8
+go get github.com/mnako/letters@v0.3.0
 ```
 
 ### Quickstart
@@ -57,13 +57,13 @@ import (
 func main() {
   rawEmail, err := os.Open("email.eml")
   if err != nil {
-    log.Fatal("error while reading email from file: %w", err)
+    log.Fatal("error while reading email from file: ", err)
     return
   }
 
   defer func() {
     if err := rawEmail.Close(); err != nil {
-      log.Fatal("error while closing rawEmail: %w", err)
+      log.Fatal("error while closing rawEmail: ", err)
       return
     }
   }()
@@ -203,13 +203,13 @@ email.AttachedFiles
 The same default parser and methods will work for other languages, text
 encodings, and transfer-encodings:
 
-````go
-r := strings.NewReader(```Subject: =?ISO-2022-JP?Q?=1B=24=42=24=24=24=6D=24=4F=32=4E=1B=28=42?=
+```go
+r := strings.NewReader(`Subject: =?ISO-2022-JP?Q?=1B=24=42=24=24=24=6D=24=4F=32=4E=1B=28=42?=
 Content-Type: text/plain; charset=ISO-2022-JP
 
 
 =1B$B?'$OFw$($I=1B(B
-=1B$B;6$j$L$k$r=1B(B```)
+=1B$B;6$j$L$k$r=1B(B`)
 
 email, _ := letters.ParseEmail(r)
 
@@ -218,7 +218,7 @@ email.Headers.Subject
 
 email.Text
 // "色は匂えど散りぬるを..."
-````
+```
 
 #### Parse Email Headers
 
@@ -230,20 +230,20 @@ the default parser, and returns a `letters.Headers` struct or an error:
 ```go
 msg, err := mail.ReadMessage(rawEmail)
 if err != nil {
-    log.Fatal("error while reading message from file: %s", err)
+    log.Fatal("error while reading message from file: ", err)
     return
 }
 
 headers, err := letters.ParseEmailHeaders(msg.Header)
 if err != nil {
-    log.Fatal("error while parsing email headers: %s", err)
+    log.Fatal("error while parsing email headers: ", err)
     return
 }
 
 headers.Sender
 // mail.Address{Name: "Alice Sender", Address: "alice.sender@example.com"}
 
-headers.Headers.From
+headers.From
 // []mail.Address{
 //  {Name: "Alice Sender", Address: "alice.sender@example.com"},
 //  {Name: "Alice Sender", Address: "alice.sender@example.net"},
@@ -252,7 +252,7 @@ headers.Headers.From
 // ...
 ```
 
-> [!TIP] 
+> [!TIP]
 > The `letters.ParseEmail()` and `letters.ParseEmailHeaders()` helpers
 > exist for developers’ convenience and are a good entrypoint to get started
 > quickly. However, if you find yourself in need of customising the parser to,
@@ -262,7 +262,7 @@ headers.Headers.From
 
 ### Advanced Usage
 
-This section documents come of Letters more advanced features.
+This section documents some of Letters’ more advanced features.
 
 #### The Email Parser
 
@@ -301,7 +301,7 @@ includes a `NoFiles` filter that does precisely that:
 
 ```go
 noFilesEmailParser := letters.NewEmailParser(
-    letters.WithFileFilter(NoFiles),
+    letters.WithFileFilter(letters.NoFiles),
 )
 email, err := noFilesEmailParser.Parse(rawEmail)
 if err != nil {
@@ -370,7 +370,7 @@ inlineFilesOnlyParser := letters.NewEmailParser(
 )
 ```
 
-You can implement arbitrarily complex conditions with those filter.
+You can implement arbitrarily complex conditions with those filters.
 
 #### Customising Headers Parsers
 
@@ -508,12 +508,12 @@ customEmailParser := letters.NewEmailParser(
 - Easy access to inline attachments
 - Easy access to attached files
 
-All of that and more in a minimal Golang library with realistic email examples
+All of that and more in a minimal Go library with realistic email examples
 and thorough test coverage.
 
 ## Current Limitations
 
-- S/MIME `multipart/signed` email are limited to clear-signed messages
+- S/MIME `multipart/signed` emails are limited to clear-signed messages
 - The decryption and signature verification and any other cryptography-related
   tasks need to be performed outside of letters.
 
@@ -524,9 +524,9 @@ Feature-complete and tests passing.
 Currently, gathering feedback and refactoring code before releasing v1.0.0.
 Fields and API are still subject to change.
 
-# Release Policy
+## Release Policy
 
-We follow [Go’s Release Policy](https://go.dev/doc/devel/release#policy) 
+We follow [Go’s Release Policy](https://go.dev/doc/devel/release#policy)
 and commit to supporting at least the two most recent major versions of Go.
 
-Letter v0.2.8 supports Go versions 1.24 through 1.25.
+Letters v0.3.0 supports Go versions 1.24 through 1.26.

--- a/structs.go
+++ b/structs.go
@@ -75,7 +75,7 @@ type ContentDispositionHeader struct {
 
 // Headers contains the parsed headers of an email message.
 type Headers struct {
-	// RFC 3522 3.6.1.  The Origination Date Field
+	// RFC 5322 3.6.1.  The Origination Date Field
 	// The origination date field consists of the field name "Date" followed
 	// by a date-time specification.
 	//
@@ -95,7 +95,7 @@ type Headers struct {
 	// connected to the network to send the message.)
 	Date time.Time
 
-	// RFC 3522 3.6.2.  Originator Fields
+	// RFC 5322 3.6.2.  Originator Fields
 	//
 	// The originator fields of a message consist of the from field, the
 	// sender field (when applicable), and optionally the reply-to field.
@@ -150,7 +150,7 @@ type Headers struct {
 	From    []*mail.Address
 	ReplyTo []*mail.Address
 
-	// RFC 3522 3.6.3.  Destination Address Fields
+	// RFC 5322 3.6.3.  Destination Address Fields
 	//
 	// The destination fields of a message consist of three possible fields,
 	// each of the same form: the field name, which is either "To", "Cc", or
@@ -174,7 +174,7 @@ type Headers struct {
 	Cc  []*mail.Address
 	Bcc []*mail.Address
 
-	// RFC 3522 3.6.4.  Identification Fields
+	// RFC 5322 3.6.4.  Identification Fields
 	//
 	// Though listed as optional in the table in section 3.6, every message
 	// SHOULD have a "Message-ID:" field.  Furthermore, reply messages
@@ -304,7 +304,7 @@ type Headers struct {
 	InReplyTo  []MessageId
 	References []MessageId
 
-	// RFC 3522 3.6.5.  Informational Fields
+	// RFC 5322 3.6.5.  Informational Fields
 	//
 	// The informational fields are all optional.  The "Subject:" and
 	// "Comments:" fields are unstructured fields as defined in section
@@ -335,7 +335,7 @@ type Headers struct {
 	Comments string
 	Keywords []string
 
-	// RFC 3522 3.6.6.  Resent Fields
+	// RFC 5322 3.6.6.  Resent Fields
 	//
 	// Resent fields SHOULD be added to any message that is reintroduced by
 	// a user into the transport system.  A separate set of resent fields


### PR DESCRIPTION
Update README and code comments for v0.3.0 release; fix typos, improve examples, and correct RFC references.

**Documentation and Example Improvements:**

* Updated the recommended `letters` library version in installation instructions from `v0.2.8` to `v0.3.0` in `README.md`.
* Fixed and improved code examples in `README.md`, including correcting error logging statements, fixing code block formatting, and using the correct field names and types in examples. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L60-R66) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L206-R212) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L221-R221) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L233-R246) [[5]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L265-R265) [[6]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L304-R304)
* Corrected typos and improved language for clarity throughout the documentation (e.g., "come" → "some", "filter" → "filters", "Golang" → "Go"). [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L265-R265) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L373-R373) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L511-R516)
* Updated the release policy section to reflect support for Go versions 1.24 through 1.26 and changed section heading formatting.

**Code Comment Corrections:**

* Corrected all references to "RFC 3522" to the correct "RFC 5322" in the `Headers` struct documentation in `structs.go`. [[1]](diffhunk://#diff-ed32211335d38b2d817f745b55cd71fcc6f824cc578a680cdbed3912002876b6L78-R78) [[2]](diffhunk://#diff-ed32211335d38b2d817f745b55cd71fcc6f824cc578a680cdbed3912002876b6L98-R98) [[3]](diffhunk://#diff-ed32211335d38b2d817f745b55cd71fcc6f824cc578a680cdbed3912002876b6L153-R153) [[4]](diffhunk://#diff-ed32211335d38b2d817f745b55cd71fcc6f824cc578a680cdbed3912002876b6L177-R177) [[5]](diffhunk://#diff-ed32211335d38b2d817f745b55cd71fcc6f824cc578a680cdbed3912002876b6L307-R307) [[6]](diffhunk://#diff-ed32211335d38b2d817f745b55cd71fcc6f824cc578a680cdbed3912002876b6L338-R338)