### PR TITLE
Fix Email Parser's fileFilter not being applied to top-level attachments

### DIFF
--- a/letters.go
+++ b/letters.go
@@ -183,6 +183,13 @@ func (ep *EmailParser) Parse(r io.Reader) (Email, error) {
 		email.InlineFiles = emailBodies.InlineFiles
 		email.AttachedFiles = emailBodies.AttachedFiles
 	default:
+		if !ep.fileFilter(
+			email.Headers.ContentType,
+			email.Headers.ContentDisposition,
+		) {
+			break
+		}
+
 		afl, err := decodeAttachmentFileFromBody(msg.Body, email.Headers, cte)
 		if err != nil {
 			return email, fmt.Errorf(

--- a/letters_test.go
+++ b/letters_test.go
@@ -311,6 +311,35 @@ func TestParseEmailEnglishNoTextContent(t *testing.T) {
 	testEmailCases(t, tcs)
 }
 
+func TestParseEmailTopLevelAttachmentWithNoFiles(t *testing.T) {
+	t.Parallel()
+
+	tcs := []emailTestCase{
+		{
+			name:     "NoFilesParser",
+			filepath: "tests/test_english_top_level_attachment.txt",
+			emailParser: letters.NewEmailParser(
+				letters.WithFileFilter(letters.NoFiles),
+			),
+			expectedEmail: letters.Email{
+				Headers: letters.Headers{
+					ContentType: letters.ContentTypeHeader{
+						ContentType: "application/octet-stream",
+						Params:      map[string]string{},
+					},
+					ContentDisposition: letters.ContentDispositionHeader{
+						ContentDisposition: letters.ContentDispositionAttachment,
+						Params:             map[string]string{},
+					},
+					ExtraHeaders: map[string][]string{},
+				},
+			},
+		},
+	}
+
+	testEmailCases(t, tcs)
+}
+
 func TestParseEmailEnglishPlaintextAsciiOver7bit(t *testing.T) {
 	t.Parallel()
 

--- a/tests/test_english_top_level_attachment.txt
+++ b/tests/test_english_top_level_attachment.txt
@@ -1,0 +1,5 @@
+Content-Type: application/octet-stream
+Content-Disposition: attachment
+Content-Transfer-Encoding: 7bit
+
+attachment data


### PR DESCRIPTION
Apply the configured file filter before decoding an email whose top-level body is an attachment.

## Bug

File filters were applied to attachments encountered while parsing multipart messages, but not to an attachment represented by the email’s top-level body.

For a top-level attachment, `EmailParser.Parse` decoded the body and appended it to `AttachedFiles` without first calling the configured file filter. Consequently:

- `WithFileFilter(NoFiles)` still decoded and returned the attachment.
- Custom file filters could not reject top-level attachments.
- Filter behaviour depended on whether the attachment was top-level or nested inside a multipart message.

This contradicted the documented behaviour of `NoFiles`, which is intended to skip all attachments.

## Fix

Call the configured file filter with the top-level `Content-Type` and `Content-Disposition` headers before decoding the attachment. When the filter rejects it, its body is not decoded and `AttachedFiles` remains empty. Parsed message headers are preserved.

Multipart attachment handling is unchanged.

## Breaking change

This is a behavioural breaking change. Applications that configured a file filter but unknowingly relied on top-level attachments bypassing that filter will no longer receive those attachments.

The new behaviour makes top-level attachments consistent with multipart attachments and with the documented file-filter contract.

## Test

Add a regression test using a non-multipart `application/octet-stream` message with `Content-Disposition: attachment`.

When parsed with `WithFileFilter(NoFiles)`, the message headers should be retained but no attached file should be returned. The test fails before the fix because the attachment is still decoded and appended.

## Changes

1. Add a (failing) test in https://github.com/mnako/letters/pull/214/commits/20697dedcc3528f7739b3dacd914a95e90688dbf to document the bug;
2. add the fileFilter in https://github.com/mnako/letters/pull/214/commits/476a16b7661161c3a33d0ac5f1bfef45c8c1245f.