### PR TITLE
Breaking Change: Rename WithInReplyHeaderParser to WithInReplyToHeaderParser

### DIFF
--- a/letters_test.go
+++ b/letters_test.go
@@ -597,7 +597,7 @@ func TestParseEmailEnglishPlaintextAsciiOver7bitCustomHeaderParsers(
 				letters.WithCcHeaderParser(customCcHeaderParser),
 				letters.WithBccHeaderParser(customBccHeaderParser),
 				letters.WithMessageIdHeaderParser(customMessageIDHeaderParser),
-				letters.WithInReplyHeaderParser(customInReplyToHeaderParser),
+				letters.WithInReplyToHeaderParser(customInReplyToHeaderParser),
 				letters.WithReferencesHeaderParser(
 					customReferencesToHeaderParser,
 				),

--- a/options.go
+++ b/options.go
@@ -119,12 +119,12 @@ func WithMessageIdHeaderParser(
 	}
 }
 
-// WithInReplyHeaderParser configures the parser used for the In-Reply-To header.
-func WithInReplyHeaderParser(
-	inReplyHeaderParserFn parseCommaSeparatedMessageIDHeaderFn,
+// WithInReplyToHeaderParser configures the parser used for the In-Reply-To header.
+func WithInReplyToHeaderParser(
+	inReplyToHeaderParserFn parseCommaSeparatedMessageIDHeaderFn,
 ) EmailParserOption {
 	return func(ep *EmailParser) {
-		ep.headersParsers.InReplyTo = inReplyHeaderParserFn
+		ep.headersParsers.InReplyTo = inReplyToHeaderParserFn
 	}
 }
 


### PR DESCRIPTION
This pull request corrects and standardizes the naming for the "In-Reply-To" header parser option to improve clarity and consistency across the codebase.

**API consistency improvements:**

* Renamed the function `WithInReplyHeaderParser` to `WithInReplyToHeaderParser` in `options.go` to match the standard "In-Reply-To" header name.
* Updated all usages of the old function name to the new `WithInReplyToHeaderParser`, including in the test file `letters_test.go`.