### PR TITLE
Fix EmailParser.ParseHeaders silently discarding ErrUnknownContentDisposition for an invalid Content-Disposition header

### DIFF
--- a/errors_test.go
+++ b/errors_test.go
@@ -57,6 +57,30 @@ func TestUnknownContentDispositionError(t *testing.T) {
 	}
 }
 
+func TestParseHeadersUnknownContentDispositionError(t *testing.T) {
+	t.Parallel()
+
+	header := mail.Header{"Content-Disposition": {"unexpected"}}
+	_, err := letters.NewEmailParser().ParseHeaders(header)
+
+	if !errors.Is(err, letters.ErrUnknownContentDisposition) {
+		t.Fatalf("expected ErrUnknownContentDisposition, got %v", err)
+	}
+
+	const expectedMessage = "letters.parsers.ParseHeaders: " +
+		"cannot parse Content-Disposition: " +
+		"letters.parsers.parseContentDisposition: " +
+		"unknown Content-Disposition \"unexpected\""
+
+	if err.Error() != expectedMessage {
+		t.Errorf(
+			"unexpected error message: got %q, want %q",
+			err,
+			expectedMessage,
+		)
+	}
+}
+
 func TestUnknownContentTransferEncodingError(t *testing.T) {
 	t.Parallel()
 

--- a/parsers.go
+++ b/parsers.go
@@ -569,9 +569,16 @@ func (ep *EmailParser) ParseHeaders(header mail.Header) (Headers, error) {
 			err)
 	}
 
-	contentDisposition, _ := ep.headersParsers.ContentDisposition(
+	contentDisposition, err := ep.headersParsers.ContentDisposition(
 		header.Get("Content-Disposition"),
 	)
+	if err != nil {
+		return Headers{}, fmt.Errorf(
+			"letters.parsers.ParseHeaders: "+
+				"cannot parse Content-Disposition: %w",
+			err,
+		)
+	}
 
 	extraHeaders := make(map[string][]string)
 


### PR DESCRIPTION
Propagate errors returned while parsing a `Content-Disposition` header.

## Bug

`EmailParser.ParseHeaders` propagated errors from the configured `Content-Type` parser but silently discarded errors from the configured `Content-Disposition` parser.

Consequently:

- An invalid top-level `Content-Disposition` header was treated as though the header were absent.
- `ErrUnknownContentDisposition` could not be detected with `errors.Is`.
- Errors returned by a custom `Content-Disposition` header parser were ignored.
- Top-level headers behaved differently from multipart headers, whose `Content-Disposition` parsing errors were already propagated.

## Fix

Capture the error returned by the configured `Content-Disposition` parser and return it with `EmailParser.ParseHeaders` context.

Successful parsing behaviour is unchanged.

## Behavioural change

Emails with an invalid top-level `Content-Disposition` header now produce an error instead of being parsed with an empty `ContentDispositionHeader`.

Applications that relied on malformed values being silently ignored may therefore observe different behaviour.

## Test

Add a regression test using an unsupported top-level `Content-Disposition` value.

The test verifies that `EmailParser.ParseHeaders` returns an error wrapping `ErrUnknownContentDisposition`. It fails before the fix because `ParseHeaders` returns a `nil` error.

## Changes

1. https://github.com/mnako/letters/commit/053216a7ec5e402338e50dc9975ab66c4900e7bd: Add a failing regression test in  documenting the ignored error
2. https://github.com/mnako/letters/pull/215/commits/4618c6f668d3f0c5c3233dca1878d98b00294f5d: Propagate the `Content-Disposition` parser error from `EmailParser.ParseHeaders`.