### PR TITLE
prepare v0.4.0 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ enriched-text, and HTML bodies; and inline and attached files.
 Install Letters with this command:
 
 ```sh
-go get github.com/mnako/letters@v0.3.1
+go get github.com/mnako/letters@v0.4.0
 ```
 
 ### Quick Start
@@ -500,4 +500,4 @@ public API, including struct fields, may still change.
 Letters follows [Go’s Release Policy](https://go.dev/doc/devel/release#policy).
 Each Letters release supports at least the two most recent major Go releases.
 
-Letters v0.3.1 supports Go 1.25 and Go 1.26.
+Letters v0.4.0 supports Go 1.25 and Go 1.26.


### PR DESCRIPTION
This pull request updates the documentation to reference the latest version of the Letters package. The `README.md` file now points to version v0.4.0 instead of v0.3.1.

- Updated installation instructions to use `letters@v0.4.0` instead of `v0.3.1` in the `go get` command.
- Updated the version reference in the Go version support section from `v0.3.1` to `v0.4.0`.