### PR TITLE
Fix EmailParser.Parse ignoring a failed charset lookup

### DIFF
--- a/errors_test.go
+++ b/errors_test.go
@@ -3,6 +3,7 @@ package letters_test
 import (
 	"errors"
 	"net/mail"
+	"os"
 	"testing"
 
 	"github.com/mnako/letters"
@@ -34,6 +35,29 @@ func TestUnknownCharsetError(t *testing.T) {
 			err,
 			expectedMessage,
 		)
+	}
+}
+
+func TestParseEmailUnknownCharsetError(t *testing.T) {
+	t.Parallel()
+
+	rawEmail, err := os.Open(
+		"tests/test_english_plaintext_unknown_charset.txt",
+	)
+	if err != nil {
+		t.Fatalf("error while reading email from file: %s", err)
+	}
+
+	defer func() {
+		if err := rawEmail.Close(); err != nil {
+			t.Errorf("error while closing rawEmail: %s", err)
+		}
+	}()
+
+	_, err = letters.NewEmailParser().Parse(rawEmail)
+
+	if !errors.Is(err, letters.ErrUnknownCharset) {
+		t.Fatalf("expected ErrUnknownCharset, got %v", err)
 	}
 }
 

--- a/letters.go
+++ b/letters.go
@@ -5,8 +5,6 @@ import (
 	"io"
 	"net/mail"
 	"strings"
-
-	"golang.org/x/net/html/charset"
 )
 
 // ParseEmailHeaders parses an email header using the default header parsers.
@@ -108,8 +106,6 @@ func (ep *EmailParser) Parse(r io.Reader) (Email, error) {
 
 	email.Headers = headers
 
-	encoding, _ := charset.Lookup(email.Headers.ContentType.Params["charset"])
-
 	cte, err := ParseContentTransferEncoding(
 		msg.Header.Get("Content-Transfer-Encoding"),
 	)
@@ -126,7 +122,11 @@ func (ep *EmailParser) Parse(r io.Reader) (Email, error) {
 	switch {
 	case contentType == contentTypeTextPlain:
 		if ep.bodyFilter(email.Headers.ContentType) {
-			email.Text, err = parseText(msg.Body, encoding, cte)
+			email.Text, err = parseText(
+				msg.Body,
+				email.Headers.ContentType.Params["charset"],
+				cte,
+			)
 			if err != nil {
 				return email, fmt.Errorf(
 					"letters.EmailParser.Parse: "+
@@ -137,7 +137,11 @@ func (ep *EmailParser) Parse(r io.Reader) (Email, error) {
 		}
 	case contentType == contentTypeTextEnriched:
 		if ep.bodyFilter(email.Headers.ContentType) {
-			email.EnrichedText, err = parseText(msg.Body, encoding, cte)
+			email.EnrichedText, err = parseText(
+				msg.Body,
+				email.Headers.ContentType.Params["charset"],
+				cte,
+			)
 			if err != nil {
 				return email,
 					fmt.Errorf(
@@ -149,7 +153,11 @@ func (ep *EmailParser) Parse(r io.Reader) (Email, error) {
 		}
 	case contentType == contentTypeTextHTML:
 		if ep.bodyFilter(email.Headers.ContentType) {
-			email.HTML, err = parseText(msg.Body, encoding, cte)
+			email.HTML, err = parseText(
+				msg.Body,
+				email.Headers.ContentType.Params["charset"],
+				cte,
+			)
 			if err != nil {
 				return email,
 					fmt.Errorf(

--- a/parsers.go
+++ b/parsers.go
@@ -11,7 +11,6 @@ import (
 	"time"
 
 	"golang.org/x/net/html/charset"
-	"golang.org/x/text/encoding"
 )
 
 func normalizeMultilineString(s string) string {
@@ -734,11 +733,16 @@ func (ep *EmailParser) ParseHeaders(header mail.Header) (Headers, error) {
 }
 
 func parseText(
-	t io.Reader,
-	e encoding.Encoding,
+	content io.Reader,
+	charsetLabel string,
 	cte ContentTransferEncoding,
 ) (string, error) {
-	reader, err := decodeContent(t, e, cte)
+	textEncoding, _ := charset.Lookup(charsetLabel)
+	if textEncoding == nil && charsetLabel != "" {
+		return "", fmt.Errorf("%w %s", ErrUnknownCharset, charsetLabel)
+	}
+
+	reader, err := decodeContent(content, textEncoding, cte)
 	if err != nil {
 		return "", fmt.Errorf(
 			"letters.parsers.parseText: "+
@@ -834,8 +838,6 @@ func (ep *EmailParser) parsePart(
 			charsetLabel = parentContentType.Params["charset"]
 		}
 
-		enc, _ := charset.Lookup(charsetLabel)
-
 		cte, err := ParseContentTransferEncoding(
 			part.Header.Get("Content-Transfer-Encoding"),
 		)
@@ -885,7 +887,7 @@ func (ep *EmailParser) parsePart(
 				continue
 			}
 
-			partTextBody, err := parseText(part, enc, cte)
+			partTextBody, err := parseText(part, charsetLabel, cte)
 			if err != nil {
 				return emailBodies, fmt.Errorf(
 					"letters.parsers.parsePart: "+
@@ -905,7 +907,7 @@ func (ep *EmailParser) parsePart(
 				continue
 			}
 
-			partEnrichedText, err := parseText(part, enc, cte)
+			partEnrichedText, err := parseText(part, charsetLabel, cte)
 			if err != nil {
 				return emailBodies, fmt.Errorf(
 					"letters.parsers.parsePart: "+
@@ -924,7 +926,7 @@ func (ep *EmailParser) parsePart(
 				continue
 			}
 
-			partHTMLBody, err := parseText(part, enc, cte)
+			partHTMLBody, err := parseText(part, charsetLabel, cte)
 			if err != nil {
 				return emailBodies, fmt.Errorf(
 					"letters.parsers.parsePart: "+

--- a/tests/test_english_plaintext_unknown_charset.txt
+++ b/tests/test_english_plaintext_unknown_charset.txt
@@ -1,0 +1,3 @@
+Content-Type: text/plain; charset=x-invalid
+
+body


### PR DESCRIPTION
Return an error when an email text body declares a charset that Letters cannot decode.

## Bug

Letters looked up the charset declared by a text body but discarded the result of that lookup.

When `charset.Lookup` could not resolve the declared charset, it returned a `nil` encoding. Letters then continued parsing without applying a character decoder and returned the original body bytes as successfully parsed text.

Consequently:

- Unsupported body charsets were silently accepted.
- Callers could not detect the failure with `errors.Is(err, ErrUnknownCharset)`.
- Body text could contain incorrectly decoded or invalid content.
- Charset handling differed between MIME-encoded headers, which already returned `ErrUnknownCharset`, and text bodies.

This affected top-level text bodies as well as text parts within multipart messages.

## Fix

Move charset resolution to the text-decoding boundary and return an error wrapping `ErrUnknownCharset` when a non-empty charset label cannot be resolved.

Both top-level and multipart text bodies now use the same validation path.

Messages that omit the charset parameter retain the existing behaviour. Bodies rejected by the configured body filter are not decoded and therefore do not produce charset errors.

## Behavioural change

A text body declaring an unsupported charset now produces an error instead of being returned as apparently valid, undecoded text.

Applications that relied on unsupported charset values being silently ignored may therefore observe different behaviour.

## Test

Add a regression fixture containing a top-level `text/plain` body with `charset=x-invalid`.

The test verifies that `EmailParser.Parse` returns an error wrapping `ErrUnknownCharset`. It fails before the fix because parsing succeeds with a `nil` error.

## Changes

1. https://github.com/mnako/letters/commit/b97fc10f9efde48942864b444ced56d8a58b0457: Add a failing regression test documenting the ignored charset lookup failure.
2. https://github.com/mnako/letters/pull/216/commits/b8d71c03384b9c97699d6138bc2054ae3556301a: Resolve the charset when parsing a text body. Return an error wrapping `ErrUnknownCharset` for unsupported, non-empty charset labels. Apply the same validation to top-level and multipart text bodies.